### PR TITLE
feat: multi-class & regression CPP via label helpers + reference generation (#61)

### DIFF
--- a/aaanalysis/feature_engineering/_backend/cpp/sequence_feature.py
+++ b/aaanalysis/feature_engineering/_backend/cpp/sequence_feature.py
@@ -12,9 +12,21 @@ from ._utils_feature_stat import add_stat_
 
 
 # I Helper Functions
+def _part_aa_freq(col=None, aa_list=None, aa_index=None):
+    """Empirical canonical-AA frequency over all strings in one part column."""
+    counts = np.zeros(len(aa_list), dtype=np.int64)
+    for s in col:
+        for c in s:
+            j = aa_index.get(c)
+            if j is not None:
+                counts[j] += 1
+    total = counts.sum()
+    if total == 0:
+        raise ValueError("'df_parts' contains no canonical amino acids for composition matching.")
+    return counts / total
 
 
-# II Main functions
+# II Main Functions
 # Parts and splits
 def get_split_kws_(n_split_min=1, n_split_max=15, steps_pattern=None, n_min=2, n_max=4, len_max=15,
                    steps_periodicpattern=None, split_types=None):
@@ -96,3 +108,66 @@ def get_df_feat_(features=None, df_parts=None, labels=None,
     # Standardize the df_feat column order (issue #18); amino_acids_* append last.
     df = ut.sort_cols_feat(df_feat=df)
     return df
+
+
+# Multi-class / regression label conversion and reference generation
+def get_labels_ovr_(labels=None, label_test=1, label_ref=0):
+    """One-vs-rest: per class, a full-length binary vector (class -> test, rest -> ref)."""
+    labels = np.asarray(labels)
+    classes = sorted(set(labels.tolist()))
+    return {c: np.where(labels == c, label_test, label_ref).astype(int) for c in classes}
+
+
+def get_labels_ovo_(labels=None, label_test=1, label_ref=0):
+    """One-vs-one: per class pair (a, b), a row mask + binary labels for the masked subset."""
+    labels = np.asarray(labels)
+    classes = sorted(set(labels.tolist()))
+    out = {}
+    for i, a in enumerate(classes):
+        for b in classes[i + 1:]:
+            mask = np.isin(labels, [a, b])
+            binary = np.where(labels[mask] == a, label_test, label_ref).astype(int)
+            out[(a, b)] = (mask, binary)
+    return out
+
+
+def get_labels_quantile_(targets=None, q=0.5, label_test=1, label_ref=0):
+    """Single-threshold split of continuous targets into binary labels (>= q-quantile -> test)."""
+    targets = np.asarray(targets, dtype=float)
+    cut = float(np.quantile(targets, q))
+    return np.where(targets >= cut, label_test, label_ref).astype(int)
+
+
+def get_df_parts_reference_(df_parts=None, method=ut.MODE_SCRAMBLED, n=None, rng=None):
+    """Generate reference ``df_parts`` rows, per-part length- and composition-faithful.
+
+    Each generated row borrows the per-part lengths of a randomly chosen real
+    row (so references match the real CPP part lengths by construction).
+    ``scrambled`` shuffles that template part in place (exact per-part
+    composition); ``global_freq`` draws from the column's empirical canonical-AA
+    frequency.
+    """
+    aa_list = list(ut.LIST_CANONICAL_AA)
+    aa_index = {a: i for i, a in enumerate(aa_list)}
+    list_parts = list(df_parts)
+    n_real = len(df_parts)
+    if n is None:
+        n = n_real
+    template_idx = rng.integers(0, n_real, size=n)
+    data = {}
+    for part in list_parts:
+        col = df_parts[part].to_numpy()
+        probs = _part_aa_freq(col=col, aa_list=aa_list, aa_index=aa_index) \
+            if method == ut.MODE_GLOBAL_FREQ else None
+        strings = []
+        for i in range(n):
+            template = col[template_idx[i]]
+            if method == ut.MODE_SCRAMBLED:
+                chars = list(template)
+                rng.shuffle(chars)
+                strings.append("".join(chars))
+            else:
+                strings.append("".join(rng.choice(aa_list, size=len(template), p=probs)))
+        data[part] = strings
+    index = [f"REF{i}" for i in range(n)]
+    return pd.DataFrame(data, index=index)

--- a/aaanalysis/feature_engineering/_sequence_feature.py
+++ b/aaanalysis/feature_engineering/_sequence_feature.py
@@ -1,8 +1,9 @@
 """
 This is a script for the frontend of the SequenceFeature class, a supportive class for the CPP feature engineering.
 """
-from typing import Optional, Union, List
+from typing import Optional, Union, List, Dict, Tuple, Any
 import warnings
+import numpy as np
 import pandas as pd
 
 import aaanalysis.utils as ut
@@ -23,7 +24,9 @@ from ._backend.cpp.utils_feature import (get_df_parts_,
                                          replace_non_canonical_aa_,
                                          get_positions_, get_amino_acids_,
                                          get_df_pos_, get_df_pos_parts_)
-from ._backend.cpp.sequence_feature import (get_split_kws_, get_features_, get_feature_names_, get_df_feat_)
+from ._backend.cpp.sequence_feature import (get_split_kws_, get_features_, get_feature_names_, get_df_feat_,
+                                            get_labels_ovr_, get_labels_ovo_, get_labels_quantile_,
+                                            get_df_parts_reference_)
 from ._backend.cpp_run import _pick_feature_matrix_builder
 
 
@@ -887,3 +890,292 @@ class SequenceFeature:
             df_pos = get_df_pos_parts_(df_pos=df_pos, value_type=value_type,
                                        start=start, **args_len, list_parts=list_parts)
         return df_pos
+
+    @staticmethod
+    def get_labels_ovr(labels: ut.ArrayLike1D = None,
+                       label_test: int = 1,
+                       label_ref: int = 0,
+                       ) -> Dict[int, np.ndarray]:
+        """
+        Convert multi-class labels into one-vs-rest binary label vectors.
+
+        Maps each of the K classes to a full-length binary vector in which that
+        class is the test group and all remaining classes are the reference
+        group. Since no samples are dropped, the K vectors can be looped through
+        a single :class:`CPP` instance via :meth:`CPP.run` (the ``df_parts`` is
+        unchanged), yielding one binary feature set per class. Discarding the
+        other classes instead (one-vs-one) requires subsetting ``df_parts`` and
+        is out of scope here.
+
+        Parameters
+        ----------
+        labels : array-like, shape (n_samples,)
+            Multi-class labels for samples (more than one distinct integer value).
+        label_test : int, default=1
+            Value assigned to the target class of each one-vs-rest vector.
+        label_ref : int, default=0
+            Value assigned to all remaining classes.
+
+        Returns
+        -------
+        dict_labels : dict
+            Dictionary mapping each class label to its one-vs-rest binary vector
+            (numpy array of shape (n_samples,)).
+
+        Notes
+        -----
+        * Each returned vector is directly usable as the ``labels`` argument of
+          :meth:`CPP.run` / :meth:`CPP.run_num`.
+        * To aggregate the per-class results, run CPP per vector and concatenate
+          the returned ``df_feat`` frames, tagging each with its class key.
+
+        Examples
+        --------
+        .. include:: examples/sf_get_labels_ovr.rst
+        """
+        # Check input
+        labels = ut.check_labels(labels=labels)
+        ut.check_number_val(name="label_test", val=label_test, just_int=True)
+        ut.check_number_val(name="label_ref", val=label_ref, just_int=True)
+        if label_test == label_ref:
+            raise ValueError(f"'label_test' ({label_test}) should differ from 'label_ref' ({label_ref}).")
+        # Convert labels
+        return get_labels_ovr_(labels=labels, label_test=label_test, label_ref=label_ref)
+
+    @staticmethod
+    def get_labels_ovo(labels: ut.ArrayLike1D = None,
+                       label_test: int = 1,
+                       label_ref: int = 0,
+                       ) -> Dict[Tuple[Any, Any], Tuple[np.ndarray, np.ndarray]]:
+        """
+        Convert multi-class labels into one-vs-one binary label vectors with row masks.
+
+        Maps each unordered pair of classes ``(a, b)`` to the subset of samples
+        belonging to either class together with a binary label vector over that
+        subset (class ``a`` as test, class ``b`` as reference). Because the other
+        classes are discarded, each pair needs its own row subset of ``df_parts``;
+        the caller applies the returned boolean ``row_mask`` to ``df_parts`` (and
+        builds a :class:`CPP` instance on that subset) before calling
+        :meth:`CPP.run`.
+
+        Parameters
+        ----------
+        labels : array-like, shape (n_samples,)
+            Multi-class labels for samples (more than one distinct integer value).
+        label_test : int, default=1
+            Value assigned to the first class of each pair.
+        label_ref : int, default=0
+            Value assigned to the second class of each pair.
+
+        Returns
+        -------
+        dict_labels : dict
+            Dictionary mapping each class pair ``(a, b)`` to a tuple
+            ``(row_mask, labels_subset)``, where ``row_mask`` is a boolean array
+            of shape (n_samples,) selecting the pair's samples and
+            ``labels_subset`` is the binary vector over the masked subset.
+
+        Notes
+        -----
+        * ``row_mask`` selects exactly the samples whose label is ``a`` or ``b``.
+        * Use ``df_parts[row_mask]`` to build the subset input; running CPP on a
+          row-subset without rebuilding the instance is a separate enhancement.
+
+        Examples
+        --------
+        .. include:: examples/sf_get_labels_ovo.rst
+        """
+        # Check input
+        labels = ut.check_labels(labels=labels)
+        ut.check_number_val(name="label_test", val=label_test, just_int=True)
+        ut.check_number_val(name="label_ref", val=label_ref, just_int=True)
+        if label_test == label_ref:
+            raise ValueError(f"'label_test' ({label_test}) should differ from 'label_ref' ({label_ref}).")
+        # Convert labels
+        return get_labels_ovo_(labels=labels, label_test=label_test, label_ref=label_ref)
+
+    @staticmethod
+    def get_labels_quantile(targets: ut.ArrayLike1D = None,
+                            q: float = 0.5,
+                            label_test: int = 1,
+                            label_ref: int = 0,
+                            ) -> np.ndarray:
+        """
+        Convert a continuous target into a binary label vector by a single quantile threshold.
+
+        Splits samples at the ``q``-quantile of ``targets``: samples at or above
+        the cut become the test group and the remainder the reference group. No
+        samples are dropped, so the result is directly usable as the ``labels``
+        argument of :meth:`CPP.run` / :meth:`CPP.run_num`, enabling regression-style
+        tasks (e.g. thermostability, binding affinity) within the binary CPP
+        framework. A banded top-vs-bottom split (dropping the middle) is out of
+        scope here.
+
+        Parameters
+        ----------
+        targets : array-like, shape (n_samples,)
+            Continuous target values for samples.
+        q : float, default=0.5
+            Quantile in the open interval (0, 1) defining the split threshold
+            (``0.5`` splits at the median).
+        label_test : int, default=1
+            Value assigned to samples at or above the threshold.
+        label_ref : int, default=0
+            Value assigned to samples below the threshold.
+
+        Returns
+        -------
+        labels : np.ndarray, shape (n_samples,)
+            Binary label vector.
+
+        Notes
+        -----
+        * If ``targets`` is constant (or ``q`` lands all samples on one side), the
+          result has a single value and :meth:`CPP.run` will reject it.
+
+        Examples
+        --------
+        .. include:: examples/sf_get_labels_quantile.rst
+        """
+        # Check input
+        targets = ut.check_list_like(name="targets", val=targets, accept_none=False)
+        targets = np.asarray(targets, dtype=float)
+        ut.check_number_range(name="q", val=q, min_val=0, max_val=1, exclusive_limits=True, just_int=False)
+        ut.check_number_val(name="label_test", val=label_test, just_int=True)
+        ut.check_number_val(name="label_ref", val=label_ref, just_int=True)
+        if label_test == label_ref:
+            raise ValueError(f"'label_test' ({label_test}) should differ from 'label_ref' ({label_ref}).")
+        # Convert targets
+        return get_labels_quantile_(targets=targets, q=q, label_test=label_test, label_ref=label_ref)
+
+    @staticmethod
+    def get_df_parts_reference(df_parts: pd.DataFrame = None,
+                               method: str = "scrambled",
+                               n: Optional[int] = None,
+                               random_state: Optional[int] = None,
+                               ) -> pd.DataFrame:
+        """
+        Generate a reference ``df_parts`` matching the part lengths and composition of the input.
+
+        Produces background reference rows for use as a negative/reference class
+        when no natural one exists, so :class:`CPP` can be applied to multi-class
+        and regression tasks. Each generated row borrows the per-part lengths of a
+        randomly chosen real row, so references match the real CPP part lengths
+        (e.g. fixed TMD/JMD) by construction. With ``method='scrambled'`` each
+        template part is shuffled in place (exact per-part amino acid composition);
+        with ``method='global_freq'`` residues are drawn from the column's
+        empirical canonical amino acid frequency. Concatenate the result with the
+        real ``df_parts`` and label the two groups before calling :meth:`CPP.run`.
+
+        Parameters
+        ----------
+        df_parts : pd.DataFrame, shape (n_samples, n_parts)
+            DataFrame of sequence parts (e.g. from :meth:`SequenceFeature.get_df_parts`).
+        method : str, default='scrambled'
+            Generation method, one of ``'scrambled'`` (shuffle a template part,
+            preserving composition) or ``'global_freq'`` (draw from the column's
+            empirical amino acid frequency).
+        n : int, optional
+            Number of reference rows to generate. If ``None``, matches the number
+            of rows in ``df_parts``.
+        random_state : int, optional
+            The seed used by the random number generator. If a positive integer, results of stochastic processes are
+            consistent, enabling reproducibility. If ``None``, stochastic processes will be truly random.
+
+        Returns
+        -------
+        df_parts_ref : pd.DataFrame, shape (n, n_parts)
+            Reference parts with the same columns as ``df_parts`` and an index of
+            ``'REF<i>'`` identifiers.
+
+        Notes
+        -----
+        * Length matching holds per part column, so the reference rows can be
+          concatenated with ``df_parts`` and split identically by :class:`CPP`.
+
+        Examples
+        --------
+        .. include:: examples/sf_get_df_parts_reference.rst
+        """
+        # Check input
+        ut.check_df_parts(df_parts=df_parts)
+        ut.check_str_options(name="method", val=method,
+                             list_str_options=[ut.MODE_SCRAMBLED, ut.MODE_GLOBAL_FREQ])
+        ut.check_number_range(name="n", val=n, min_val=1, accept_none=True, just_int=True)
+        random_state = ut.check_random_state(random_state=random_state)
+        # Generate reference parts
+        rng = np.random.default_rng(random_state)
+        return get_df_parts_reference_(df_parts=df_parts, method=method, n=n, rng=rng)
+
+    @staticmethod
+    def get_df_parts_from_windows(dict_parts: Dict[str, Union[pd.DataFrame, ut.ArrayLike1D]] = None,
+                                  ) -> pd.DataFrame:
+        """
+        Assemble a ``df_parts`` from per-part window sets (e.g. :class:`AAWindowSampler` outputs).
+
+        Builds a reference ``df_parts`` by stitching one window set per sequence
+        part, so each part can be generated with its **own** recipe. This unlocks
+        biologically-motivated reference backgrounds where the parts differ in
+        physicochemical prior, e.g. a coil-propensity JMD-N, an alpha-helix TMD,
+        and a coil-propensity JMD-C, each produced by a separate call to
+        :meth:`AAWindowSampler.sample_synthetic` with a different ``generator`` and
+        ``window_size``. The assembled frame is used as the reference class for
+        :class:`CPP` exactly like a real ``df_parts``.
+
+        Parameters
+        ----------
+        dict_parts : dict
+            Dictionary mapping each part name (one of :attr:`aaanalysis.utils.LIST_ALL_PARTS`,
+            e.g. ``'jmd_n'``, ``'tmd'``, ``'jmd_c'``) to its window set. Each value is
+            either a DataFrame with a ``'window'`` column (the output of
+            :meth:`AAWindowSampler.sample_synthetic`) or an array-like of equal-length
+            window strings. All parts must supply the same number of windows.
+
+        Returns
+        -------
+        df_parts : pd.DataFrame, shape (n_windows, n_parts)
+            Reference parts with one column per key in ``dict_parts`` and an index of
+            ``'REF<i>'`` identifiers.
+
+        Notes
+        -----
+        * Rows are aligned by position across parts, so the i-th window of every
+          part forms the i-th reference row.
+        * Concatenate the result with a real ``df_parts`` (matching columns) and
+          label the two groups before calling :meth:`CPP.run`.
+
+        Examples
+        --------
+        .. include:: examples/sf_get_df_parts_from_windows.rst
+        """
+        # Check input
+        ut.check_dict(name="dict_parts", val=dict_parts, accept_none=False)
+        if len(dict_parts) == 0:
+            raise ValueError("'dict_parts' should not be empty.")
+        data = {}
+        n_windows = None
+        for part, source in dict_parts.items():
+            if part not in ut.LIST_ALL_PARTS:
+                raise ValueError(f"'dict_parts' key '{part}' should be one of: {ut.LIST_ALL_PARTS}")
+            if isinstance(source, pd.DataFrame):
+                if ut.COL_WINDOW not in source.columns:
+                    raise ValueError(f"'dict_parts['{part}']' DataFrame should contain a "
+                                     f"'{ut.COL_WINDOW}' column (the output of "
+                                     f"AAWindowSampler.sample_synthetic).")
+                windows = source[ut.COL_WINDOW].tolist()
+            else:
+                windows = list(ut.check_list_like(name=f"dict_parts['{part}']", val=source))
+            if len(windows) == 0:
+                raise ValueError(f"'dict_parts['{part}']' should contain at least one window.")
+            if not all(isinstance(w, str) for w in windows):
+                raise ValueError(f"'dict_parts['{part}']' windows should all be strings.")
+            if n_windows is None:
+                n_windows = len(windows)
+            elif len(windows) != n_windows:
+                raise ValueError(f"All parts in 'dict_parts' should have the same number of windows; "
+                                 f"'{part}' has {len(windows)} but expected {n_windows}.")
+            data[part] = windows
+        # Assemble parts
+        df_parts = pd.DataFrame(data, index=[f"REF{i}" for i in range(n_windows)])
+        ut.check_df_parts(df_parts=df_parts)
+        return df_parts

--- a/examples/feature_engineering/sf_get_df_parts_from_windows.ipynb
+++ b/examples/feature_engineering/sf_get_df_parts_from_windows.ipynb
@@ -1,0 +1,84 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "Assemble a reference ``df_parts`` from per-part window sets, so each sequence part can use its **own** generator. Here a biologically-motivated background is built with a coil-propensity JMD-N, an alpha-helix TMD, and a coil-propensity JMD-C - each from a separate ``AAWindowSampler.sample_synthetic`` call:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "import pandas as pd\n",
+    "import aaanalysis as aa\n",
+    "\n",
+    "df_seq = aa.load_dataset(name=\"DOM_GSEC\", n=8)\n",
+    "sf = aa.SequenceFeature()\n",
+    "df_parts = sf.get_df_parts(df_seq=df_seq, list_parts=[\"jmd_n\", \"tmd\", \"jmd_c\"])\n",
+    "n_ref = len(df_parts)\n",
+    "\n",
+    "aws = aa.AAWindowSampler(random_state=0)\n",
+    "dict_parts = {\n",
+    "    \"jmd_n\": aws.sample_synthetic(df_seq=df_seq, n=n_ref, window_size=10, generator=\"coil\"),\n",
+    "    \"tmd\":   aws.sample_synthetic(df_seq=df_seq, n=n_ref, window_size=20, generator=\"alpha_helix\"),\n",
+    "    \"jmd_c\": aws.sample_synthetic(df_seq=df_seq, n=n_ref, window_size=10, generator=\"coil\"),\n",
+    "}\n",
+    "df_parts_ref = aa.SequenceFeature.get_df_parts_from_windows(dict_parts)\n",
+    "df_parts_ref.head()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "Concatenate the per-part reference with the real parts as the reference class (0) and run CPP. A smaller ``split_kws`` is used because the base JMD parts are short:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "df_all = pd.concat([df_parts, df_parts_ref])\n",
+    "labels = [1] * len(df_parts) + [0] * len(df_parts_ref)\n",
+    "split_kws = sf.get_split_kws(n_split_max=5, steps_pattern=[3, 4], n_min=2, n_max=3, len_max=8)\n",
+    "df_feat = aa.CPP(df_parts=df_all, split_kws=split_kws).run(labels=labels, n_filter=5)\n",
+    "df_feat[[\"feature\", \"abs_auc\"]].head()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/feature_engineering/sf_get_df_parts_reference.ipynb
+++ b/examples/feature_engineering/sf_get_df_parts_reference.ipynb
@@ -1,0 +1,76 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "Generate a reference ``df_parts`` matching the part lengths and amino acid composition of an input ``df_parts``. This provides a background reference class when no natural negative set exists. With ``method='scrambled'`` each template part is shuffled (exact composition); with ``method='global_freq'`` residues are drawn from the column's empirical frequency:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "import pandas as pd\n",
+    "import aaanalysis as aa\n",
+    "\n",
+    "df_seq = aa.load_dataset(name=\"DOM_GSEC\", n=8)\n",
+    "sf = aa.SequenceFeature()\n",
+    "df_parts = sf.get_df_parts(df_seq=df_seq)\n",
+    "\n",
+    "df_parts_ref = aa.SequenceFeature.get_df_parts_reference(df_parts, method=\"scrambled\", random_state=0)\n",
+    "df_parts_ref.head()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "Concatenate the references with the real parts as the reference class (0) and run CPP:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "df_all = pd.concat([df_parts, df_parts_ref])\n",
+    "labels = [1] * len(df_parts) + [0] * len(df_parts_ref)\n",
+    "df_feat = aa.CPP(df_parts=df_all).run(labels=labels, n_filter=5)\n",
+    "df_feat[[\"feature\", \"abs_auc\"]].head()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/feature_engineering/sf_get_labels_ovo.ipynb
+++ b/examples/feature_engineering/sf_get_labels_ovo.ipynb
@@ -1,0 +1,79 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "Convert multi-class labels into one-vs-one (OvO) binary vectors. Each class pair maps to a boolean row mask (which samples belong to the pair) and the binary labels over that subset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "import numpy as np\n",
+    "import aaanalysis as aa\n",
+    "\n",
+    "labels = [0, 0, 1, 1, 2, 2]\n",
+    "dict_labels = aa.SequenceFeature.get_labels_ovo(labels)\n",
+    "dict_labels"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "Apply the mask to ``df_parts`` to build the per-pair subset, then run CPP on that subset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "df_seq = aa.load_dataset(name=\"DOM_GSEC\", n=9)\n",
+    "sf = aa.SequenceFeature()\n",
+    "df_parts = sf.get_df_parts(df_seq=df_seq)\n",
+    "multiclass = np.array([i % 3 for i in range(len(df_parts))])\n",
+    "\n",
+    "(a, b), (row_mask, binary) = next(iter(aa.SequenceFeature.get_labels_ovo(multiclass).items()))\n",
+    "df_parts_pair = df_parts[row_mask]\n",
+    "df_feat = aa.CPP(df_parts=df_parts_pair).run(labels=binary, n_filter=3)\n",
+    "print(f\"pair ({a}, {b}): {df_parts_pair.shape[0]} samples\")\n",
+    "df_feat[[\"feature\", \"abs_auc\"]].head()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/feature_engineering/sf_get_labels_ovr.ipynb
+++ b/examples/feature_engineering/sf_get_labels_ovr.ipynb
@@ -1,0 +1,83 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "Convert multi-class labels into one-vs-rest (OvR) binary vectors. Each class becomes the test group (1) while all others become the reference group (0), so every vector can be passed straight to ``CPP.run`` without changing ``df_parts``:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import aaanalysis as aa\n",
+    "\n",
+    "labels = [0, 0, 1, 1, 2, 2]\n",
+    "dict_labels = aa.SequenceFeature.get_labels_ovr(labels)\n",
+    "dict_labels"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "Aggregate per-class CPP results by running CPP once per OvR vector and concatenating the ``df_feat`` frames, tagging each with its class:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "df_seq = aa.load_dataset(name=\"DOM_GSEC\", n=9)\n",
+    "sf = aa.SequenceFeature()\n",
+    "df_parts = sf.get_df_parts(df_seq=df_seq)\n",
+    "multiclass = np.array([i % 3 for i in range(len(df_parts))])\n",
+    "\n",
+    "cpp = aa.CPP(df_parts=df_parts)\n",
+    "frames = []\n",
+    "for cls, vec in aa.SequenceFeature.get_labels_ovr(multiclass).items():\n",
+    "    df_feat = cpp.run(labels=vec, n_filter=3)\n",
+    "    df_feat[\"class\"] = cls\n",
+    "    frames.append(df_feat)\n",
+    "df_feat_multiclass = pd.concat(frames, ignore_index=True)\n",
+    "df_feat_multiclass[[\"class\", \"feature\", \"abs_auc\"]].head()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/feature_engineering/sf_get_labels_quantile.ipynb
+++ b/examples/feature_engineering/sf_get_labels_quantile.ipynb
@@ -1,0 +1,76 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "Convert a continuous target into a binary label vector by a single quantile threshold (default median). Samples at or above the cut are the test group (1), the rest the reference group (0) - enabling regression-style targets within the binary CPP framework:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "import numpy as np\n",
+    "import aaanalysis as aa\n",
+    "\n",
+    "targets = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]\n",
+    "aa.SequenceFeature.get_labels_quantile(targets, q=0.5)"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "Use the resulting labels directly with ``CPP.run``:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "df_seq = aa.load_dataset(name=\"DOM_GSEC\", n=8)\n",
+    "sf = aa.SequenceFeature()\n",
+    "df_parts = sf.get_df_parts(df_seq=df_seq)\n",
+    "\n",
+    "targets = np.linspace(0, 1, len(df_parts))\n",
+    "labels = aa.SequenceFeature.get_labels_quantile(targets, q=0.5)\n",
+    "df_feat = aa.CPP(df_parts=df_parts).run(labels=labels, n_filter=4)\n",
+    "df_feat[[\"feature\", \"abs_auc\"]].head()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/unit/sequence_feature_tests/test_sf_labels_reference.py
+++ b/tests/unit/sequence_feature_tests/test_sf_labels_reference.py
@@ -1,0 +1,273 @@
+"""This is a script to test the SequenceFeature label-conversion and reference-generation methods.
+
+Covers get_labels_ovr, get_labels_ovo, get_labels_quantile, and get_df_parts_reference
+(issue #61: multi-class & regression CPP via label conversion + reference generation).
+"""
+import numpy as np
+import pandas as pd
+from collections import Counter
+import pytest
+import aaanalysis as aa
+
+SF = aa.SequenceFeature
+
+
+def _toy_df_parts():
+    return pd.DataFrame(
+        {
+            "jmd_n": ["AAAA", "CDEC", "DDWD"],
+            "tmd": ["EEFEEY", "FFLFFF", "GMGGGG"],
+            "jmd_c": ["HHHK", "IIRI", "KKQK"],
+        }
+    )
+
+
+# Normal Cases
+class TestGetLabelsOvr:
+    """Test get_labels_ovr."""
+
+    def test_keys_are_classes(self):
+        d = SF.get_labels_ovr([0, 0, 1, 1, 2, 2])
+        assert list(d.keys()) == [0, 1, 2]
+
+    def test_one_vs_rest_membership(self):
+        d = SF.get_labels_ovr([0, 0, 1, 1, 2, 2])
+        assert d[1].tolist() == [0, 0, 1, 1, 0, 0]
+        assert d[2].tolist() == [0, 0, 0, 0, 1, 1]
+
+    def test_full_length_no_drop(self):
+        labels = [0, 1, 2, 0, 1]
+        d = SF.get_labels_ovr(labels)
+        assert all(len(v) == len(labels) for v in d.values())
+
+    def test_binary_only(self):
+        d = SF.get_labels_ovr([0, 1, 2])
+        for v in d.values():
+            assert set(np.unique(v)).issubset({0, 1})
+
+    def test_custom_test_ref(self):
+        d = SF.get_labels_ovr([0, 1, 2], label_test=5, label_ref=-1)
+        assert set(np.unique(d[0])) == {5, -1}
+
+
+class TestGetLabelsOvo:
+    """Test get_labels_ovo."""
+
+    def test_pairs(self):
+        o = SF.get_labels_ovo([0, 0, 1, 1, 2, 2])
+        assert list(o.keys()) == [(0, 1), (0, 2), (1, 2)]
+
+    def test_mask_selects_pair_only(self):
+        o = SF.get_labels_ovo([0, 0, 1, 1, 2, 2])
+        mask, binary = o[(0, 1)]
+        assert mask.tolist() == [True, True, True, True, False, False]
+        assert binary.tolist() == [1, 1, 0, 0]
+
+    def test_binary_len_matches_mask(self):
+        o = SF.get_labels_ovo([0, 1, 2, 0, 1, 2])
+        for mask, binary in o.values():
+            assert len(binary) == int(mask.sum())
+            assert set(np.unique(binary)).issubset({0, 1})
+
+
+class TestGetLabelsQuantile:
+    """Test get_labels_quantile."""
+
+    def test_median_split(self):
+        labels = SF.get_labels_quantile([1.0, 2, 3, 4, 5, 6], q=0.5)
+        assert labels.tolist() == [0, 0, 0, 1, 1, 1]
+
+    def test_length_preserved(self):
+        t = [0.1, 0.2, 0.3, 0.9]
+        assert len(SF.get_labels_quantile(t, q=0.25)) == len(t)
+
+    def test_quantile_threshold(self):
+        labels = SF.get_labels_quantile([10, 20, 30, 40], q=0.75)
+        # cut = 75th percentile = 32.5 -> only 40 >= cut
+        assert labels.tolist() == [0, 0, 0, 1]
+
+    def test_custom_test_ref(self):
+        labels = SF.get_labels_quantile([1.0, 2, 3, 4], q=0.5, label_test=9, label_ref=2)
+        assert set(np.unique(labels)).issubset({9, 2})
+
+
+class TestGetDfPartsReference:
+    """Test get_df_parts_reference."""
+
+    def test_same_columns(self):
+        dfp = _toy_df_parts()
+        ref = SF.get_df_parts_reference(dfp, method="scrambled", random_state=0)
+        assert list(ref) == list(dfp)
+
+    def test_per_part_length_matches_a_real_row(self):
+        dfp = _toy_df_parts()
+        ref = SF.get_df_parts_reference(dfp, method="global_freq", n=5, random_state=0)
+        for part in dfp:
+            real_lengths = {len(s) for s in dfp[part]}
+            assert all(len(s) in real_lengths for s in ref[part])
+
+    def test_scrambled_preserves_composition(self):
+        dfp = _toy_df_parts()
+        ref = SF.get_df_parts_reference(dfp, method="scrambled", n=10, random_state=3)
+        # Each scrambled part is an anagram of SOME real part in that column.
+        for part in dfp:
+            real_comps = {frozenset(Counter(s).items()) for s in dfp[part]}
+            for s in ref[part]:
+                assert frozenset(Counter(s).items()) in real_comps
+
+    def test_n_rows(self):
+        dfp = _toy_df_parts()
+        assert len(SF.get_df_parts_reference(dfp, n=7, random_state=0)) == 7
+        assert len(SF.get_df_parts_reference(dfp, random_state=0)) == len(dfp)
+
+    def test_seed_determinism(self):
+        dfp = _toy_df_parts()
+        a = SF.get_df_parts_reference(dfp, method="global_freq", n=6, random_state=42)
+        b = SF.get_df_parts_reference(dfp, method="global_freq", n=6, random_state=42)
+        assert a.equals(b)
+
+    def test_global_freq_only_canonical(self):
+        dfp = _toy_df_parts()
+        ref = SF.get_df_parts_reference(dfp, method="global_freq", n=8, random_state=1)
+        canonical = set("ACDEFGHIKLMNPQRSTVWY")
+        for part in dfp:
+            assert set("".join(ref[part])).issubset(canonical)
+
+
+class TestGetDfPartsFromWindows:
+    """Test get_df_parts_from_windows (assemble df_parts from per-part window sets)."""
+
+    def test_from_lists(self):
+        d = {
+            "jmd_n": ["AAAA", "CCCC"],
+            "tmd": ["EEEEEE", "FFFFFF"],
+            "jmd_c": ["HHHH", "KKKK"],
+        }
+        df_parts = SF.get_df_parts_from_windows(d)
+        assert list(df_parts) == ["jmd_n", "tmd", "jmd_c"]
+        assert df_parts.index.tolist() == ["REF0", "REF1"]
+        assert df_parts.loc["REF1", "tmd"] == "FFFFFF"
+
+    def test_from_aawindowsampler_output(self):
+        df_seq = aa.load_dataset(name="DOM_GSEC", n=5)
+        aws = aa.AAWindowSampler(random_state=0)
+        d = {
+            "jmd_n": aws.sample_synthetic(df_seq=df_seq, n=6, window_size=10, generator="coil"),
+            "tmd": aws.sample_synthetic(df_seq=df_seq, n=6, window_size=20, generator="alpha_helix"),
+            "jmd_c": aws.sample_synthetic(df_seq=df_seq, n=6, window_size=10, generator="coil"),
+        }
+        df_parts = SF.get_df_parts_from_windows(d)
+        assert df_parts.shape == (6, 3)
+        assert all(len(s) == 10 for s in df_parts["jmd_n"])
+        assert all(len(s) == 20 for s in df_parts["tmd"])
+
+    def test_unequal_lengths_raise(self):
+        with pytest.raises(ValueError):
+            SF.get_df_parts_from_windows({"jmd_n": ["AAAA"], "tmd": ["EEE", "FFF"]})
+
+    def test_invalid_part_name_raises(self):
+        with pytest.raises(ValueError):
+            SF.get_df_parts_from_windows({"not_a_part": ["AAAA", "CCCC"]})
+
+    def test_missing_window_column_raises(self):
+        bad = pd.DataFrame({"sequence": ["AAAA", "CCCC"]})
+        with pytest.raises(ValueError):
+            SF.get_df_parts_from_windows({"jmd_n": bad})
+
+    def test_non_string_raises(self):
+        with pytest.raises(ValueError):
+            SF.get_df_parts_from_windows({"jmd_n": [1, 2], "tmd": [3, 4]})
+
+    def test_empty_dict_raises(self):
+        with pytest.raises(ValueError):
+            SF.get_df_parts_from_windows({})
+
+
+# Integration
+class TestIntegrationWithCPP:
+    """Label helpers + reference generator flow through the real CPP pipeline."""
+
+    def test_reference_as_negative_class_runs(self):
+        df_seq = aa.load_dataset(name="DOM_GSEC", n=8)
+        sf = SF()
+        df_parts = sf.get_df_parts(df_seq=df_seq)
+        df_ref = SF.get_df_parts_reference(df_parts, method="scrambled", random_state=0)
+        df_all = pd.concat([df_parts, df_ref])
+        labels = [1] * len(df_parts) + [0] * len(df_ref)
+        df_feat = aa.CPP(df_parts=df_all).run(labels=labels, n_filter=5)
+        assert ut_cols_present(df_feat)
+        assert len(df_feat) == 5
+
+    def test_ovr_vector_equals_manual_binary_run(self):
+        # Build a 3-class label vector by relabeling DOM_GSEC into thirds.
+        df_seq = aa.load_dataset(name="DOM_GSEC", n=9)
+        sf = SF()
+        df_parts = sf.get_df_parts(df_seq=df_seq)
+        n = len(df_parts)
+        mc = np.array([i % 3 for i in range(n)])
+        d = SF.get_labels_ovr(mc)
+        cpp = aa.CPP(df_parts=df_parts)
+        for c, vec in d.items():
+            manual = np.where(mc == c, 1, 0)
+            assert vec.tolist() == manual.tolist()
+            df_feat = cpp.run(labels=vec, n_filter=3)
+            assert len(df_feat) == 3
+
+    def test_quantile_labels_run(self):
+        df_seq = aa.load_dataset(name="DOM_GSEC", n=8)
+        sf = SF()
+        df_parts = sf.get_df_parts(df_seq=df_seq)
+        targets = np.linspace(0, 1, len(df_parts))
+        labels = SF.get_labels_quantile(targets, q=0.5)
+        df_feat = aa.CPP(df_parts=df_parts).run(labels=labels, n_filter=4)
+        assert len(df_feat) == 4
+
+    def test_per_part_prior_reference_runs(self):
+        # jmd_n=coil, tmd=alpha_helix, jmd_c=coil reference, assembled then run via CPP.
+        df_seq = aa.load_dataset(name="DOM_GSEC", n=8)
+        sf = SF()
+        df_parts = sf.get_df_parts(df_seq=df_seq, list_parts=["jmd_n", "tmd", "jmd_c"])
+        n_ref = len(df_parts)
+        aws = aa.AAWindowSampler(random_state=0)
+        df_ref = SF.get_df_parts_from_windows({
+            "jmd_n": aws.sample_synthetic(df_seq=df_seq, n=n_ref, window_size=10, generator="coil"),
+            "tmd": aws.sample_synthetic(df_seq=df_seq, n=n_ref, window_size=20, generator="alpha_helix"),
+            "jmd_c": aws.sample_synthetic(df_seq=df_seq, n=n_ref, window_size=10, generator="coil"),
+        })
+        df_all = pd.concat([df_parts, df_ref])
+        labels = [1] * len(df_parts) + [0] * len(df_ref)
+        split_kws = sf.get_split_kws(n_split_max=5, steps_pattern=[3, 4], n_min=2, n_max=3, len_max=8)
+        df_feat = aa.CPP(df_parts=df_all, split_kws=split_kws).run(labels=labels, n_filter=5)
+        assert len(df_feat) == 5
+
+
+def ut_cols_present(df_feat):
+    import aaanalysis.utils as ut
+    return set(ut.LIST_COLS_FEAT).issubset(set(df_feat.columns))
+
+
+# Error Cases
+class TestErrors:
+    """Invalid inputs raise informative errors."""
+
+    def test_ovr_single_class_raises(self):
+        with pytest.raises(ValueError):
+            SF.get_labels_ovr([1, 1, 1])
+
+    def test_ovr_equal_test_ref_raises(self):
+        with pytest.raises(ValueError):
+            SF.get_labels_ovr([0, 1], label_test=1, label_ref=1)
+
+    def test_quantile_bad_q_raises(self):
+        with pytest.raises(ValueError):
+            SF.get_labels_quantile([1.0, 2, 3], q=0)
+        with pytest.raises(ValueError):
+            SF.get_labels_quantile([1.0, 2, 3], q=1)
+
+    def test_reference_bad_method_raises(self):
+        with pytest.raises(ValueError):
+            SF.get_df_parts_reference(_toy_df_parts(), method="nonsense")
+
+    def test_reference_bad_seed_raises(self):
+        with pytest.raises(ValueError):
+            SF.get_df_parts_reference(_toy_df_parts(), random_state=-1)


### PR DESCRIPTION
Implements #61 as **label transformations + reference synthesis feeding the existing `CPP.run`** — no new `fit_*`/`run_*` methods, no public top-level symbols (no `__init__.py` change).

## What's added (static methods on `SequenceFeature`)
- `get_labels_ovr(labels)` → one-vs-rest binary vectors (X unchanged; loop `run`).
- `get_labels_ovo(labels)` → per class-pair `(row_mask, binary_subset)`.
- `get_labels_quantile(targets, q=0.5)` → continuous → binary via a single quantile cut (no drop).
- `get_df_parts_reference(df_parts, method, n, random_state)` → scrambled / composition-matched reference parts, length-faithful per part by construction.
- `get_df_parts_from_windows(dict_parts)` → assemble a reference `df_parts` from per-part `AAWindowSampler` window sets, enabling **per-part priors** (e.g. coil JMD-N, α-helix TMD, coil JMD-C).

Backend in `_backend/cpp/sequence_feature.py`. Five example notebooks; tests cover golden/error/seed cases plus integration through the real `CPP.run` (#18 `LIST_COLS_FEAT` schema preserved).

## Deferred
- SHAP multi-class/regression → later **pro** PR.
- One-vs-one and **banded** quantile regression need *CPP-on-a-row-subset of `df_parts`* (the `CPP.__init__` binding) — drafted as a separate "part problem" issue.

## Verification (local)
- New suite + full SequenceFeature suite green (225 passed); CPP suite 263 passed; API tests green.
- Docstring checker: 0 defects; doc-signature drift: 0.
- All 5 example notebooks execute clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)