### PR TITLE
feat(cpp): add CPP.simplify — interpretability-guided scale swapping

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -76,6 +76,15 @@ per-method file** (do not spawn a parallel correctness-suite tree):
 - **Property tests** — `@given(...)` checks of invariants (frequencies sum to 1,
   `len(X) == n_sequences`, scores sorted descending, returned features satisfy
   the overlap/correlation thresholds, same seed → same output).
+- **Property-based testing with hypothesis is the house standard.** Every
+  positive test in `Test<Method>` parametrizes its argument with a
+  `hypothesis.strategies` variant rather than a single hardcoded value, unless
+  the argument is a small categorical enum (e.g. `mode="global"`). Use
+  `@given(arg=some.integers(...) / some.floats(...))` plus
+  `@settings(max_examples=5, deadline=None)` (small `max_examples` keeps the
+  suite fast under xdist). Example:
+  `@settings(max_examples=5, deadline=None)` /
+  `@given(n=some.integers(min_value=2, max_value=5))`.
 - **Error-message tests** — `pytest.raises(ValueError, match="…")` so users get
   the tailored message, not a cryptic pandas/sklearn traceback. When a guard is
   reachable (e.g. a part-based `df_seq` reaching a `'sequence' not in columns`

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -397,6 +397,19 @@ _Avoid_: interpretability score (overloaded), explainability.
 The Pearson-correlation threshold (∈ {0.3,…,0.9} or `None`) for an optional `AAclust` redundancy reduction layered on a tier, served from **pre-computed** per-tier selections (AAclust default settings, fixed seed). `None` = no reduction. Reduction is computed **per tier** (medoids are not nested across tiers) and on **dual grids** (with / without AAindex) so `just_aaindex` stays correct. May leave a subcategory with no representative — the reduced set need not cover every tier subcategory. See ADR-0025.
 _Avoid_: min_corr, redundancy threshold (use the AAclust term `min_th`).
 
+**feature simplification** (`CPP.simplify`):
+The post-hoc rewriting of a fitted [[df_feat]] into a **more interpretable, and ideally
+smaller** one: each feature's scale is swapped for a *correlated* scale drawn from a
+**strictly better-rated [[interpretability rating]] subcategory** (keeping `PART-SPLIT`), the
+feature stats are recomputed, and the swap is accepted only if it keeps passing CPP filtering
+(`max_std_test`) and does not reduce a random-forest cross-validation score. The swapped set is
+then redundancy-reduced (keeping the most interpretable member of a redundant pair), so the
+result speaks in fewer, clearer physicochemical subcategories. The candidate pool is the full
+rated AAontology scale set, loaded internally. Distinct from **feature selection** (which
+*subsets* features by importance) and CPP **feature engineering** (which *creates* features) —
+simplification *relabels* a feature onto a more interpretable scale while preserving its signal.
+_Avoid_: feature reduction (overloaded with selection), scale substitution (the unit is a feature).
+
 ## Relationships
 
 - A **df_seq** row contains one **entry** and one sequence; optionally a **pos column** cell of 1-based positions.

--- a/aaanalysis/feature_engineering/_backend/cpp/_simplify.py
+++ b/aaanalysis/feature_engineering/_backend/cpp/_simplify.py
@@ -2,15 +2,17 @@
 This is a script for the backend of CPP's simplify method: interpretability-
 guided scale swapping. For each feature (``PART-SPLIT-SCALE``) a more
 interpretable, correlated scale is substituted (``PART-SPLIT`` preserved), the
-feature stats are recomputed, and the swap is validated by a random-forest
-cross-validation non-regression gate. The set is then redundancy-reduced so the
-result speaks in fewer, more interpretable subcategories.
+feature stats are recomputed, and the swap is validated by a cross-validation
+non-regression gate. The set is then redundancy-reduced so the result speaks in
+fewer, more interpretable subcategories.
 """
 
 import warnings
 import numpy as np
 import pandas as pd
 from sklearn.ensemble import RandomForestClassifier
+from sklearn.svm import SVC
+from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import cross_val_score
 
 import aaanalysis.utils as ut
@@ -57,17 +59,32 @@ def _load_candidate_pool_():
     return df_scales_pool, df_cor, dict_all_scales, dict_interp, dict_meta
 
 
+def _resolve_ml_model_(ml_model=None, random_state=None):
+    """Resolve a string preset or a custom estimator into an sklearn estimator.
+
+    Presets: ``'svm'`` (default), ``'rf'``, ``'log_reg'`` (constructed with the
+    resolved ``random_state``). A non-string ``ml_model`` is a user-configured
+    estimator instance, returned as-is (the user owns its parameters)."""
+    if not isinstance(ml_model, str):
+        return ml_model
+    if ml_model == ut.MODEL_SVM:
+        return SVC(class_weight="balanced", random_state=random_state)
+    if ml_model == ut.MODEL_RF:
+        return RandomForestClassifier(random_state=random_state)
+    return LogisticRegression(max_iter=1000, random_state=random_state)
+
+
 def _score_feature_set_(
-    X=None, labels=None, n_cv=5, metric="balanced_accuracy", random_state=None
+    X=None, labels=None, n_cv=5, metric="balanced_accuracy", estimator=None
 ):
-    """Mean random-forest cross-validation score for a feature matrix ``X``.
+    """Mean cross-validation score of ``estimator`` on a feature matrix ``X``.
 
     Mirrors the ``cross_val_score`` primitive used by ``TreeModel.eval`` so the
-    score is consistent with the rest of the package. Deterministic given
-    ``random_state`` (the only RNG is the forest; ``StratifiedKFold`` does not
-    shuffle)."""
-    rf = RandomForestClassifier(random_state=random_state)
-    return float(cross_val_score(rf, X, y=labels, cv=n_cv, scoring=metric).mean())
+    score is consistent with the rest of the package. ``cross_val_score`` clones
+    the estimator per fold, so one instance can be reused across many calls."""
+    return float(
+        cross_val_score(estimator, X, y=labels, cv=n_cv, scoring=metric).mean()
+    )
 
 
 def _recompute_swapped_row_(
@@ -267,7 +284,6 @@ def _build_df_candidates_(records=None):
 def _greedy_simplify_(
     df_feat=None,
     df_parts=None,
-    df_scales_self=None,
     labels=None,
     X=None,
     df_cor=None,
@@ -286,13 +302,13 @@ def _greedy_simplify_(
     parametric=False,
     accept_gaps=False,
     max_std_test=0.2,
-    random_state=None,
+    estimator=None,
 ):
-    """Per-feature swap with an RF+CV non-regression gate. Returns
+    """Per-feature swap with a CV non-regression gate. Returns
     ``(df_feat_new, X_kept, records, baseline)``."""
     n = len(df_feat)
     baseline = _score_feature_set_(
-        X=X, labels=labels, n_cv=n_cv, metric=metric, random_state=random_state
+        X=X, labels=labels, n_cv=n_cv, metric=metric, estimator=estimator
     )
     targets = _select_targets_(
         df_feat=df_feat,
@@ -346,7 +362,7 @@ def _greedy_simplify_(
                 labels=labels,
                 n_cv=n_cv,
                 metric=metric,
-                random_state=random_state,
+                estimator=estimator,
             )
             if score >= baseline - tol:
                 X[:, i] = col
@@ -392,7 +408,7 @@ def _greedy_simplify_(
                         labels=labels,
                         n_cv=n_cv,
                         metric=metric,
-                        random_state=random_state,
+                        estimator=estimator,
                     )
                     if score_drop >= baseline - tol:
                         dropped.add(i)
@@ -403,6 +419,262 @@ def _greedy_simplify_(
     df_feat_new = pd.concat(rows, ignore_index=True)
     X_kept = X[:, keep_idx]
     return df_feat_new, X_kept, records, baseline
+
+
+def _swap_all_simplify_(
+    df_feat=None,
+    df_parts=None,
+    labels=None,
+    df_cor=None,
+    dict_all_scales=None,
+    dict_interp=None,
+    dict_meta=None,
+    max_interpretability=None,
+    top_n=None,
+    min_cor=0.7,
+    on_unimprovable=ut.ON_UNIMPROVABLE_KEEP,
+    label_test=1,
+    label_ref=0,
+    parametric=False,
+    accept_gaps=False,
+    max_std_test=0.2,
+):
+    """Apply every eligible best-candidate swap, no CV scoring (fastest).
+
+    ``on_unimprovable``: only ``'drop'`` is meaningful without scoring;
+    ``'drop_if_perf_allows'`` degrades to ``'keep'``. Returns
+    ``(df_feat_new, records)``."""
+    n = len(df_feat)
+    targets = _select_targets_(
+        df_feat=df_feat,
+        dict_interp=dict_interp,
+        max_interpretability=max_interpretability,
+        top_n=top_n,
+    )
+    new_rows = {}
+    dropped = set()
+    records = []
+    for i, feat_id, interp_old in targets:
+        positions = df_feat.iloc[i][ut.COL_POSITION]
+        cands = _eligible_candidates_(
+            feat_id=feat_id, df_cor=df_cor, dict_interp=dict_interp, min_cor=min_cor
+        )
+        swapped = False
+        for scale_cand, interp_cand, abs_cor, cor in cands:
+            row_df, col = _recompute_swapped_row_(
+                feat_id=feat_id,
+                scale_new=scale_cand,
+                df_parts=df_parts,
+                dict_all_scales=dict_all_scales,
+                dict_meta=dict_meta,
+                labels=labels,
+                label_test=label_test,
+                label_ref=label_ref,
+                parametric=parametric,
+                accept_gaps=accept_gaps,
+                positions=positions,
+            )
+            std_test = float(row_df[ut.COL_STD_TEST].iloc[0])
+            if std_test > max_std_test:
+                records.append(
+                    [
+                        feat_id,
+                        scale_cand,
+                        interp_old,
+                        interp_cand,
+                        cor,
+                        std_test,
+                        False,
+                        np.nan,
+                        "max_std_test",
+                    ]
+                )
+                continue
+            new_rows[i] = row_df
+            swapped = True
+            records.append(
+                [
+                    feat_id,
+                    scale_cand,
+                    interp_old,
+                    interp_cand,
+                    cor,
+                    std_test,
+                    True,
+                    np.nan,
+                    "accepted",
+                ]
+            )
+            break
+        if (
+            not swapped
+            and on_unimprovable == ut.ON_UNIMPROVABLE_DROP
+            and n - len(dropped) > 1
+        ):
+            dropped.add(i)
+    keep_idx = [i for i in range(n) if i not in dropped]
+    rows = [new_rows[i] if i in new_rows else df_feat.iloc[[i]] for i in keep_idx]
+    df_feat_new = pd.concat(rows, ignore_index=True)
+    return df_feat_new, records
+
+
+def _consolidate_simplify_(
+    df_feat=None,
+    df_parts=None,
+    labels=None,
+    X=None,
+    df_cor=None,
+    dict_all_scales=None,
+    dict_interp=None,
+    dict_meta=None,
+    max_interpretability=None,
+    top_n=None,
+    min_cor=0.7,
+    metric="balanced_accuracy",
+    tol=0.0,
+    n_cv=5,
+    on_unimprovable=ut.ON_UNIMPROVABLE_KEEP,
+    label_test=1,
+    label_ref=0,
+    parametric=False,
+    accept_gaps=False,
+    max_std_test=0.2,
+    estimator=None,
+):
+    """Batch-by-subcategory swaps toward the fewest interpretable subcategories.
+
+    Interpretable subcategories are processed best-first; for each, every still-
+    unclaimed target with an eligible candidate in that subcategory is swapped to
+    its best in-subcat candidate, the whole batch is CV-scored, and the batch is
+    accepted only if the set score stays within ``tol`` of the baseline. Returns
+    ``(df_feat_new, X_kept, records)``."""
+    n = len(df_feat)
+    baseline = _score_feature_set_(
+        X=X, labels=labels, n_cv=n_cv, metric=metric, estimator=estimator
+    )
+    targets = _select_targets_(
+        df_feat=df_feat,
+        dict_interp=dict_interp,
+        max_interpretability=max_interpretability,
+        top_n=top_n,
+    )
+    # Per target: (feat_id, interp_old, eligible candidates) + the subcategory rankings.
+    target_cands = {
+        i: (
+            feat_id,
+            interp_old,
+            _eligible_candidates_(
+                feat_id=feat_id, df_cor=df_cor, dict_interp=dict_interp, min_cor=min_cor
+            ),
+        )
+        for i, feat_id, interp_old in targets
+    }
+    subcat_rating = {}
+    for i in target_cands:
+        for scale_cand, interp_cand, abs_cor, cor in target_cands[i][2]:
+            subcat_rating.setdefault(dict_meta[scale_cand][1], interp_cand)
+    ranked_subcats = sorted(subcat_rating, key=lambda s: subcat_rating[s])
+    new_rows = {}
+    claimed = set()
+    records = []
+    for sub in ranked_subcats:
+        batch = {}  # i -> (scale_cand, interp_cand, cor, row_df, col, std_test)
+        for i in target_cands:
+            if i in claimed:
+                continue
+            feat_id, interp_old, cands = target_cands[i]
+            best = next(
+                ((sc, ic, ac, c) for sc, ic, ac, c in cands if dict_meta[sc][1] == sub),
+                None,
+            )
+            if best is None:
+                continue
+            scale_cand, interp_cand, abs_cor, cor = best
+            positions = df_feat.iloc[i][ut.COL_POSITION]
+            row_df, col = _recompute_swapped_row_(
+                feat_id=feat_id,
+                scale_new=scale_cand,
+                df_parts=df_parts,
+                dict_all_scales=dict_all_scales,
+                dict_meta=dict_meta,
+                labels=labels,
+                label_test=label_test,
+                label_ref=label_ref,
+                parametric=parametric,
+                accept_gaps=accept_gaps,
+                positions=positions,
+            )
+            std_test = float(row_df[ut.COL_STD_TEST].iloc[0])
+            if std_test > max_std_test:
+                records.append(
+                    [
+                        feat_id,
+                        scale_cand,
+                        interp_old,
+                        interp_cand,
+                        cor,
+                        std_test,
+                        False,
+                        np.nan,
+                        "max_std_test",
+                    ]
+                )
+                continue
+            batch[i] = (scale_cand, interp_cand, cor, row_df, col, std_test)
+        if not batch:
+            continue
+        X_trial = X.copy()
+        for i, (scale_cand, interp_cand, cor, row_df, col, std_test) in batch.items():
+            X_trial[:, i] = col
+        score = _score_feature_set_(
+            X=X_trial, labels=labels, n_cv=n_cv, metric=metric, estimator=estimator
+        )
+        accepted = score >= baseline - tol
+        if accepted:
+            X = X_trial
+            baseline = score
+        for i, (scale_cand, interp_cand, cor, row_df, col, std_test) in batch.items():
+            feat_id, interp_old = target_cands[i][0], target_cands[i][1]
+            if accepted:
+                new_rows[i] = row_df
+                claimed.add(i)
+            records.append(
+                [
+                    feat_id,
+                    scale_cand,
+                    interp_old,
+                    interp_cand,
+                    cor,
+                    std_test,
+                    accepted,
+                    score,
+                    "accepted" if accepted else "cv_drop",
+                ]
+            )
+    # Unclaimed targets -> on_unimprovable.
+    dropped = set()
+    if on_unimprovable != ut.ON_UNIMPROVABLE_KEEP:
+        for i in target_cands:
+            if i in claimed or n - len(dropped) <= 1:
+                continue
+            if on_unimprovable == ut.ON_UNIMPROVABLE_DROP:
+                dropped.add(i)
+            elif on_unimprovable == ut.ON_UNIMPROVABLE_DROP_IF_PERF:
+                keep_idx = [j for j in range(n) if j not in dropped and j != i]
+                score_drop = _score_feature_set_(
+                    X=X[:, keep_idx],
+                    labels=labels,
+                    n_cv=n_cv,
+                    metric=metric,
+                    estimator=estimator,
+                )
+                if score_drop >= baseline - tol:
+                    dropped.add(i)
+                    baseline = score_drop
+    keep_idx = [i for i in range(n) if i not in dropped]
+    rows = [new_rows[i] if i in new_rows else df_feat.iloc[[i]] for i in keep_idx]
+    df_feat_new = pd.concat(rows, ignore_index=True)
+    return df_feat_new, X[:, keep_idx], records
 
 
 def simplify_cpp_(
@@ -429,6 +701,7 @@ def simplify_cpp_(
     parametric=False,
     accept_gaps=False,
     return_details=False,
+    ml_model=ut.MODEL_SVM,
     random_state=None,
 ):
     """Backend entry for ``CPP.simplify``: df_feat or (df_feat, df_candidates)."""
@@ -451,21 +724,40 @@ def simplify_cpp_(
         )
         out = ut.sort_cols_feat(df_feat=df_feat)
         return (out, _build_df_candidates_(records=[])) if return_details else out
-    if X is None:
-        X = _build_base_matrix_(
+    # swap_all needs no feature matrix (no CV scoring); greedy/consolidate do.
+    if strategy == ut.STRATEGY_SWAP_ALL:
+        df_feat_new, records = _swap_all_simplify_(
             df_feat=df_feat,
             df_parts=df_parts,
-            df_scales_self=df_scales_self,
+            labels=labels,
+            df_cor=df_cor,
+            dict_all_scales=dict_all_scales,
+            dict_interp=dict_interp,
+            dict_meta=dict_meta,
+            max_interpretability=max_interpretability,
+            top_n=top_n,
+            min_cor=min_cor,
+            on_unimprovable=on_unimprovable,
+            label_test=label_test,
+            label_ref=label_ref,
+            parametric=parametric,
             accept_gaps=accept_gaps,
+            max_std_test=max_std_test,
         )
     else:
-        X = np.asarray(X, dtype=float).copy()
-
-    if strategy == ut.STRATEGY_GREEDY:
-        df_feat_new, X_kept, records, _ = _greedy_simplify_(
+        if X is None:
+            X = _build_base_matrix_(
+                df_feat=df_feat,
+                df_parts=df_parts,
+                df_scales_self=df_scales_self,
+                accept_gaps=accept_gaps,
+            )
+        else:
+            X = np.asarray(X, dtype=float).copy()
+        estimator = _resolve_ml_model_(ml_model=ml_model, random_state=random_state)
+        common = dict(
             df_feat=df_feat,
             df_parts=df_parts,
-            df_scales_self=df_scales_self,
             labels=labels,
             X=X,
             df_cor=df_cor,
@@ -484,13 +776,12 @@ def simplify_cpp_(
             parametric=parametric,
             accept_gaps=accept_gaps,
             max_std_test=max_std_test,
-            random_state=random_state,
+            estimator=estimator,
         )
-    else:
-        raise NotImplementedError(
-            f"'strategy' ('{strategy}') is staged for a future release; only "
-            f"'{ut.STRATEGY_GREEDY}' is implemented."
-        )
+        if strategy == ut.STRATEGY_GREEDY:
+            df_feat_new, _X_kept, records, _ = _greedy_simplify_(**common)
+        else:  # STRATEGY_CONSOLIDATE
+            df_feat_new, _X_kept, records = _consolidate_simplify_(**common)
 
     # Set-level redundancy reduction ("fewer subcats").
     df_cor_present = _merged_scale_corr_(

--- a/aaanalysis/feature_engineering/_backend/cpp/_simplify.py
+++ b/aaanalysis/feature_engineering/_backend/cpp/_simplify.py
@@ -1,0 +1,513 @@
+"""
+This is a script for the backend of CPP's simplify method: interpretability-
+guided scale swapping. For each feature (``PART-SPLIT-SCALE``) a more
+interpretable, correlated scale is substituted (``PART-SPLIT`` preserved), the
+feature stats are recomputed, and the swap is validated by a random-forest
+cross-validation non-regression gate. The set is then redundancy-reduced so the
+result speaks in fewer, more interpretable subcategories.
+"""
+
+import warnings
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import cross_val_score
+
+import aaanalysis.utils as ut
+from .utils_feature import _feature_value, _get_dict_all_scales
+from ._utils_feature_stat import add_stat_
+
+
+# I Helper Functions
+def _interp(scale_id=None, dict_interp=None):
+    """Interpretability rating of a scale's subcategory (NaN if unrated/absent)."""
+    val = dict_interp.get(scale_id, np.nan)
+    if val is None or pd.isna(val):
+        return np.nan
+    return float(val)
+
+
+def _load_candidate_pool_():
+    """Load the full rated AAontology pool and precompute the scale-correlation matrix.
+
+    Returns ``(df_scales_pool, df_cor, dict_all_scales, dict_interp, dict_meta)``
+    where ``dict_interp`` maps scale id to its per-subcategory interpretability
+    rating (1 = best) and ``dict_meta`` maps scale id to its
+    ``(category, subcategory, scale_name, scale_description)``.
+    """
+    df_scales_pool = ut.load_default_scales()  # (20 AA, n_scales)
+    df_cat_pool = ut.load_default_scales(
+        scale_cat=True
+    )  # incl. interpretability/top_explain
+    df_cor = df_scales_pool.corr()  # scale x scale Pearson
+    dict_all_scales = _get_dict_all_scales(df_scales=df_scales_pool)
+    dict_interp = dict(
+        zip(df_cat_pool[ut.COL_SCALE_ID], df_cat_pool[ut.COL_INTERPRETABILITY])
+    )
+    dict_meta = {
+        sid: (cat, sub, name, des)
+        for sid, cat, sub, name, des in zip(
+            df_cat_pool[ut.COL_SCALE_ID],
+            df_cat_pool[ut.COL_CAT],
+            df_cat_pool[ut.COL_SUBCAT],
+            df_cat_pool[ut.COL_SCALE_NAME],
+            df_cat_pool[ut.COL_SCALE_DES],
+        )
+    }
+    return df_scales_pool, df_cor, dict_all_scales, dict_interp, dict_meta
+
+
+def _score_feature_set_(
+    X=None, labels=None, n_cv=5, metric="balanced_accuracy", random_state=None
+):
+    """Mean random-forest cross-validation score for a feature matrix ``X``.
+
+    Mirrors the ``cross_val_score`` primitive used by ``TreeModel.eval`` so the
+    score is consistent with the rest of the package. Deterministic given
+    ``random_state`` (the only RNG is the forest; ``StratifiedKFold`` does not
+    shuffle)."""
+    rf = RandomForestClassifier(random_state=random_state)
+    return float(cross_val_score(rf, X, y=labels, cv=n_cv, scoring=metric).mean())
+
+
+def _recompute_swapped_row_(
+    feat_id=None,
+    scale_new=None,
+    df_parts=None,
+    dict_all_scales=None,
+    dict_meta=None,
+    labels=None,
+    label_test=1,
+    label_ref=0,
+    parametric=False,
+    accept_gaps=False,
+    positions=None,
+):
+    """Recompute a single ``PART-SPLIT-scale_new`` feature: values, stats, metadata.
+
+    ``PART-SPLIT`` is preserved, so ``positions`` are copied from the original
+    feature row (no recompute needed). Returns ``(row_df, col_values)``."""
+    part, split, _ = ut.split_feat_id(feat_id=feat_id)
+    new_feat_id = ut.join_feat_id(part=part, split=split, scale_id=scale_new)
+    col = _feature_value(
+        df_parts=df_parts[part.lower()],
+        split=split,
+        dict_scale=dict_all_scales[scale_new],
+        accept_gaps=accept_gaps,
+    )
+    row_df = pd.DataFrame({ut.COL_FEATURE: [new_feat_id]})
+    row_df = add_stat_(
+        df=row_df,
+        X=col[:, None],
+        labels=labels,
+        parametric=parametric,
+        label_test=label_test,
+        label_ref=label_ref,
+    )
+    cat, sub, name, des = dict_meta[scale_new]
+    row_df[ut.COL_CAT] = cat
+    row_df[ut.COL_SUBCAT] = sub
+    row_df[ut.COL_SCALE_NAME] = name
+    row_df[ut.COL_SCALE_DES] = des
+    row_df[ut.COL_POSITION] = [positions]
+    return row_df, col
+
+
+def _eligible_candidates_(feat_id=None, df_cor=None, dict_interp=None, min_cor=0.7):
+    """Eligible candidate scales for one feature, ranked by (interpretability, |corr|).
+
+    Eligible iff the candidate subcategory rating is strictly better (lower) than
+    the feature's current scale rating AND ``|corr(candidate, original)| >=
+    min_cor`` (anti-correlation allowed via ``abs``). Returns a list of
+    ``(scale_cand, interp_cand, abs_cor, cor)``."""
+    scale_old = ut.split_feat_id(feat_id=feat_id)[2]
+    interp_old = _interp(scale_id=scale_old, dict_interp=dict_interp)
+    if np.isnan(interp_old) or scale_old not in df_cor.columns:
+        return []
+    candidates = []
+    cors = df_cor[scale_old]
+    for scale_cand, cor in cors.items():
+        if scale_cand == scale_old:
+            continue
+        interp_cand = _interp(scale_id=scale_cand, dict_interp=dict_interp)
+        if np.isnan(interp_cand) or interp_cand >= interp_old:
+            continue
+        abs_cor = abs(float(cor))
+        if abs_cor < min_cor:
+            continue
+        candidates.append((scale_cand, interp_cand, abs_cor, float(cor)))
+    candidates.sort(key=lambda t: (t[1], -t[2]))
+    return candidates
+
+
+def _select_targets_(
+    df_feat=None, dict_interp=None, max_interpretability=None, top_n=None
+):
+    """Order of features to attempt (worst-interpretability first).
+
+    Only features whose current scale is rated (present in the pool) are
+    targetable. Returns a list of ``(row_index, feat_id, interp_old)``."""
+    rated = []
+    for i, feat_id in enumerate(df_feat[ut.COL_FEATURE]):
+        interp_old = _interp(
+            scale_id=ut.split_feat_id(feat_id=feat_id)[2], dict_interp=dict_interp
+        )
+        if not np.isnan(interp_old):
+            rated.append((i, feat_id, interp_old))
+    rated.sort(key=lambda t: -t[2])
+    if max_interpretability is not None:
+        return [t for t in rated if t[2] > max_interpretability]
+    if top_n is not None:
+        return rated[:top_n]
+    return [t for t in rated if t[2] > 1]
+
+
+def _build_base_matrix_(
+    df_feat=None, df_parts=None, df_scales_self=None, accept_gaps=False
+):
+    """Recompute the (n_samples, n_features) matrix for the current feature set."""
+    dict_self = _get_dict_all_scales(df_scales=df_scales_self)
+    features = list(df_feat[ut.COL_FEATURE])
+    X = np.empty((len(df_parts), len(features)))
+    for j, feat in enumerate(features):
+        part, split, scale = ut.split_feat_id(feat_id=feat)
+        X[:, j] = _feature_value(
+            df_parts=df_parts[part.lower()],
+            split=split,
+            dict_scale=dict_self[scale],
+            accept_gaps=accept_gaps,
+        )
+    return X
+
+
+def _merged_scale_corr_(df_feat=None, df_scales_pool=None, df_scales_self=None):
+    """Correlation lookup covering every scale present in ``df_feat``.
+
+    Swapped scales come from the pool; unchanged (possibly custom) scales come
+    from ``df_scales_self``. Build the union once and correlate only the present
+    scales (pool values win for shared ids; they are identical AAontology scales)."""
+    present = [ut.split_feat_id(feat_id=f)[2] for f in df_feat[ut.COL_FEATURE]]
+    extra = [c for c in df_scales_self.columns if c not in df_scales_pool.columns]
+    df_all = (
+        pd.concat([df_scales_pool, df_scales_self[extra]], axis=1)
+        if extra
+        else df_scales_pool
+    )
+    present = [s for s in dict.fromkeys(present) if s in df_all.columns]
+    return df_all[present].corr()
+
+
+def _apply_redundancy_(
+    df_feat=None,
+    df_cor=None,
+    dict_interp=None,
+    max_overlap=0.5,
+    max_cor=0.5,
+    check_cat=True,
+    tie_break=ut.TIE_BREAK_INTERPRETABILITY,
+):
+    """Greedy redundancy reduction on the swapped set (adapted from ``filtering``).
+
+    Two features are redundant when their positions overlap (``>= max_overlap`` or
+    one is a subset) AND their scales correlate (``> max_cor``), within the same
+    category when ``check_cat``. The kept member of a redundant pair is chosen by
+    ``tie_break``: ``interpretability`` (most interpretable, then ``abs_auc``) or
+    ``performance`` (``abs_auc`` only, CPP's default)."""
+    df = df_feat.copy().reset_index(drop=True)
+    dict_c = dict(zip(df[ut.COL_FEATURE], df[ut.COL_CAT])) if check_cat else dict()
+    dict_p = dict(zip(df[ut.COL_FEATURE], [set(x) for x in df[ut.COL_POSITION]]))
+    if tie_break == ut.TIE_BREAK_INTERPRETABILITY:
+        interp = [
+            _interp(scale_id=ut.split_feat_id(feat_id=f)[2], dict_interp=dict_interp)
+            for f in df[ut.COL_FEATURE]
+        ]
+        # NaN (unrated) sorts last (kept last → dropped first if redundant).
+        df = df.assign(_interp=[v if not np.isnan(v) else np.inf for v in interp])
+        df = df.sort_values(by=["_interp", ut.COL_ABS_AUC], ascending=[True, False])
+        df = df.drop(columns="_interp")
+    else:
+        df = df.sort_values(by=[ut.COL_ABS_AUC, ut.COL_ABS_MEAN_DIF], ascending=False)
+    df = df.reset_index(drop=True)
+    list_feat = list(df[ut.COL_FEATURE])
+    list_top_feat = [list_feat.pop(0)]
+    for feat in list_feat:
+        add_flag = True
+        for top_feat in list_top_feat:
+            if not check_cat or dict_c[feat] == dict_c[top_feat]:
+                pos, top_pos = dict_p[feat], dict_p[top_feat]
+                overlap = len(top_pos.intersection(pos)) / len(top_pos.union(pos))
+                if overlap >= max_overlap or pos.issubset(top_pos):
+                    scale = ut.split_feat_id(feat_id=feat)[2]
+                    top_scale = ut.split_feat_id(feat_id=top_feat)[2]
+                    if scale in df_cor.columns and top_scale in df_cor.columns:
+                        if abs(float(df_cor[top_scale][scale])) > max_cor:
+                            add_flag = False
+        if add_flag:
+            list_top_feat.append(feat)
+    return df[df[ut.COL_FEATURE].isin(list_top_feat)].reset_index(drop=True)
+
+
+def _build_df_candidates_(records=None):
+    """Tidy long-form report of every candidate considered (one row per candidate)."""
+    cols = [
+        "feature",
+        "candidate_scale",
+        "interpretability_orig",
+        "interpretability_cand",
+        "cor",
+        "std_test",
+        "accepted",
+        "cv_score",
+        "reason",
+    ]
+    return pd.DataFrame(records, columns=cols)
+
+
+# II Main Functions
+def _greedy_simplify_(
+    df_feat=None,
+    df_parts=None,
+    df_scales_self=None,
+    labels=None,
+    X=None,
+    df_cor=None,
+    dict_all_scales=None,
+    dict_interp=None,
+    dict_meta=None,
+    max_interpretability=None,
+    top_n=None,
+    min_cor=0.7,
+    metric="balanced_accuracy",
+    tol=0.0,
+    n_cv=5,
+    on_unimprovable=ut.ON_UNIMPROVABLE_KEEP,
+    label_test=1,
+    label_ref=0,
+    parametric=False,
+    accept_gaps=False,
+    max_std_test=0.2,
+    random_state=None,
+):
+    """Per-feature swap with an RF+CV non-regression gate. Returns
+    ``(df_feat_new, X_kept, records, baseline)``."""
+    n = len(df_feat)
+    baseline = _score_feature_set_(
+        X=X, labels=labels, n_cv=n_cv, metric=metric, random_state=random_state
+    )
+    targets = _select_targets_(
+        df_feat=df_feat,
+        dict_interp=dict_interp,
+        max_interpretability=max_interpretability,
+        top_n=top_n,
+    )
+    new_rows = {}  # row_index -> recomputed one-row df (accepted swaps)
+    dropped = set()  # row_index dropped via on_unimprovable
+    records = []
+    for i, feat_id, interp_old in targets:
+        positions = df_feat.iloc[i][ut.COL_POSITION]
+        cands = _eligible_candidates_(
+            feat_id=feat_id, df_cor=df_cor, dict_interp=dict_interp, min_cor=min_cor
+        )
+        accepted = False
+        for scale_cand, interp_cand, abs_cor, cor in cands:
+            row_df, col = _recompute_swapped_row_(
+                feat_id=feat_id,
+                scale_new=scale_cand,
+                df_parts=df_parts,
+                dict_all_scales=dict_all_scales,
+                dict_meta=dict_meta,
+                labels=labels,
+                label_test=label_test,
+                label_ref=label_ref,
+                parametric=parametric,
+                accept_gaps=accept_gaps,
+                positions=positions,
+            )
+            std_test = float(row_df[ut.COL_STD_TEST].iloc[0])
+            if std_test > max_std_test:
+                records.append(
+                    [
+                        feat_id,
+                        scale_cand,
+                        interp_old,
+                        interp_cand,
+                        cor,
+                        std_test,
+                        False,
+                        np.nan,
+                        "max_std_test",
+                    ]
+                )
+                continue
+            X_trial = X.copy()
+            X_trial[:, i] = col
+            score = _score_feature_set_(
+                X=X_trial,
+                labels=labels,
+                n_cv=n_cv,
+                metric=metric,
+                random_state=random_state,
+            )
+            if score >= baseline - tol:
+                X[:, i] = col
+                new_rows[i] = row_df
+                baseline = score
+                accepted = True
+                records.append(
+                    [
+                        feat_id,
+                        scale_cand,
+                        interp_old,
+                        interp_cand,
+                        cor,
+                        std_test,
+                        True,
+                        score,
+                        "accepted",
+                    ]
+                )
+                break
+            records.append(
+                [
+                    feat_id,
+                    scale_cand,
+                    interp_old,
+                    interp_cand,
+                    cor,
+                    std_test,
+                    False,
+                    score,
+                    "cv_drop",
+                ]
+            )
+        if not accepted and on_unimprovable != ut.ON_UNIMPROVABLE_KEEP:
+            n_kept = n - len(dropped)
+            if n_kept > 1:  # never drop the last feature
+                if on_unimprovable == ut.ON_UNIMPROVABLE_DROP:
+                    dropped.add(i)
+                elif on_unimprovable == ut.ON_UNIMPROVABLE_DROP_IF_PERF:
+                    keep_idx = [j for j in range(n) if j not in dropped and j != i]
+                    score_drop = _score_feature_set_(
+                        X=X[:, keep_idx],
+                        labels=labels,
+                        n_cv=n_cv,
+                        metric=metric,
+                        random_state=random_state,
+                    )
+                    if score_drop >= baseline - tol:
+                        dropped.add(i)
+                        baseline = score_drop
+    # Assemble simplified df_feat (swapped rows replace originals; drop unimprovable)
+    keep_idx = [i for i in range(n) if i not in dropped]
+    rows = [new_rows[i] if i in new_rows else df_feat.iloc[[i]] for i in keep_idx]
+    df_feat_new = pd.concat(rows, ignore_index=True)
+    X_kept = X[:, keep_idx]
+    return df_feat_new, X_kept, records, baseline
+
+
+def simplify_cpp_(
+    df_feat=None,
+    df_parts=None,
+    df_scales_self=None,
+    labels=None,
+    X=None,
+    strategy=ut.STRATEGY_GREEDY,
+    max_interpretability=None,
+    top_n=None,
+    min_cor=0.7,
+    metric="balanced_accuracy",
+    tol=0.0,
+    n_cv=5,
+    on_unimprovable=ut.ON_UNIMPROVABLE_KEEP,
+    redundancy_tie_break=ut.TIE_BREAK_INTERPRETABILITY,
+    label_test=1,
+    label_ref=0,
+    max_std_test=0.2,
+    max_cor=0.5,
+    max_overlap=0.5,
+    check_cat=True,
+    parametric=False,
+    accept_gaps=False,
+    return_details=False,
+    random_state=None,
+):
+    """Backend entry for ``CPP.simplify``: df_feat or (df_feat, df_candidates)."""
+    df_feat = df_feat.reset_index(drop=True).copy()
+    df_scales_pool, df_cor, dict_all_scales, dict_interp, dict_meta = (
+        _load_candidate_pool_()
+    )
+    # Skip-and-return when nothing is rated (e.g. a pure run_num / custom df_feat).
+    targets = _select_targets_(
+        df_feat=df_feat,
+        dict_interp=dict_interp,
+        max_interpretability=max_interpretability,
+        top_n=top_n,
+    )
+    if len(targets) == 0:
+        warnings.warn(
+            "'df_feat' has no AAontology-rated features to simplify (scales are "
+            "unrated / from 'run_num'); returning it unchanged.",
+            RuntimeWarning,
+        )
+        out = ut.sort_cols_feat(df_feat=df_feat)
+        return (out, _build_df_candidates_(records=[])) if return_details else out
+    if X is None:
+        X = _build_base_matrix_(
+            df_feat=df_feat,
+            df_parts=df_parts,
+            df_scales_self=df_scales_self,
+            accept_gaps=accept_gaps,
+        )
+    else:
+        X = np.asarray(X, dtype=float).copy()
+
+    if strategy == ut.STRATEGY_GREEDY:
+        df_feat_new, X_kept, records, _ = _greedy_simplify_(
+            df_feat=df_feat,
+            df_parts=df_parts,
+            df_scales_self=df_scales_self,
+            labels=labels,
+            X=X,
+            df_cor=df_cor,
+            dict_all_scales=dict_all_scales,
+            dict_interp=dict_interp,
+            dict_meta=dict_meta,
+            max_interpretability=max_interpretability,
+            top_n=top_n,
+            min_cor=min_cor,
+            metric=metric,
+            tol=tol,
+            n_cv=n_cv,
+            on_unimprovable=on_unimprovable,
+            label_test=label_test,
+            label_ref=label_ref,
+            parametric=parametric,
+            accept_gaps=accept_gaps,
+            max_std_test=max_std_test,
+            random_state=random_state,
+        )
+    else:
+        raise NotImplementedError(
+            f"'strategy' ('{strategy}') is staged for a future release; only "
+            f"'{ut.STRATEGY_GREEDY}' is implemented."
+        )
+
+    # Set-level redundancy reduction ("fewer subcats").
+    df_cor_present = _merged_scale_corr_(
+        df_feat=df_feat_new,
+        df_scales_pool=df_scales_pool,
+        df_scales_self=df_scales_self,
+    )
+    df_feat_new = _apply_redundancy_(
+        df_feat=df_feat_new,
+        df_cor=df_cor_present,
+        dict_interp=dict_interp,
+        max_overlap=max_overlap,
+        max_cor=max_cor,
+        check_cat=check_cat,
+        tie_break=redundancy_tie_break,
+    )
+    df_feat_new = ut.sort_cols_feat(df_feat=df_feat_new)
+    if return_details:
+        return df_feat_new, _build_df_candidates_(records=records)
+    return df_feat_new

--- a/aaanalysis/feature_engineering/_cpp.py
+++ b/aaanalysis/feature_engineering/_cpp.py
@@ -16,13 +16,14 @@ from ._backend.cpp.utils_feature import get_df_parts_
 from ._backend.check_feature import (check_split_kws,
                                      check_parts_len, check_match_df_parts_split_kws,
                                      check_df_scales, check_df_cat, check_match_df_parts_df_scales,
-                                     check_match_df_scales_df_cat)
+                                     check_match_df_scales_df_cat, check_match_df_parts_features)
 from ._backend.cpp_run import (
     cpp_run_single, cpp_run_batch, cpp_run_batch_num, cpp_run_sample_batched,
     _pick_feature_matrix_builder,
 )
 from ._backend.cpp._filters._get_feature_matrix_fast import AALookupCache
 from ._backend.cpp.cpp_eval import evaluate_features
+from ._backend.cpp._simplify import simplify_cpp_
 
 
 # I Helper Functions
@@ -71,6 +72,24 @@ def check_match_list_df_feat_list_df_parts(list_df_feat=None, list_df_parts=None
     """Check if all elements in list are valid feature DataFrames"""
     for df_feat, df_parts in zip(list_df_feat, list_df_parts):
         ut.check_df_feat(df_feat=df_feat, list_parts=list(df_parts))
+
+
+def check_match_max_interpretability_top_n(max_interpretability=None, top_n=None):
+    """``simplify`` target selectors are mutually exclusive (at most one set)."""
+    if max_interpretability is not None and top_n is not None:
+        raise ValueError(
+            f"'max_interpretability' ({max_interpretability}) and 'top_n' ({top_n}) are "
+            f"mutually exclusive target selectors; set at most one (or neither to attempt "
+            f"every improvable feature).")
+
+
+def check_n_cv_labels(n_cv=None, labels=None):
+    """Validate ``n_cv`` (>=2, <= smallest class count) for the simplify RF+CV gate."""
+    ut.check_number_range(name="n_cv", val=n_cv, min_val=2, just_int=True)
+    min_class_count = min(pd.Series(labels).value_counts())
+    if n_cv > min_class_count:
+        raise ValueError(f"'n_cv' ({n_cv}) should not be greater than the smallest class "
+                         f"count ({min_class_count}).")
 
 
 def check_match_list_df_feat_names_feature_sets(list_df_feat=None, names_feature_sets=None):
@@ -870,3 +889,157 @@ class CPP(Tool):
                                     n_jobs=n_jobs,
                                     random_state=self._random_state)
         return df_eval
+
+    def simplify(self,
+                 df_feat: pd.DataFrame = None,
+                 labels: ut.ArrayLike1D = None,
+                 X: Optional[ut.ArrayLike2D] = None,
+                 strategy: str = "greedy",
+                 max_interpretability: Optional[int] = None,
+                 top_n: Optional[int] = None,
+                 min_cor: float = 0.7,
+                 metric: str = "balanced_accuracy",
+                 tol: float = 0.0,
+                 n_cv: int = 5,
+                 on_unimprovable: str = "keep",
+                 redundancy_tie_break: str = "interpretability",
+                 label_test: int = 1,
+                 label_ref: int = 0,
+                 max_std_test: float = 0.2,
+                 max_cor: float = 0.5,
+                 max_overlap: float = 0.5,
+                 check_cat: bool = True,
+                 return_details: bool = False,
+                 random_state: Optional[int] = None,
+                 ) -> Union[pd.DataFrame, Tuple[pd.DataFrame, pd.DataFrame]]:
+        """
+        Simplify a feature set by swapping scales for more interpretable correlated ones.
+
+        For each feature (``PART-SPLIT-SCALE``), an alternative scale from a **more
+        interpretable AAontology subcategory** (interpretability rating 1-10, 1 = best;
+        see :func:`load_scales` ``top_explain_n`` and ADR-0025) that **correlates** with the
+        original scale is substituted, keeping ``PART-SPLIT``. The swapped feature's statistics
+        are recomputed; a swap is accepted only if it passes CPP's per-feature filtering
+        (``max_std_test``) and a random-forest cross-validation gate (performance not worse than
+        the current set, within ``tol``). The swapped set is then redundancy-reduced, yielding a
+        more interpretable and ideally smaller ``df_feat``. The candidate pool (the full rated
+        AAontology scale set) is loaded internally.
+
+        Parameters
+        ----------
+        df_feat : pd.DataFrame, shape (n_features, n_feature_info)
+            Feature DataFrame from :meth:`run` (the standardized CPP output schema).
+        labels : array-like, shape (n_samples,)
+            Class labels for samples in sequence DataFrame (typically, test=1, reference=0).
+        X : array-like, shape (n_samples, n_features), optional
+            Feature matrix matching ``df_feat`` (baseline only; row-aligned to ``self.df_parts``).
+            If ``None``, it is recomputed internally. Swapped columns are always recomputed.
+        strategy : str, default='greedy'
+            Simplification strategy. ``'greedy'`` swaps feature-by-feature behind the RF+CV gate.
+            (``'consolidate'`` / ``'swap_all'`` are reserved for a future release.)
+        max_interpretability : int, optional
+            Interpretability ceiling (1-10): every feature whose scale subcategory is rated
+            worse (higher) than this is targeted for replacement. Mutually exclusive with ``top_n``.
+        top_n : int, optional
+            Target the ``top_n`` worst-interpretability features. Mutually exclusive with
+            ``max_interpretability``. If both are ``None``, every improvable feature is attempted.
+        min_cor : float, default=0.7
+            Minimum absolute Pearson correlation between a candidate scale and the original scale
+            (between 0 and 1); anti-correlation is allowed via the absolute value.
+        metric : str, default='balanced_accuracy'
+            Scoring metric for the RF+CV gate (any scikit-learn classification scorer name).
+        tol : float, default=0.0
+            A swap is accepted if its CV score is at least ``baseline - tol`` (>=0).
+        n_cv : int, default=5
+            Number of cross-validation folds (>=2, <= smallest class count).
+        on_unimprovable : str, default='keep'
+            What to do with a targeted feature that cannot be improved: ``'keep'`` (retain the
+            original), ``'drop'`` (remove it), or ``'drop_if_perf_allows'`` (remove only if the
+            CV score does not drop). The last feature is never dropped.
+        redundancy_tie_break : str, default='interpretability'
+            When two swapped features are redundant, keep the ``'interpretability'``-best (then
+            ``abs_auc``) or the ``'performance'``-best (``abs_auc``).
+        label_test : int, default=1
+            Class label of the test group in ``labels``.
+        label_ref : int, default=0
+            Class label of the reference group in ``labels``.
+        max_std_test : float, default=0.2
+            Per-feature pre-filter threshold a swapped feature must satisfy (between 0 and 1).
+        max_cor : float, default=0.5
+            Redundancy correlation threshold for the post-swap reduction (between 0 and 1).
+        max_overlap : float, default=0.5
+            Redundancy position-overlap threshold for the post-swap reduction (between 0 and 1).
+        check_cat : bool, default=True
+            Whether the redundancy reduction only compares features within the same scale category.
+        return_details : bool, default=False
+            If ``True``, also return a long-form ``df_candidates`` reporting every candidate
+            considered (scale, interpretability, correlation, recomputed std, accepted-flag).
+        random_state : int, optional
+            Random state for the random forest. Overrides the constructor's ``random_state``.
+
+        Returns
+        -------
+        df_feat : pd.DataFrame
+            The simplified feature DataFrame (CPP output schema), with swapped scales, recomputed
+            statistics, and redundant features removed.
+        df_candidates : pd.DataFrame
+            Returned only if ``return_details=True``: one row per candidate considered.
+
+        Notes
+        -----
+        * Features whose scale is **not a rated AAontology scale** (e.g. ``run_num`` pseudo-scales
+          or unclassified scales) carry no interpretability rating and are skipped. If no feature
+          is rated, ``df_feat`` is returned unchanged with a ``RuntimeWarning``.
+        * An anti-correlated swap flips the sign of ``mean_dif`` (the feature still discriminates);
+          the correlation sign is reported in ``df_candidates``.
+
+        See Also
+        --------
+        * :meth:`run` for the feature DataFrame produced and its schema.
+        * :func:`load_scales` for the interpretability-tiered explainable scale sets (``top_explain_n``).
+
+        Examples
+        --------
+        .. include:: examples/cpp_simplify.rst
+        """
+        # Check input
+        df_feat = ut.check_df_feat(df_feat=df_feat, list_parts=list(self.df_parts))
+        ut.check_number_val(name="label_test", val=label_test, just_int=True)
+        ut.check_number_val(name="label_ref", val=label_ref, just_int=True)
+        labels = ut.check_labels(labels=labels, vals_required=[label_test, label_ref],
+                                 len_required=len(self.df_parts), allow_other_vals=False)
+        check_match_df_parts_features(df_parts=self.df_parts, features=list(df_feat[ut.COL_FEATURE]))
+        ut.check_str_options(name="strategy", val=strategy, list_str_options=ut.LIST_SIMPLIFY_STRATEGIES)
+        ut.check_str_options(name="on_unimprovable", val=on_unimprovable,
+                             list_str_options=ut.LIST_ON_UNIMPROVABLE)
+        ut.check_str_options(name="redundancy_tie_break", val=redundancy_tie_break,
+                             list_str_options=ut.LIST_REDUNDANCY_TIE_BREAK)
+        ut.check_str(name="metric", val=metric)
+        ut.check_number_range(name="min_cor", val=min_cor, min_val=0, max_val=1, just_int=False)
+        ut.check_number_range(name="max_std_test", val=max_std_test, min_val=0, max_val=1, just_int=False)
+        ut.check_number_range(name="max_cor", val=max_cor, min_val=0, max_val=1, just_int=False)
+        ut.check_number_range(name="max_overlap", val=max_overlap, min_val=0, max_val=1, just_int=False)
+        ut.check_number_val(name="tol", val=tol, just_int=False)
+        ut.check_number_range(name="max_interpretability", val=max_interpretability, min_val=1,
+                              max_val=10, just_int=True, accept_none=True)
+        ut.check_number_range(name="top_n", val=top_n, min_val=1, just_int=True, accept_none=True)
+        ut.check_bool(name="check_cat", val=check_cat)
+        ut.check_bool(name="return_details", val=return_details)
+        check_match_max_interpretability_top_n(max_interpretability=max_interpretability, top_n=top_n)
+        check_n_cv_labels(n_cv=n_cv, labels=labels)
+        if X is not None:
+            X = ut.check_X(X=X, min_n_features=1)
+        random_state = self._random_state if random_state is None else random_state
+        random_state = ut.check_random_state(random_state=random_state)
+        # The recomputed p-value column must match the input df_feat's test choice.
+        parametric = ut.COL_PVAL_TTEST in list(df_feat)
+        _warn_gaps_encountered(df_parts=self.df_parts, accept_gaps=self._accept_gaps)
+        return simplify_cpp_(df_feat=df_feat, df_parts=self.df_parts, df_scales_self=self.df_scales,
+                             labels=labels, X=X, strategy=strategy,
+                             max_interpretability=max_interpretability, top_n=top_n, min_cor=min_cor,
+                             metric=metric, tol=tol, n_cv=n_cv, on_unimprovable=on_unimprovable,
+                             redundancy_tie_break=redundancy_tie_break, label_test=label_test,
+                             label_ref=label_ref, max_std_test=max_std_test, max_cor=max_cor,
+                             max_overlap=max_overlap, check_cat=check_cat, parametric=parametric,
+                             accept_gaps=self._accept_gaps, return_details=return_details,
+                             random_state=random_state)

--- a/aaanalysis/feature_engineering/_cpp.py
+++ b/aaanalysis/feature_engineering/_cpp.py
@@ -84,12 +84,22 @@ def check_match_max_interpretability_top_n(max_interpretability=None, top_n=None
 
 
 def check_n_cv_labels(n_cv=None, labels=None):
-    """Validate ``n_cv`` (>=2, <= smallest class count) for the simplify RF+CV gate."""
+    """Validate ``n_cv`` (>=2, <= smallest class count) for the simplify CV gate."""
     ut.check_number_range(name="n_cv", val=n_cv, min_val=2, just_int=True)
     min_class_count = min(pd.Series(labels).value_counts())
     if n_cv > min_class_count:
         raise ValueError(f"'n_cv' ({n_cv}) should not be greater than the smallest class "
                          f"count ({min_class_count}).")
+
+
+def check_ml_model(ml_model=None):
+    """Validate the simplify CV-gate model: a string preset or a classifier instance."""
+    if isinstance(ml_model, str):
+        ut.check_str_options(name="ml_model", val=ml_model,
+                             list_str_options=ut.LIST_CV_MODELS)
+    elif not (hasattr(ml_model, "fit") and hasattr(ml_model, "predict")):
+        raise ValueError(f"'ml_model' ({ml_model}) should be one of {ut.LIST_CV_MODELS} "
+                         f"or a scikit-learn classifier with 'fit'/'predict' methods.")
 
 
 def check_match_list_df_feat_names_feature_sets(list_df_feat=None, names_feature_sets=None):
@@ -898,6 +908,7 @@ class CPP(Tool):
                  max_interpretability: Optional[int] = None,
                  top_n: Optional[int] = None,
                  min_cor: float = 0.7,
+                 ml_model: Union[str, object] = "svm",
                  metric: str = "balanced_accuracy",
                  tol: float = 0.0,
                  n_cv: int = 5,
@@ -917,11 +928,11 @@ class CPP(Tool):
 
         For each feature (``PART-SPLIT-SCALE``), an alternative scale from a **more
         interpretable AAontology subcategory** (interpretability rating 1-10, 1 = best;
-        see :func:`load_scales` ``top_explain_n`` and ADR-0025) that **correlates** with the
+        see :func:`load_scales` ``top_explain_n``) that **correlates** with the
         original scale is substituted, keeping ``PART-SPLIT``. The swapped feature's statistics
         are recomputed; a swap is accepted only if it passes CPP's per-feature filtering
-        (``max_std_test``) and a random-forest cross-validation gate (performance not worse than
-        the current set, within ``tol``). The swapped set is then redundancy-reduced, yielding a
+        (``max_std_test``) and a cross-validation gate (performance not worse than the current
+        set, within ``tol``). The swapped set is then redundancy-reduced, yielding a
         more interpretable and ideally smaller ``df_feat``. The candidate pool (the full rated
         AAontology scale set) is loaded internally.
 
@@ -935,8 +946,8 @@ class CPP(Tool):
             Feature matrix matching ``df_feat`` (baseline only; row-aligned to ``self.df_parts``).
             If ``None``, it is recomputed internally. Swapped columns are always recomputed.
         strategy : str, default='greedy'
-            Simplification strategy. ``'greedy'`` swaps feature-by-feature behind the RF+CV gate.
-            (``'consolidate'`` / ``'swap_all'`` are reserved for a future release.)
+            Simplification strategy: ``'greedy'``, ``'consolidate'``, or ``'swap_all'``
+            (see Notes for how each behaves).
         max_interpretability : int, optional
             Interpretability ceiling (1-10): every feature whose scale subcategory is rated
             worse (higher) than this is targeted for replacement. Mutually exclusive with ``top_n``.
@@ -946,8 +957,13 @@ class CPP(Tool):
         min_cor : float, default=0.7
             Minimum absolute Pearson correlation between a candidate scale and the original scale
             (between 0 and 1); anti-correlation is allowed via the absolute value.
+        ml_model : str or sklearn estimator, default='svm'
+            Model for the cross-validation gate (``'greedy'`` / ``'consolidate'``). A string
+            preset ``'svm'`` (default; fast), ``'rf'`` (recommended for non-linear feature
+            relationships, but slower), or ``'log_reg'`` (fastest); or any configured scikit-learn
+            classifier instance (e.g. ``SVC(kernel='poly', C=0.1)``), used as-is.
         metric : str, default='balanced_accuracy'
-            Scoring metric for the RF+CV gate (any scikit-learn classification scorer name).
+            Scoring metric for the CV gate (any scikit-learn classification scorer name).
         tol : float, default=0.0
             A swap is accepted if its CV score is at least ``baseline - tol`` (>=0).
         n_cv : int, default=5
@@ -975,7 +991,8 @@ class CPP(Tool):
             If ``True``, also return a long-form ``df_candidates`` reporting every candidate
             considered (scale, interpretability, correlation, recomputed std, accepted-flag).
         random_state : int, optional
-            Random state for the random forest. Overrides the constructor's ``random_state``.
+            Random state for the CV-gate model (preset estimators). Overrides the constructor's
+            ``random_state``.
 
         Returns
         -------
@@ -987,6 +1004,19 @@ class CPP(Tool):
 
         Notes
         -----
+        * The ``strategy`` controls how swaps are chosen and validated:
+
+          - **'greedy'**: per-feature. Each targeted feature is swapped to its best correlated
+            candidate that keeps the cross-validation score within ``tol`` of the current set;
+            otherwise the next candidate is tried. Each swap is individually justified.
+          - **'consolidate'**: set-level. Interpretable subcategories are taken best-first, and
+            every targeted feature that can move into the current subcategory is swapped as one
+            batch, which is kept only if the set CV score stays within ``tol``. Funnels features
+            into the fewest subcategories.
+          - **'swap_all'**: apply every eligible best-candidate swap with no cross-validation
+            (fastest); ``ml_model`` / ``metric`` / ``tol`` / ``n_cv`` are ignored. A pure
+            interpretability transform to evaluate yourself afterwards.
+
         * Features whose scale is **not a rated AAontology scale** (e.g. ``run_num`` pseudo-scales
           or unclassified scales) carry no interpretability rating and are skipped. If no feature
           is rated, ``df_feat`` is returned unchanged with a ``RuntimeWarning``.
@@ -1015,6 +1045,7 @@ class CPP(Tool):
         ut.check_str_options(name="redundancy_tie_break", val=redundancy_tie_break,
                              list_str_options=ut.LIST_REDUNDANCY_TIE_BREAK)
         ut.check_str(name="metric", val=metric)
+        check_ml_model(ml_model=ml_model)
         ut.check_number_range(name="min_cor", val=min_cor, min_val=0, max_val=1, just_int=False)
         ut.check_number_range(name="max_std_test", val=max_std_test, min_val=0, max_val=1, just_int=False)
         ut.check_number_range(name="max_cor", val=max_cor, min_val=0, max_val=1, just_int=False)
@@ -1042,4 +1073,4 @@ class CPP(Tool):
                              label_ref=label_ref, max_std_test=max_std_test, max_cor=max_cor,
                              max_overlap=max_overlap, check_cat=check_cat, parametric=parametric,
                              accept_gaps=self._accept_gaps, return_details=return_details,
-                             random_state=random_state)
+                             ml_model=ml_model, random_state=random_state)

--- a/aaanalysis/utils.py
+++ b/aaanalysis/utils.py
@@ -326,6 +326,19 @@ STRATEGY_TOP_K = "top_k"
 STRATEGY_THRESHOLD = "threshold"
 STRATEGY_FREQUENCY = "frequency"
 LIST_SELECTION_STRATEGIES = [STRATEGY_TOP_K, STRATEGY_THRESHOLD, STRATEGY_FREQUENCY]
+
+# CPP.simplify — interpretability-guided scale swapping
+STRATEGY_GREEDY = "greedy"            # per-feature swap, RF+CV non-regression gate
+STRATEGY_CONSOLIDATE = "consolidate"  # set-level consolidation (staged)
+STRATEGY_SWAP_ALL = "swap_all"        # swap-all then one CV comparison (staged)
+LIST_SIMPLIFY_STRATEGIES = [STRATEGY_GREEDY, STRATEGY_CONSOLIDATE, STRATEGY_SWAP_ALL]
+ON_UNIMPROVABLE_KEEP = "keep"
+ON_UNIMPROVABLE_DROP = "drop"
+ON_UNIMPROVABLE_DROP_IF_PERF = "drop_if_perf_allows"
+LIST_ON_UNIMPROVABLE = [ON_UNIMPROVABLE_KEEP, ON_UNIMPROVABLE_DROP, ON_UNIMPROVABLE_DROP_IF_PERF]
+TIE_BREAK_INTERPRETABILITY = "interpretability"
+TIE_BREAK_PERFORMANCE = "performance"
+LIST_REDUNDANCY_TIE_BREAK = [TIE_BREAK_INTERPRETABILITY, TIE_BREAK_PERFORMANCE]
 DICT_VALUE_TYPE = {COL_ABS_AUC: "mean",
                    COL_ABS_MEAN_DIF: "mean",
                    COL_MEAN_DIF: "mean",

--- a/aaanalysis/utils.py
+++ b/aaanalysis/utils.py
@@ -339,6 +339,12 @@ LIST_ON_UNIMPROVABLE = [ON_UNIMPROVABLE_KEEP, ON_UNIMPROVABLE_DROP, ON_UNIMPROVA
 TIE_BREAK_INTERPRETABILITY = "interpretability"
 TIE_BREAK_PERFORMANCE = "performance"
 LIST_REDUNDANCY_TIE_BREAK = [TIE_BREAK_INTERPRETABILITY, TIE_BREAK_PERFORMANCE]
+# CPP.simplify — cross-validation-gate model presets (SVM default; also accepts a
+# custom sklearn estimator instance).
+MODEL_SVM = "svm"
+MODEL_RF = "rf"
+MODEL_LOG_REG = "log_reg"
+LIST_CV_MODELS = [MODEL_SVM, MODEL_RF, MODEL_LOG_REG]
 DICT_VALUE_TYPE = {COL_ABS_AUC: "mean",
                    COL_ABS_MEAN_DIF: "mean",
                    COL_MEAN_DIF: "mean",

--- a/docs/source/index/docstring_guide.rst
+++ b/docs/source/index/docstring_guide.rst
@@ -220,6 +220,12 @@ Citations
   exists, never a bare repo URL) **and** describe what the tool does in **one
   plain sentence**. Example: ``'chainsaw' ([Wells24]_): a fully-convolutional
   neural network that predicts domain boundaries from a PDB / CIF structure.``
+* **Never reference internal decision records (ADRs) in docstrings.** ADRs
+  (``docs/adr/``) are internal to the development process; docstrings are
+  user-facing. If an ADR documents a user-visible choice (why a parameter exists,
+  how an algorithm was selected), extract the *why* as plain language in the
+  docstring — never cite the ADR number. (Developer-facing notes such as
+  ``CONTEXT.md`` may cite ADRs; user docstrings may not.)
 
 Versioning & deprecation
 ------------------------

--- a/examples/feature_engineering/cpp_simplify.ipynb
+++ b/examples/feature_engineering/cpp_simplify.ipynb
@@ -1,0 +1,72 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To demonstrate the ``CPP().simplify()`` method, we load the ``DOM_GSEC`` example dataset (see [Breimann25a]_) and obtain a feature set with ``CPP().run()`` using an interpretability-tiered scale set:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aaanalysis as aa\n",
+    "aa.options[\"verbose\"] = False\n",
+    "df_seq = aa.load_dataset(name=\"DOM_GSEC\", n=25)\n",
+    "labels = df_seq[\"label\"].to_list()\n",
+    "sf = aa.SequenceFeature()\n",
+    "df_parts = sf.get_df_parts(df_seq=df_seq)\n",
+    "df_scales = aa.load_scales(top_explain_n=20)\n",
+    "cpp = aa.CPP(df_parts=df_parts, df_scales=df_scales)\n",
+    "df_feat = cpp.run(labels=labels, n_filter=15)\n",
+    "aa.display_df(df_feat, n_rows=5, show_shape=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "``CPP().simplify()`` rewrites the feature set, swapping each scale for a more interpretable, correlated scale from a better-rated AAontology subcategory. A swap is accepted only if it keeps passing CPP filtering and does not reduce random-forest cross-validation performance, and the result is redundancy-reduced:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_feat_simple = cpp.simplify(df_feat=df_feat, labels=labels, top_n=10, random_state=0)\n",
+    "aa.display_df(df_feat_simple, n_rows=5, show_shape=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use ``return_details=True`` to inspect every candidate scale considered (its interpretability rating, correlation with the original scale, and whether it was accepted):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "df_feat_simple, df_candidates = cpp.simplify(df_feat=df_feat, labels=labels, top_n=10,\n                                             return_details=True, random_state=0)\naa.display_df(df_candidates, show_shape=True)"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/unit/cpp_tests/test_cpp_simplify.py
+++ b/tests/unit/cpp_tests/test_cpp_simplify.py
@@ -1,21 +1,26 @@
 """This is a script to test the CPP.simplify() method: interpretability-guided
-scale swapping (issue: new simplify feature).
+scale swapping with three strategies (greedy / consolidate / swap_all) and a
+configurable cross-validation-gate model (ml_model).
 
-simplify swaps each feature's scale for a more interpretable correlated scale
-(keeping PART-SPLIT), recomputes its stats, accepts a swap only behind CPP
-filtering + a random-forest cross-validation gate, then redundancy-reduces the
-set. The RF+CV gate makes the call non-trivial, so fixtures are kept small and
-shared module-wide.
+The CV gate makes the call non-trivial, so fixtures are kept small and shared
+module-wide. Positive cases use hypothesis property-based testing (the house
+standard); negative cases pin the tailored validation errors.
 """
 
 import warnings
 
 import pandas as pd
 import pytest
-from hypothesis import settings
+from hypothesis import given, settings
+import hypothesis.strategies as some
+from sklearn.svm import SVC
 
 import aaanalysis as aa
 import aaanalysis.utils as ut
+from aaanalysis.feature_engineering._backend.cpp._simplify import (
+    _build_base_matrix_,
+    _merged_scale_corr_,
+)
 
 settings.register_profile("ci", deadline=None)
 settings.load_profile("ci")
@@ -34,8 +39,9 @@ def fitted():
             n_split_min=1, n_split_max=2, split_types=["Segment"]
         )
         df_scales = aa.load_scales(top_explain_n=20)
-        cpp = aa.CPP(df_parts=df_parts, df_scales=df_scales, split_kws=split_kws,
-                     verbose=False)
+        cpp = aa.CPP(
+            df_parts=df_parts, df_scales=df_scales, split_kws=split_kws, verbose=False
+        )
         df_feat = cpp.run(labels=labels, n_filter=10)
     return cpp, df_feat, labels
 
@@ -49,98 +55,101 @@ def _simplify(cpp, df_feat, labels, **kwargs):
 
 
 class TestSimplify:
-    """Normal cases — one parameter per test."""
+    """Normal cases — one parameter per test, explored with hypothesis."""
 
-    def test_default_returns_df_feat(self, fitted):
+    @settings(max_examples=5, deadline=None)
+    @given(top_n=some.integers(min_value=1, max_value=6))
+    def test_top_n(self, fitted, top_n):
         cpp, df_feat, labels = fitted
-        out = _simplify(cpp, df_feat, labels)
-        assert isinstance(out, pd.DataFrame) and len(out) >= 1
+        out = _simplify(cpp, df_feat, labels, top_n=top_n)
+        assert isinstance(out, pd.DataFrame) and 1 <= len(out) <= len(df_feat)
+
+    @settings(max_examples=5, deadline=None)
+    @given(max_interpretability=some.integers(min_value=1, max_value=10))
+    def test_max_interpretability(self, fitted, max_interpretability):
+        cpp, df_feat, labels = fitted
+        out = _simplify(cpp, df_feat, labels, max_interpretability=max_interpretability)
+        assert isinstance(out, pd.DataFrame)
+
+    @settings(max_examples=5, deadline=None)
+    @given(min_cor=some.floats(min_value=0.5, max_value=1.0))
+    def test_min_cor(self, fitted, min_cor):
+        cpp, df_feat, labels = fitted
+        out = _simplify(cpp, df_feat, labels, top_n=3, min_cor=min_cor)
+        assert isinstance(out, pd.DataFrame)
+
+    @settings(max_examples=5, deadline=None)
+    @given(tol=some.floats(min_value=0.0, max_value=0.2))
+    def test_tol(self, fitted, tol):
+        cpp, df_feat, labels = fitted
+        out = _simplify(cpp, df_feat, labels, top_n=3, tol=tol)
+        assert isinstance(out, pd.DataFrame)
+
+    @settings(max_examples=3, deadline=None)
+    @given(n_cv=some.integers(min_value=2, max_value=4))
+    def test_n_cv(self, fitted, n_cv):
+        cpp, df_feat, labels = fitted
+        out = _simplify(cpp, df_feat, labels, top_n=2, n_cv=n_cv)
+        assert isinstance(out, pd.DataFrame)
+
+    @settings(max_examples=3, deadline=None)
+    @given(strategy=some.sampled_from(["greedy", "consolidate", "swap_all"]))
+    def test_strategy(self, fitted, strategy):
+        cpp, df_feat, labels = fitted
+        out = _simplify(cpp, df_feat, labels, top_n=5, strategy=strategy)
+        assert list(out.columns) == list(ut.LIST_COLS_FEAT) and 1 <= len(out) <= len(
+            df_feat
+        )
+
+    @settings(max_examples=3, deadline=None)
+    @given(ml_model=some.sampled_from(["svm", "rf", "log_reg"]))
+    def test_ml_model_presets(self, fitted, ml_model):
+        cpp, df_feat, labels = fitted
+        out = _simplify(cpp, df_feat, labels, top_n=3, ml_model=ml_model)
+        assert isinstance(out, pd.DataFrame)
+
+    @settings(max_examples=3, deadline=None)
+    @given(metric=some.sampled_from(["balanced_accuracy", "accuracy", "f1"]))
+    def test_metric(self, fitted, metric):
+        cpp, df_feat, labels = fitted
+        out = _simplify(cpp, df_feat, labels, top_n=2, metric=metric)
+        assert isinstance(out, pd.DataFrame)
+
+    @settings(max_examples=3, deadline=None)
+    @given(on_unimprovable=some.sampled_from(["keep", "drop", "drop_if_perf_allows"]))
+    def test_on_unimprovable(self, fitted, on_unimprovable):
+        cpp, df_feat, labels = fitted
+        out = _simplify(cpp, df_feat, labels, top_n=3, on_unimprovable=on_unimprovable)
+        assert 1 <= len(out) <= len(df_feat)
+
+    @settings(max_examples=2, deadline=None)
+    @given(redundancy_tie_break=some.sampled_from(["interpretability", "performance"]))
+    def test_redundancy_tie_break(self, fitted, redundancy_tie_break):
+        cpp, df_feat, labels = fitted
+        out = _simplify(
+            cpp, df_feat, labels, top_n=5, redundancy_tie_break=redundancy_tie_break
+        )
+        assert isinstance(out, pd.DataFrame)
 
     def test_canonical_schema(self, fitted):
         cpp, df_feat, labels = fitted
         out = _simplify(cpp, df_feat, labels, top_n=3)
         assert list(out.columns) == list(ut.LIST_COLS_FEAT)
 
-    def test_top_n(self, fitted):
-        cpp, df_feat, labels = fitted
-        out = _simplify(cpp, df_feat, labels, top_n=2)
-        assert len(out) <= len(df_feat)
-
-    def test_max_interpretability(self, fitted):
-        cpp, df_feat, labels = fitted
-        out = _simplify(cpp, df_feat, labels, max_interpretability=3)
-        assert isinstance(out, pd.DataFrame)
-
-    def test_min_cor_high_limits_swaps(self, fitted):
-        cpp, df_feat, labels = fitted
-        out = _simplify(cpp, df_feat, labels, top_n=3, min_cor=0.99)
-        assert isinstance(out, pd.DataFrame)
-
-    def test_tol(self, fitted):
-        cpp, df_feat, labels = fitted
-        out = _simplify(cpp, df_feat, labels, top_n=3, tol=0.1)
-        assert isinstance(out, pd.DataFrame)
-
-    def test_n_cv(self, fitted):
-        cpp, df_feat, labels = fitted
-        out = _simplify(cpp, df_feat, labels, top_n=2, n_cv=4)
-        assert isinstance(out, pd.DataFrame)
-
-    def test_on_unimprovable_keep(self, fitted):
-        cpp, df_feat, labels = fitted
-        keep = _simplify(
-            cpp, df_feat, labels, top_n=3, min_cor=1.0, on_unimprovable="keep"
-        )
-        drop = _simplify(
-            cpp, df_feat, labels, top_n=3, min_cor=1.0, on_unimprovable="drop"
-        )
-        # min_cor=1.0 blocks all swaps; 'keep' retains at least as many as 'drop'.
-        assert 1 <= len(drop) <= len(keep) <= len(df_feat)
-
-    def test_on_unimprovable_drop(self, fitted):
-        cpp, df_feat, labels = fitted
-        out = _simplify(
-            cpp, df_feat, labels, top_n=3, min_cor=0.99, on_unimprovable="drop"
-        )
-        assert len(out) <= len(df_feat)
-
-    def test_on_unimprovable_drop_if_perf(self, fitted):
-        cpp, df_feat, labels = fitted
-        out = _simplify(
-            cpp,
-            df_feat,
-            labels,
-            top_n=3,
-            min_cor=0.99,
-            on_unimprovable="drop_if_perf_allows",
-        )
-        assert isinstance(out, pd.DataFrame) and len(out) >= 1
-
-    def test_redundancy_tie_break_performance(self, fitted):
-        cpp, df_feat, labels = fitted
-        out = _simplify(
-            cpp, df_feat, labels, top_n=3, redundancy_tie_break="performance"
-        )
-        assert isinstance(out, pd.DataFrame)
-
-    def test_metric_accuracy(self, fitted):
-        cpp, df_feat, labels = fitted
-        out = _simplify(cpp, df_feat, labels, top_n=2, metric="accuracy")
-        assert isinstance(out, pd.DataFrame)
-
     def test_return_details_tuple(self, fitted):
         cpp, df_feat, labels = fitted
         out = _simplify(cpp, df_feat, labels, top_n=3, return_details=True)
         assert isinstance(out, tuple) and len(out) == 2
-        df_out, df_cand = out
+        _, df_cand = out
         assert "candidate_scale" in df_cand.columns and "accepted" in df_cand.columns
+
+    def test_ml_model_custom_instance(self, fitted):
+        cpp, df_feat, labels = fitted
+        out = _simplify(cpp, df_feat, labels, top_n=3, ml_model=SVC(kernel="linear"))
+        assert isinstance(out, pd.DataFrame)
 
     def test_X_provided(self, fitted):
         cpp, df_feat, labels = fitted
-        from aaanalysis.feature_engineering._backend.cpp._simplify import (
-            _build_base_matrix_,
-        )
-
         X = _build_base_matrix_(
             df_feat=df_feat, df_parts=cpp.df_parts, df_scales_self=cpp.df_scales
         )
@@ -162,6 +171,16 @@ class TestSimplify:
         cpp, df_feat, labels = fitted
         with pytest.raises(ValueError, match="redundancy_tie_break"):
             cpp.simplify(df_feat=df_feat, labels=labels, redundancy_tie_break="bogus")
+
+    def test_invalid_ml_model_string(self, fitted):
+        cpp, df_feat, labels = fitted
+        with pytest.raises(ValueError, match="ml_model"):
+            cpp.simplify(df_feat=df_feat, labels=labels, ml_model="bogus")
+
+    def test_invalid_ml_model_object(self, fitted):
+        cpp, df_feat, labels = fitted
+        with pytest.raises(ValueError, match="ml_model"):
+            cpp.simplify(df_feat=df_feat, labels=labels, ml_model=42)
 
     def test_max_interpretability_and_top_n_mutually_exclusive(self, fitted):
         cpp, df_feat, labels = fitted
@@ -211,21 +230,43 @@ class TestSimplifyComplex:
 
     def test_swapped_features_improve_interpretability(self, fitted):
         cpp, df_feat, labels = fitted
-        out, df_cand = _simplify(cpp, df_feat, labels, top_n=5, return_details=True)
+        _, df_cand = _simplify(cpp, df_feat, labels, top_n=5, return_details=True)
         accepted = df_cand[df_cand["accepted"]]
-        if len(accepted):  # every accepted swap must go to a strictly better rating
+        if len(accepted):
             assert (
                 accepted["interpretability_cand"] < accepted["interpretability_orig"]
             ).all()
 
     def test_redundancy_does_not_increase_count(self, fitted):
         cpp, df_feat, labels = fitted
-        out = _simplify(cpp, df_feat, labels, top_n=5)
-        assert len(out) <= len(df_feat)
+        for strategy in ["greedy", "consolidate", "swap_all"]:
+            out = _simplify(cpp, df_feat, labels, top_n=5, strategy=strategy)
+            assert len(out) <= len(df_feat)
+
+    def test_consolidate_reduces_or_equal_subcats(self, fitted):
+        cpp, df_feat, labels = fitted
+        out = _simplify(cpp, df_feat, labels, top_n=8, strategy="consolidate", tol=0.1)
+        assert out["subcategory"].nunique() <= df_feat["subcategory"].nunique()
+
+    def test_swap_all_drops_unimprovable(self, fitted):
+        cpp, df_feat, labels = fitted
+        # swap_all does no CV; on_unimprovable='drop' still prunes unswappable targets.
+        out = _simplify(
+            cpp,
+            df_feat,
+            labels,
+            top_n=6,
+            strategy="swap_all",
+            min_cor=1.0,
+            on_unimprovable="drop",
+        )
+        assert list(out.columns) == list(ut.LIST_COLS_FEAT) and 1 <= len(out) <= len(
+            df_feat
+        )
 
     def test_accepted_swaps_pass_max_std_test(self, fitted):
         cpp, df_feat, labels = fitted
-        out, df_cand = _simplify(
+        _, df_cand = _simplify(
             cpp, df_feat, labels, top_n=5, return_details=True, max_std_test=0.2
         )
         accepted = df_cand[df_cand["accepted"]]
@@ -239,6 +280,34 @@ class TestSimplifyComplex:
         pd.testing.assert_frame_equal(
             out1.reset_index(drop=True), out2.reset_index(drop=True)
         )
+
+    def test_drop_if_perf_allows_can_drop(self, fitted):
+        cpp, df_feat, labels = fitted
+        # min_cor=1.0 blocks swaps; generous tol lets the perf-allows drop accept.
+        out = _simplify(
+            cpp,
+            df_feat,
+            labels,
+            top_n=3,
+            min_cor=1.0,
+            on_unimprovable="drop_if_perf_allows",
+            tol=1.0,
+        )
+        assert 1 <= len(out) < len(df_feat)
+
+    def test_consolidate_drop_if_perf_allows(self, fitted):
+        cpp, df_feat, labels = fitted
+        out = _simplify(
+            cpp,
+            df_feat,
+            labels,
+            top_n=3,
+            strategy="consolidate",
+            min_cor=1.0,
+            on_unimprovable="drop_if_perf_allows",
+            tol=1.0,
+        )
+        assert 1 <= len(out) <= len(df_feat)
 
     def test_no_rated_features_warns_and_returns_unchanged(self, fitted):
         cpp, df_feat, labels = fitted
@@ -255,45 +324,29 @@ class TestSimplifyComplex:
             out = cpp.simplify(df_feat=df_fake, labels=labels, n_cv=3, random_state=0)
         assert len(out) == len(df_fake)
 
-    def test_consolidate_strategy_not_implemented(self, fitted):
-        cpp, df_feat, labels = fitted
-        with pytest.raises(NotImplementedError, match="staged"):
-            cpp.simplify(
-                df_feat=df_feat,
-                labels=labels,
-                strategy="consolidate",
-                top_n=2,
-                n_cv=3,
-                random_state=0,
-            )
-
-    def test_swap_all_strategy_not_implemented(self, fitted):
-        cpp, df_feat, labels = fitted
-        with pytest.raises(NotImplementedError, match="staged"):
-            cpp.simplify(
-                df_feat=df_feat,
-                labels=labels,
-                strategy="swap_all",
-                top_n=2,
-                n_cv=3,
-                random_state=0,
-            )
-
-    def test_details_records_rejected_and_accepted(self, fitted):
-        cpp, df_feat, labels = fitted
-        _, df_cand = _simplify(cpp, df_feat, labels, top_n=5, return_details=True)
-        assert set(df_cand["accepted"].unique()).issubset({True, False})
-
-    def test_output_scales_in_pool_or_original(self, fitted):
-        cpp, df_feat, labels = fitted
-        out = _simplify(cpp, df_feat, labels, top_n=5)
-        # every output feature id is a valid PART-SPLIT-SCALE
-        for f in out[ut.COL_FEATURE]:
-            part, split, scale = ut.split_feat_id(feat_id=f)
-            assert part and split and scale
-
     def test_drop_never_removes_last_feature(self, fitted):
         cpp, df_feat, labels = fitted
-        # Force everything unimprovable (min_cor=1.0) + drop → must keep >= 1 feature
         out = _simplify(cpp, df_feat, labels, min_cor=1.0, on_unimprovable="drop")
         assert len(out) >= 1
+
+    def test_merged_corr_includes_custom_scale(self, fitted):
+        # _merged_scale_corr_ must cover a scale present only in df_scales_self.
+        pool = aa.load_scales()
+        df_scales_self = pool.iloc[:, :3].copy()
+        df_scales_self["CUSTOM_X"] = pool.iloc[:, 10].to_numpy()
+        df_feat = pd.DataFrame(
+            {
+                ut.COL_FEATURE: [
+                    ut.join_feat_id(
+                        part="TMD", split="Segment(1,1)", scale_id=pool.columns[0]
+                    ),
+                    ut.join_feat_id(
+                        part="TMD", split="Segment(1,1)", scale_id="CUSTOM_X"
+                    ),
+                ]
+            }
+        )
+        df_cor = _merged_scale_corr_(
+            df_feat=df_feat, df_scales_pool=pool, df_scales_self=df_scales_self
+        )
+        assert "CUSTOM_X" in df_cor.columns and pool.columns[0] in df_cor.columns

--- a/tests/unit/cpp_tests/test_cpp_simplify.py
+++ b/tests/unit/cpp_tests/test_cpp_simplify.py
@@ -1,0 +1,299 @@
+"""This is a script to test the CPP.simplify() method: interpretability-guided
+scale swapping (issue: new simplify feature).
+
+simplify swaps each feature's scale for a more interpretable correlated scale
+(keeping PART-SPLIT), recomputes its stats, accepts a swap only behind CPP
+filtering + a random-forest cross-validation gate, then redundancy-reduces the
+set. The RF+CV gate makes the call non-trivial, so fixtures are kept small and
+shared module-wide.
+"""
+
+import warnings
+
+import pandas as pd
+import pytest
+from hypothesis import settings
+
+import aaanalysis as aa
+import aaanalysis.utils as ut
+
+settings.register_profile("ci", deadline=None)
+settings.load_profile("ci")
+
+
+@pytest.fixture(scope="module")
+def fitted():
+    """A fitted CPP + a rated feature set (interpretability-tiered scales)."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        df_seq = aa.load_dataset(name="DOM_GSEC", n=20)
+        labels = df_seq["label"].to_list()
+        sf = aa.SequenceFeature()
+        df_parts = sf.get_df_parts(df_seq=df_seq)
+        split_kws = sf.get_split_kws(
+            n_split_min=1, n_split_max=2, split_types=["Segment"]
+        )
+        df_scales = aa.load_scales(top_explain_n=20)
+        cpp = aa.CPP(df_parts=df_parts, df_scales=df_scales, split_kws=split_kws,
+                     verbose=False)
+        df_feat = cpp.run(labels=labels, n_filter=10)
+    return cpp, df_feat, labels
+
+
+def _simplify(cpp, df_feat, labels, **kwargs):
+    kwargs.setdefault("n_cv", 3)
+    kwargs.setdefault("random_state", 0)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return cpp.simplify(df_feat=df_feat, labels=labels, **kwargs)
+
+
+class TestSimplify:
+    """Normal cases — one parameter per test."""
+
+    def test_default_returns_df_feat(self, fitted):
+        cpp, df_feat, labels = fitted
+        out = _simplify(cpp, df_feat, labels)
+        assert isinstance(out, pd.DataFrame) and len(out) >= 1
+
+    def test_canonical_schema(self, fitted):
+        cpp, df_feat, labels = fitted
+        out = _simplify(cpp, df_feat, labels, top_n=3)
+        assert list(out.columns) == list(ut.LIST_COLS_FEAT)
+
+    def test_top_n(self, fitted):
+        cpp, df_feat, labels = fitted
+        out = _simplify(cpp, df_feat, labels, top_n=2)
+        assert len(out) <= len(df_feat)
+
+    def test_max_interpretability(self, fitted):
+        cpp, df_feat, labels = fitted
+        out = _simplify(cpp, df_feat, labels, max_interpretability=3)
+        assert isinstance(out, pd.DataFrame)
+
+    def test_min_cor_high_limits_swaps(self, fitted):
+        cpp, df_feat, labels = fitted
+        out = _simplify(cpp, df_feat, labels, top_n=3, min_cor=0.99)
+        assert isinstance(out, pd.DataFrame)
+
+    def test_tol(self, fitted):
+        cpp, df_feat, labels = fitted
+        out = _simplify(cpp, df_feat, labels, top_n=3, tol=0.1)
+        assert isinstance(out, pd.DataFrame)
+
+    def test_n_cv(self, fitted):
+        cpp, df_feat, labels = fitted
+        out = _simplify(cpp, df_feat, labels, top_n=2, n_cv=4)
+        assert isinstance(out, pd.DataFrame)
+
+    def test_on_unimprovable_keep(self, fitted):
+        cpp, df_feat, labels = fitted
+        keep = _simplify(
+            cpp, df_feat, labels, top_n=3, min_cor=1.0, on_unimprovable="keep"
+        )
+        drop = _simplify(
+            cpp, df_feat, labels, top_n=3, min_cor=1.0, on_unimprovable="drop"
+        )
+        # min_cor=1.0 blocks all swaps; 'keep' retains at least as many as 'drop'.
+        assert 1 <= len(drop) <= len(keep) <= len(df_feat)
+
+    def test_on_unimprovable_drop(self, fitted):
+        cpp, df_feat, labels = fitted
+        out = _simplify(
+            cpp, df_feat, labels, top_n=3, min_cor=0.99, on_unimprovable="drop"
+        )
+        assert len(out) <= len(df_feat)
+
+    def test_on_unimprovable_drop_if_perf(self, fitted):
+        cpp, df_feat, labels = fitted
+        out = _simplify(
+            cpp,
+            df_feat,
+            labels,
+            top_n=3,
+            min_cor=0.99,
+            on_unimprovable="drop_if_perf_allows",
+        )
+        assert isinstance(out, pd.DataFrame) and len(out) >= 1
+
+    def test_redundancy_tie_break_performance(self, fitted):
+        cpp, df_feat, labels = fitted
+        out = _simplify(
+            cpp, df_feat, labels, top_n=3, redundancy_tie_break="performance"
+        )
+        assert isinstance(out, pd.DataFrame)
+
+    def test_metric_accuracy(self, fitted):
+        cpp, df_feat, labels = fitted
+        out = _simplify(cpp, df_feat, labels, top_n=2, metric="accuracy")
+        assert isinstance(out, pd.DataFrame)
+
+    def test_return_details_tuple(self, fitted):
+        cpp, df_feat, labels = fitted
+        out = _simplify(cpp, df_feat, labels, top_n=3, return_details=True)
+        assert isinstance(out, tuple) and len(out) == 2
+        df_out, df_cand = out
+        assert "candidate_scale" in df_cand.columns and "accepted" in df_cand.columns
+
+    def test_X_provided(self, fitted):
+        cpp, df_feat, labels = fitted
+        from aaanalysis.feature_engineering._backend.cpp._simplify import (
+            _build_base_matrix_,
+        )
+
+        X = _build_base_matrix_(
+            df_feat=df_feat, df_parts=cpp.df_parts, df_scales_self=cpp.df_scales
+        )
+        out = _simplify(cpp, df_feat, labels, top_n=2, X=X)
+        assert isinstance(out, pd.DataFrame)
+
+    # --- negative ---
+    def test_invalid_strategy(self, fitted):
+        cpp, df_feat, labels = fitted
+        with pytest.raises(ValueError, match="strategy"):
+            cpp.simplify(df_feat=df_feat, labels=labels, strategy="bogus")
+
+    def test_invalid_on_unimprovable(self, fitted):
+        cpp, df_feat, labels = fitted
+        with pytest.raises(ValueError, match="on_unimprovable"):
+            cpp.simplify(df_feat=df_feat, labels=labels, on_unimprovable="bogus")
+
+    def test_invalid_tie_break(self, fitted):
+        cpp, df_feat, labels = fitted
+        with pytest.raises(ValueError, match="redundancy_tie_break"):
+            cpp.simplify(df_feat=df_feat, labels=labels, redundancy_tie_break="bogus")
+
+    def test_max_interpretability_and_top_n_mutually_exclusive(self, fitted):
+        cpp, df_feat, labels = fitted
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            cpp.simplify(
+                df_feat=df_feat, labels=labels, max_interpretability=3, top_n=5
+            )
+
+    def test_n_cv_too_large(self, fitted):
+        cpp, df_feat, labels = fitted
+        with pytest.raises(ValueError, match="n_cv"):
+            cpp.simplify(df_feat=df_feat, labels=labels, n_cv=999)
+
+    def test_n_cv_too_small(self, fitted):
+        cpp, df_feat, labels = fitted
+        with pytest.raises(ValueError, match="n_cv"):
+            cpp.simplify(df_feat=df_feat, labels=labels, n_cv=1)
+
+    def test_min_cor_out_of_range(self, fitted):
+        cpp, df_feat, labels = fitted
+        with pytest.raises(ValueError, match="min_cor"):
+            cpp.simplify(df_feat=df_feat, labels=labels, min_cor=1.5)
+
+    def test_max_interpretability_out_of_range(self, fitted):
+        cpp, df_feat, labels = fitted
+        with pytest.raises(ValueError, match="max_interpretability"):
+            cpp.simplify(df_feat=df_feat, labels=labels, max_interpretability=99)
+
+    def test_top_n_below_one(self, fitted):
+        cpp, df_feat, labels = fitted
+        with pytest.raises(ValueError, match="top_n"):
+            cpp.simplify(df_feat=df_feat, labels=labels, top_n=0)
+
+    def test_metric_not_str(self, fitted):
+        cpp, df_feat, labels = fitted
+        with pytest.raises(ValueError, match="metric"):
+            cpp.simplify(df_feat=df_feat, labels=labels, metric=123)
+
+    def test_labels_wrong_length(self, fitted):
+        cpp, df_feat, labels = fitted
+        with pytest.raises(ValueError):
+            cpp.simplify(df_feat=df_feat, labels=labels[:5])
+
+
+class TestSimplifyComplex:
+    """Combinations and edge interactions."""
+
+    def test_swapped_features_improve_interpretability(self, fitted):
+        cpp, df_feat, labels = fitted
+        out, df_cand = _simplify(cpp, df_feat, labels, top_n=5, return_details=True)
+        accepted = df_cand[df_cand["accepted"]]
+        if len(accepted):  # every accepted swap must go to a strictly better rating
+            assert (
+                accepted["interpretability_cand"] < accepted["interpretability_orig"]
+            ).all()
+
+    def test_redundancy_does_not_increase_count(self, fitted):
+        cpp, df_feat, labels = fitted
+        out = _simplify(cpp, df_feat, labels, top_n=5)
+        assert len(out) <= len(df_feat)
+
+    def test_accepted_swaps_pass_max_std_test(self, fitted):
+        cpp, df_feat, labels = fitted
+        out, df_cand = _simplify(
+            cpp, df_feat, labels, top_n=5, return_details=True, max_std_test=0.2
+        )
+        accepted = df_cand[df_cand["accepted"]]
+        if len(accepted):
+            assert (accepted["std_test"] <= 0.2).all()
+
+    def test_reproducible_same_seed(self, fitted):
+        cpp, df_feat, labels = fitted
+        out1 = _simplify(cpp, df_feat, labels, top_n=5, random_state=0)
+        out2 = _simplify(cpp, df_feat, labels, top_n=5, random_state=0)
+        pd.testing.assert_frame_equal(
+            out1.reset_index(drop=True), out2.reset_index(drop=True)
+        )
+
+    def test_no_rated_features_warns_and_returns_unchanged(self, fitted):
+        cpp, df_feat, labels = fitted
+        df_fake = df_feat.copy()
+        df_fake[ut.COL_FEATURE] = [
+            ut.join_feat_id(
+                part=ut.split_feat_id(feat_id=f)[0],
+                split=ut.split_feat_id(feat_id=f)[1],
+                scale_id="ZZZ_FAKE",
+            )
+            for f in df_fake[ut.COL_FEATURE]
+        ]
+        with pytest.warns(RuntimeWarning, match="no AAontology-rated"):
+            out = cpp.simplify(df_feat=df_fake, labels=labels, n_cv=3, random_state=0)
+        assert len(out) == len(df_fake)
+
+    def test_consolidate_strategy_not_implemented(self, fitted):
+        cpp, df_feat, labels = fitted
+        with pytest.raises(NotImplementedError, match="staged"):
+            cpp.simplify(
+                df_feat=df_feat,
+                labels=labels,
+                strategy="consolidate",
+                top_n=2,
+                n_cv=3,
+                random_state=0,
+            )
+
+    def test_swap_all_strategy_not_implemented(self, fitted):
+        cpp, df_feat, labels = fitted
+        with pytest.raises(NotImplementedError, match="staged"):
+            cpp.simplify(
+                df_feat=df_feat,
+                labels=labels,
+                strategy="swap_all",
+                top_n=2,
+                n_cv=3,
+                random_state=0,
+            )
+
+    def test_details_records_rejected_and_accepted(self, fitted):
+        cpp, df_feat, labels = fitted
+        _, df_cand = _simplify(cpp, df_feat, labels, top_n=5, return_details=True)
+        assert set(df_cand["accepted"].unique()).issubset({True, False})
+
+    def test_output_scales_in_pool_or_original(self, fitted):
+        cpp, df_feat, labels = fitted
+        out = _simplify(cpp, df_feat, labels, top_n=5)
+        # every output feature id is a valid PART-SPLIT-SCALE
+        for f in out[ut.COL_FEATURE]:
+            part, split, scale = ut.split_feat_id(feat_id=f)
+            assert part and split and scale
+
+    def test_drop_never_removes_last_feature(self, fitted):
+        cpp, df_feat, labels = fitted
+        # Force everything unimprovable (min_cor=1.0) + drop → must keep >= 1 feature
+        out = _simplify(cpp, df_feat, labels, min_cor=1.0, on_unimprovable="drop")
+        assert len(out) >= 1


### PR DESCRIPTION
## Summary
Adds `CPP.simplify(df_feat, labels, ...)`: rewrites a fitted `df_feat` into a **more interpretable (and ideally smaller)** one. For each feature (`PART-SPLIT-SCALE`), it swaps the scale for a **correlated** scale from a **strictly better-rated AAontology subcategory** (interpretability 1–10, 1 = best; ADR-0025), keeping `PART-SPLIT`, recomputes the feature stats, and accepts the swap only behind CPP's per-feature filter (`max_std_test`) **and** a random-forest cross-validation non-regression gate. The swapped set is then redundancy-reduced (keeping the most interpretable member of a redundant pair).

Design settled via `/grill-with-docs`.

## What's included
- **Frontend** `CPP.simplify` — `strategy="greedy"` (default); `consolidate`/`swap_all` are staged seams. Full validation block + numpydoc docstring.
- **Backend** `aaanalysis/feature_engineering/_backend/cpp/_simplify.py` — candidate pool loaded internally (full rated AAontology + a precomputed scale-correlation matrix reused for eligibility *and* redundancy), cheap single-feature recompute (`_feature_value` + `add_stat_`), the `cross_val_score` RF primitive `TreeModel.eval` uses, greedy loop with `on_unimprovable` = `keep` / `drop` / `drop_if_perf_allows`, and an interpretability-first redundancy re-filter adapted from `filtering()`.
- **Output** — clean simplified `df_feat` (canonical #18 schema via `sort_cols_feat`); `return_details=True` adds a long-form `df_candidates` report.
- Skips non-AAontology / unrated scales (`run_num` pseudo-scales); `RuntimeWarning` + unchanged when nothing is rated.
- `utils.py` strategy/enum constants; `CONTEXT.md` glossary entry; `cpp_simplify` example notebook.

## Scope decisions
- Zero new heavy deps (sklearn + `load_scales`, both core).
- Builds on the #18 `df_feat` schema (`LIST_COLS_FEAT` + `sort_cols_feat`).
- Independent of the parallel #61 work (no shared files).

## Tests / verification
- 35 tests (`tests/unit/cpp_tests/test_cpp_simplify.py`): per-param positive/negative, golden canonical schema, reproducibility (`random_state`), scope-skip → `RuntimeWarning`, redundancy reduction, staged-strategy `NotImplementedError`.
- Full unit suite green incl. the ADR-0015 regression anchor; 0 docstring defects; black-formatted; example notebook executes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)