### PR TITLE
feat: model-free feature pruning (variance + correlation) — issue #32

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -405,6 +405,41 @@ _Avoid_: selection mode (collides with `output_mode`), selection method.
 A constructor-level boolean mask on `TreeModel` marking features to keep *before* RFE runs in `fit` — an upstream gate, not a **selection strategy**. Orthogonal to `select_features`, which acts after fitting.
 _Avoid_: preselection strategy (it carries no strategy), prefilter (collides with RFE prefiltering).
 
+**feature pruning**:
+The *model-free*, *post-hoc* reduction of a [[df_feat]] by dropping features that are near-constant
+or empirically redundant **across the user's own samples**, performed by
+`SequenceFeature.prune_by_variance` and `SequenceFeature.prune_by_correlation`. Pruning runs on a
+fitted `df_feat` (e.g. from `CPP.run`) and composes **before** model-based **feature selection** —
+the recommended order is **variance pruning → correlation pruning → `TreeModel.select_features`**.
+Both methods are df_feat-in / df_feat-out (row-filtered, reset index) and build the feature matrix
+via `SequenceFeature.feature_matrix` (or accept a pre-computed `X`). Distinct from **feature
+selection** (model-based, TreeModel), CPP **feature filtering** (the in-run split/scale screening),
+CPP **redundancy reduction** (scale-vector correlation + position overlap, see below), and **feature
+simplification** (`CPP.simplify`, which relabels scales). See ADR-0026.
+_Avoid_: feature filtering (the CPP in-run term), feature reduction (overloaded with selection),
+data cleaning (too generic).
+
+**variance pruning**:
+`SequenceFeature.prune_by_variance(df_feat, df_parts, threshold=0.0)` — drops every feature whose
+**feature-matrix column variance over all samples** is at or below `threshold`. The default `0.0`
+removes only strictly constant features (zero peak-to-peak range, robust to float epsilon); raise it
+to prune low-variance features. Distinct from CPP's in-run pre-filter, which screens *candidate*
+features by the **test-group** standard deviation (`max_std_test`) rather than the spread of the
+already-selected features over all samples.
+_Avoid_: low-variance filter (use the method's pruning verb), constant-feature filter (too narrow).
+
+**empirical correlation pruning**:
+`SequenceFeature.prune_by_correlation(df_feat, df_parts, max_cor=0.7)` — among features whose
+**realized feature values are pairwise correlated** beyond `max_cor` (absolute Pearson over the
+actual samples), keeps the higher-`abs_auc` feature and drops the others; deterministic because
+features are ordered by `[abs_auc, abs_mean_dif]` before pruning, and constant columns (undefined
+correlation) are always retained. **Deliberately different** from CPP's in-run **redundancy
+reduction**, which compares the underlying *scale vectors* (`df_scales.corr()`) plus positional
+overlap — empirical pruning catches features that are redundant on a *specific dataset* even when
+their scales are not. Reuses the `NumericalFeature.filter_correlation` matrix primitive.
+_Avoid_: redundancy reduction (reserved for CPP's in-run scale-correlation step), correlation
+filtering (ambiguous about scale-vector vs sample-level correlation).
+
 ### Explainability (CPP-SHAP) vocabulary
 
 **feature importance**:
@@ -480,6 +515,7 @@ _Avoid_: interpretability score (a high score usually reads as good; the grade i
 - **Compositional** CPP strategy is a single `Segment(1,1)` whole-part split; **positional** is `n_split_max>1` / **Pattern** / **PeriodicPattern**. Compositional suits **protein level**, positional suits **residue level**, **domain level** uses both.
 - **Determinant discovery** and **design / engineering** are cross-cutting use-case classes (any level); **relational / interaction** is a documented scope boundary, not a level.
 - **Feature selection** happens *after* `TreeModel.fit`: `top_k` / `threshold` read the Monte Carlo `feat_importance`; `frequency` aggregates the per-round `is_selected_` masks that **RFE prefiltering** (`fit(use_rfe=True)`) produced. **is_preselected** gates features *before* RFE. So the order is: `is_preselected` (pre-RFE) → RFE in `fit` → `select_features` (post-fit).
+- **Feature pruning** sits *before* feature selection and is model-free: **variance pruning** → **empirical correlation pruning** (`SequenceFeature.prune_by_*`) shrink a `df_feat` on the user's own samples, then `TreeModel.select_features` applies the model-based cut. Pruning's empirical correlation is distinct from CPP's in-run **redundancy reduction** (scale-vector correlation + position overlap). See ADR-0026.
 
 ## Example dialogue
 

--- a/aaanalysis/feature_engineering/_backend/num_feat/filter_variance.py
+++ b/aaanalysis/feature_engineering/_backend/num_feat/filter_variance.py
@@ -1,0 +1,18 @@
+"""
+This is a script for the backend of the SequenceFeature.prune_by_variance() method.
+"""
+import numpy as np
+
+
+# II Main Functions
+def filter_variance_(X, threshold=0.0):
+    """Filter features whose column variance is at or below ``threshold``."""
+    X = np.asarray(X, dtype=float)
+    # Population variance per feature column (ddof=0).
+    variances = np.var(X, axis=0)
+    # A genuinely constant column can yield a tiny float epsilon (not exactly 0) when its
+    # value is not exactly representable; snap zero-range columns to 0 so a threshold of 0
+    # removes exactly the constant features.
+    variances = np.where(np.ptp(X, axis=0) == 0, 0.0, variances)
+    is_selected = variances > threshold
+    return is_selected

--- a/aaanalysis/feature_engineering/_sequence_feature.py
+++ b/aaanalysis/feature_engineering/_sequence_feature.py
@@ -704,12 +704,18 @@ class SequenceFeature:
             DataFrame of scales with letters typically representing amino acids. Default from :meth:`load_scales`
             unless specified in ``options['df_scales']``.
         threshold : float, default=0.0
-            Features with column variance ``<= threshold`` are dropped. With the default ``0.0`` only
-            strictly constant features are removed; raise it to prune low-variance features more aggressively.
+            Minimum **population variance** (``numpy`` ``var``, ``ddof=0``) a feature's column must exceed
+            to be kept; the threshold is in **variance units**, not standard-deviation units. Feature
+            values are means of (typically ``[0, 1]``-normalized) scale values, so variances are small —
+            commonly below ``0.1`` — and a useful range is: ``0.0`` removes only strictly constant
+            features, while ``~0.01`` to ``~0.05`` also prunes low-variance features. The variance is
+            computed **over all provided samples** (every row of ``df_parts`` / ``X``, both classes
+            together) per feature column — not the test group only, and not per split.
         X : array-like, shape (n_samples, n_features), optional
-            Pre-computed feature matrix aligned column-for-column with ``df_feat``. If given, it is used
-            directly and ``df_parts`` / ``df_scales`` are ignored (e.g. to reuse a matrix or to prune a
-            :meth:`CPP.run_num` ``df_feat``).
+            Pre-computed feature matrix. Column ``i`` must correspond to the feature in row ``i`` of
+            ``df_feat`` (same order). If given, it is used directly and ``df_parts`` / ``df_scales`` are
+            ignored (e.g. to reuse a matrix across pruning calls or to prune a :meth:`CPP.run_num`
+            ``df_feat``).
         accept_gaps : bool, default=False
             Whether to accept missing values by enabling omitting for computations (if ``True``).
         n_jobs : int, None, or -1, default=1
@@ -723,6 +729,13 @@ class SequenceFeature:
 
         Notes
         -----
+        * **Variance metric**: population variance (``ddof=0``) of each feature column over all samples.
+          A feature that is constant across the samples (zero peak-to-peak range) is treated as exactly
+          zero variance, so ``threshold=0.0`` removes precisely the constant features even when floating
+          point would otherwise leave a tiny non-zero variance.
+        * **Scope**: variance reflects how much a feature varies across *your* samples; it is unrelated to
+          CPP's in-run pre-filter, which screens *candidate* features by the **test-group** standard
+          deviation (``max_std_test``) rather than the spread over all samples.
         * Recommended pruning order: variance (this method) -> correlation
           (:meth:`SequenceFeature.prune_by_correlation`) -> :meth:`TreeModel.select_features`.
         * A pruning that retains no feature (e.g. ``threshold`` above every feature's variance) raises a
@@ -777,6 +790,12 @@ class SequenceFeature:
         scale vectors (``df_scales.corr()``) together with positional overlap. Pruning here catches
         features that happen to be redundant on a specific dataset even when their scales are not.
 
+        Compared with the lower-level :meth:`NumericalFeature.filter_correlation`, which takes a raw
+        matrix ``X`` and returns a boolean mask keeping the **first** column of each correlated pair (in
+        the order given), this method is df_feat-in / df_feat-out: it builds ``X`` for you, **ranks
+        features by ``abs_auc`` first** so the dropped feature of a pair is always the weaker one, and
+        returns the row-filtered ``df_feat``.
+
         .. versionadded:: 1.1.0
 
         Parameters
@@ -790,11 +809,15 @@ class SequenceFeature:
             DataFrame of scales with letters typically representing amino acids. Default from :meth:`load_scales`
             unless specified in ``options['df_scales']``.
         max_cor : float, default=0.7
-            Maximum absolute Pearson correlation [0-1] between retained features. For each pair exceeding it,
-            the lower-``abs_auc`` feature is dropped; lower ``max_cor`` to prune more aggressively.
+            Maximum **absolute Pearson correlation** [0-1] allowed between any two retained features.
+            For each pair whose ``|corr| > max_cor``, the feature with the **lower** ``abs_auc`` is
+            dropped (and the higher-``abs_auc`` one kept) — regardless of the input row order, because
+            the method ranks by ``abs_auc`` internally. Lower ``max_cor`` to prune more aggressively.
         X : array-like, shape (n_samples, n_features), optional
-            Pre-computed feature matrix aligned column-for-column with ``df_feat``. If given, it is used
-            directly and ``df_parts`` / ``df_scales`` are ignored (e.g. to reuse a matrix or to prune a
+            Pre-computed feature matrix. Column ``i`` must correspond to the feature in row ``i`` of the
+            ``df_feat`` you pass (same order); the method then re-ranks ``df_feat`` and ``X`` together by
+            ``abs_auc`` internally, so you do **not** pre-sort. If given, it is used directly and
+            ``df_parts`` / ``df_scales`` are ignored (e.g. to reuse a matrix or to prune a
             :meth:`CPP.run_num` ``df_feat``).
         accept_gaps : bool, default=False
             Whether to accept missing values by enabling omitting for computations (if ``True``).
@@ -810,9 +833,14 @@ class SequenceFeature:
 
         Notes
         -----
-        * The retained set is guaranteed to contain no feature pair with absolute correlation above
-          ``max_cor``, and the output is deterministic (byte-identical across runs) because features are
-          ordered by ``abs_auc`` (ties broken by ``abs_mean_dif``) before pruning.
+        * **Tie-break / determinism**: features are sorted by descending ``abs_auc`` (ties broken by
+          ``abs_mean_dif``) before pruning, so for every correlated pair the lower-``abs_auc`` feature is
+          the one removed. This makes the output independent of the input row order and byte-identical
+          across runs; the returned ``df_feat`` is in descending-``abs_auc`` order.
+        * **X alignment**: if you pass a pre-computed ``X``, its columns must be aligned to the ``df_feat``
+          rows you pass (column ``i`` = feature in row ``i``); the method reorders both together, so a
+          mis-aligned ``X`` would correlate the wrong features.
+        * The retained set is guaranteed to contain no feature pair with ``|corr| > max_cor``.
         * Constant (zero-variance) features have undefined correlation and are always retained here; run
           :meth:`SequenceFeature.prune_by_variance` first to remove them.
         * A ``df_feat`` with fewer than two features is returned unchanged (nothing to compare).

--- a/aaanalysis/feature_engineering/_sequence_feature.py
+++ b/aaanalysis/feature_engineering/_sequence_feature.py
@@ -28,6 +28,8 @@ from ._backend.cpp.sequence_feature import (get_split_kws_, get_features_, get_f
                                             get_labels_ovr_, get_labels_ovo_, get_labels_quantile_,
                                             get_labels_tiered_)
 from ._backend.cpp_run import _pick_feature_matrix_builder
+from ._backend.num_feat.filter_correlation import filter_correlation_
+from ._backend.num_feat.filter_variance import filter_variance_
 
 
 # I Helper Functions
@@ -137,6 +139,20 @@ def subset_value_sources(row_mask=None, df_parts=None, dict_num_parts=None):
     else:
         dict_num_parts_sub = None
     return df_parts_sub, dict_num_parts_sub
+
+
+def check_match_df_feat_X(df_feat=None, X=None):
+    """Check that a pre-computed feature matrix X aligns column-wise with df_feat."""
+    X = np.asarray(X)
+    if X.ndim != 2:
+        raise ValueError(f"'X' (ndim={X.ndim}) should be a 2D feature matrix of shape (n_samples, n_features).")
+    n_features = X.shape[1]
+    if n_features != len(df_feat):
+        raise ValueError(f"'X' (n_features={n_features}) should have one column per feature "
+                         f"in 'df_feat' (n_features={len(df_feat)}).")
+    if not np.isfinite(X).all():
+        raise ValueError("'X' should not contain NaN or infinite values.")
+    return X
 
 
 # II Main Functions
@@ -652,6 +668,195 @@ class SequenceFeature:
             list_X.append(X_all[start:start + n])
             start += n
         return list_X if batch else list_X[0]
+
+    def prune_by_variance(self,
+                          df_feat: pd.DataFrame = None,
+                          df_parts: Optional[pd.DataFrame] = None,
+                          df_scales: Optional[pd.DataFrame] = None,
+                          threshold: float = 0.0,
+                          X: Optional[ut.ArrayLike2D] = None,
+                          accept_gaps: bool = False,
+                          n_jobs: Union[int, None] = 1,
+                          ) -> pd.DataFrame:
+        """
+        Prune near-constant features from a feature DataFrame by variance.
+
+        Model-free **feature pruning** step: drops every feature whose column variance in the
+        realized feature matrix (built from ``df_parts``, or supplied directly via ``X``) is at or
+        below ``threshold``, and returns the row-filtered ``df_feat``. Use it on a fitted
+        ``df_feat`` (e.g. from :meth:`CPP.run`) as the first reduction stage, before
+        :meth:`SequenceFeature.prune_by_correlation` and :meth:`TreeModel.select_features`.
+
+        This is distinct from CPP's in-run pre-filter (which screens candidate features by the
+        test-group standard deviation): pruning measures variance over **all** samples of the
+        already-selected features.
+
+        .. versionadded:: 1.1.0
+
+        Parameters
+        ----------
+        df_feat : pd.DataFrame, shape (n_features, n_feature_info)
+            Feature DataFrame with a unique identifier, scale information, statistics, and positions for
+            each feature.
+        df_parts : pd.DataFrame, shape (n_samples, n_parts), optional
+            DataFrame with sequence parts. Used to build the feature matrix; not required if ``X`` is given.
+        df_scales : pd.DataFrame, shape (n_letters, n_scales), optional
+            DataFrame of scales with letters typically representing amino acids. Default from :meth:`load_scales`
+            unless specified in ``options['df_scales']``.
+        threshold : float, default=0.0
+            Features with column variance ``<= threshold`` are dropped. With the default ``0.0`` only
+            strictly constant features are removed; raise it to prune low-variance features more aggressively.
+        X : array-like, shape (n_samples, n_features), optional
+            Pre-computed feature matrix aligned column-for-column with ``df_feat``. If given, it is used
+            directly and ``df_parts`` / ``df_scales`` are ignored (e.g. to reuse a matrix or to prune a
+            :meth:`CPP.run_num` ``df_feat``).
+        accept_gaps : bool, default=False
+            Whether to accept missing values by enabling omitting for computations (if ``True``).
+        n_jobs : int, None, or -1, default=1
+            Number of CPU cores (>=1) used for multiprocessing. If ``None``, the number is optimized automatically.
+            If ``-1``, the number is set to all available cores. Overridden by ``options['n_jobs']`` when set.
+
+        Returns
+        -------
+        df_feat : pd.DataFrame, shape (n_selected_features, n_feature_info)
+            Feature DataFrame filtered to the features with variance above ``threshold``, with a reset index.
+
+        Notes
+        -----
+        * Recommended pruning order: variance (this method) -> correlation
+          (:meth:`SequenceFeature.prune_by_correlation`) -> :meth:`TreeModel.select_features`.
+        * A pruning that retains no feature (e.g. ``threshold`` above every feature's variance) raises a
+          ``ValueError`` rather than returning an empty DataFrame.
+
+        See Also
+        --------
+        * :meth:`SequenceFeature.prune_by_correlation` for the complementary redundancy-pruning step.
+        * :meth:`SequenceFeature.feature_matrix` for the feature matrix that variance is computed over.
+        * :meth:`TreeModel.select_features` for the model-based selection that follows pruning.
+
+        Examples
+        --------
+        .. include:: examples/sf_prune_by_variance.rst
+        """
+        # Check input
+        df_feat = ut.check_df_feat(df_feat=df_feat)
+        ut.check_number_range(name="threshold", val=threshold, min_val=0, just_int=False, accept_none=False)
+        if X is None:
+            ut.check_df_parts(df_parts=df_parts)
+            X = self.feature_matrix(features=df_feat, df_parts=df_parts, df_scales=df_scales,
+                                    accept_gaps=accept_gaps, n_jobs=n_jobs)
+        else:
+            X = check_match_df_feat_X(df_feat=df_feat, X=X)
+        # Prune features whose variance is at or below the threshold
+        is_selected = filter_variance_(X, threshold=threshold)
+        if not is_selected.any():
+            raise ValueError(f"'threshold' ({threshold}) removed all features. Lower it to retain features.")
+        df_feat = df_feat[is_selected].reset_index(drop=True)
+        return df_feat
+
+    def prune_by_correlation(self,
+                             df_feat: pd.DataFrame = None,
+                             df_parts: Optional[pd.DataFrame] = None,
+                             df_scales: Optional[pd.DataFrame] = None,
+                             max_cor: float = 0.7,
+                             X: Optional[ut.ArrayLike2D] = None,
+                             accept_gaps: bool = False,
+                             n_jobs: Union[int, None] = 1,
+                             ) -> pd.DataFrame:
+        """
+        Prune mutually correlated features from a feature DataFrame.
+
+        Model-free **feature pruning** step: among features whose realized feature values
+        (built from ``df_parts``, or supplied directly via ``X``) are pairwise correlated beyond
+        ``max_cor``, keeps the one with the higher ``abs_auc`` and drops the others, returning the
+        row-filtered ``df_feat``. Use it after :meth:`SequenceFeature.prune_by_variance` and before
+        :meth:`TreeModel.select_features`.
+
+        The correlation is **empirical** — measured over the actual samples in ``df_parts``. This is
+        deliberately different from CPP's in-run redundancy reduction, which compares the underlying
+        scale vectors (``df_scales.corr()``) together with positional overlap. Pruning here catches
+        features that happen to be redundant on a specific dataset even when their scales are not.
+
+        .. versionadded:: 1.1.0
+
+        Parameters
+        ----------
+        df_feat : pd.DataFrame, shape (n_features, n_feature_info)
+            Feature DataFrame with a unique identifier, scale information, statistics, and positions for
+            each feature. Must contain the ``abs_auc`` statistic used as the deterministic tie-break.
+        df_parts : pd.DataFrame, shape (n_samples, n_parts), optional
+            DataFrame with sequence parts. Used to build the feature matrix; not required if ``X`` is given.
+        df_scales : pd.DataFrame, shape (n_letters, n_scales), optional
+            DataFrame of scales with letters typically representing amino acids. Default from :meth:`load_scales`
+            unless specified in ``options['df_scales']``.
+        max_cor : float, default=0.7
+            Maximum absolute Pearson correlation [0-1] between retained features. For each pair exceeding it,
+            the lower-``abs_auc`` feature is dropped; lower ``max_cor`` to prune more aggressively.
+        X : array-like, shape (n_samples, n_features), optional
+            Pre-computed feature matrix aligned column-for-column with ``df_feat``. If given, it is used
+            directly and ``df_parts`` / ``df_scales`` are ignored (e.g. to reuse a matrix or to prune a
+            :meth:`CPP.run_num` ``df_feat``).
+        accept_gaps : bool, default=False
+            Whether to accept missing values by enabling omitting for computations (if ``True``).
+        n_jobs : int, None, or -1, default=1
+            Number of CPU cores (>=1) used for multiprocessing. If ``None``, the number is optimized automatically.
+            If ``-1``, the number is set to all available cores. Overridden by ``options['n_jobs']`` when set.
+
+        Returns
+        -------
+        df_feat : pd.DataFrame, shape (n_selected_features, n_feature_info)
+            Feature DataFrame filtered to a non-redundant subset (sorted by descending ``abs_auc``),
+            with a reset index.
+
+        Notes
+        -----
+        * The retained set is guaranteed to contain no feature pair with absolute correlation above
+          ``max_cor``, and the output is deterministic (byte-identical across runs) because features are
+          ordered by ``abs_auc`` (ties broken by ``abs_mean_dif``) before pruning.
+        * Constant (zero-variance) features have undefined correlation and are always retained here; run
+          :meth:`SequenceFeature.prune_by_variance` first to remove them.
+        * A ``df_feat`` with fewer than two features is returned unchanged (nothing to compare).
+
+        See Also
+        --------
+        * :meth:`SequenceFeature.prune_by_variance` for the variance-pruning step that should precede this.
+        * :meth:`NumericalFeature.filter_correlation` for the underlying correlation primitive on a matrix.
+        * :meth:`TreeModel.select_features` for the model-based selection that follows pruning.
+
+        Examples
+        --------
+        .. include:: examples/sf_prune_by_correlation.rst
+        """
+        # Check input
+        df_feat = ut.check_df_feat(df_feat=df_feat)
+        ut.check_number_range(name="max_cor", val=max_cor, min_val=0, max_val=1, just_int=False, accept_none=False)
+        if X is not None:
+            X = check_match_df_feat_X(df_feat=df_feat, X=X)
+        elif df_parts is not None:
+            ut.check_df_parts(df_parts=df_parts)
+        else:
+            raise ValueError("Either 'df_parts' or a pre-computed 'X' should be provided.")
+        # Nothing to compare with fewer than two features
+        if len(df_feat) < 2:
+            return df_feat.reset_index(drop=True)
+        # Order by descending abs_auc (tie-break abs_mean_dif) so the stronger feature of a pair is kept
+        order = df_feat.sort_values(by=[ut.COL_ABS_AUC, ut.COL_ABS_MEAN_DIF],
+                                    ascending=False).index.to_numpy()
+        df_feat = df_feat.loc[order].reset_index(drop=True)
+        if X is None:
+            X = self.feature_matrix(features=df_feat, df_parts=df_parts, df_scales=df_scales,
+                                    accept_gaps=accept_gaps, n_jobs=n_jobs)
+        else:
+            X = X[:, order]
+        # Prune redundant features (constant columns have undefined correlation -> always kept).
+        # Detect constant columns by zero peak-to-peak range (robust to float epsilon).
+        is_selected = np.ones(X.shape[1], dtype=bool)
+        non_constant = np.ptp(np.asarray(X, dtype=float), axis=0) > 0
+        idx_nc = np.where(non_constant)[0]
+        if idx_nc.size >= 2:
+            is_selected[idx_nc] = filter_correlation_(X[:, idx_nc], max_cor=max_cor)
+        df_feat = df_feat[is_selected].reset_index(drop=True)
+        return df_feat
 
     def get_features(self,
                      list_parts: Optional[List[str]] = None,

--- a/docs/adr/0026-feature-pruning-empirical-not-scale-correlation.md
+++ b/docs/adr/0026-feature-pruning-empirical-not-scale-correlation.md
@@ -1,0 +1,101 @@
+# ADR-0026 — Feature pruning is empirical (sample-level), df_feat-in/out methods on `SequenceFeature`
+
+Status: Accepted — 2026-06-11
+
+## Context
+
+Issue #32 (narrowed scope) asks for **model-free variance + correlation
+filtering** of a CPP feature table — a reduction step that runs on a fitted
+`df_feat`, returns a row-filtered `df_feat`, and composes *before* the
+model-based `TreeModel.select_features` (ADR-0023). The model/importance-based
+half is already shipped and must not be reimplemented here.
+
+Two facts complicated the design:
+
+1. **`CPP.run` already redundancy-reduces internally.** The backend
+   `_backend/cpp/_filters/_redundancy_filter.py::filtering` walks candidate
+   features in descending `abs_auc` and drops a feature when its **scale-vector
+   correlation** (`df_scales.corr()`, the 20-dim AA scales) exceeds `max_cor`
+   *and* its positions overlap an already-kept feature (`max_overlap`), within
+   category. "Drop correlated, keep higher `abs_auc`" therefore already exists —
+   but on *scale vectors + position overlap*, computed once from the scales,
+   independent of any dataset.
+2. **The reusable primitive correlates something else.** The helper the issue
+   points at — `NumericalFeature.filter_correlation(X, max_cor)` — correlates the
+   **empirical feature matrix** `X` (realized feature values across the user's
+   actual proteins). Two features built from different scales/parts can be
+   near-perfectly correlated on a *specific* dataset while their scales are not.
+
+So the question was whether #32's correlation step is just a re-export of CPP's
+in-run filter, or a genuinely different surface — and where the whole thing
+should live.
+
+## Decision
+
+**D1 — Pruning is empirical (sample-level), not a re-export of CPP's redundancy
+filter.** `prune_by_correlation` filters on the **empirical** correlation of `X`
+over the user's samples (reusing `filter_correlation`), with no position-overlap
+or category checks. This catches dataset-specific redundancy CPP's scale-vector
+filter cannot, making the two **complementary**, not duplicative. The glossary
+coins **feature pruning** and separates it from CPP **redundancy reduction**
+(scale-corr + overlap), **feature selection** (model-based), CPP **feature
+filtering** (in-run split/scale screening), and **feature simplification**.
+
+**D2 — Two dedicated df_feat-in/df_feat-out methods on `SequenceFeature`.**
+`prune_by_variance(df_feat, df_parts, threshold=0.0)` and
+`prune_by_correlation(df_feat, df_parts, max_cor=0.7)` — not one
+strategy-dispatched method. They are a *pipeline* (variance → correlation →
+`select_features`), independently testable, and chain to compose. They live on
+`SequenceFeature` because it is the only class that turns `df_feat` + `df_parts`
+into `X` (via `feature_matrix`); the low-level X→mask work stays on
+`NumericalFeature.filter_correlation` (existing) and a private
+`filter_variance_` backend helper. Both are additive methods on an
+already-exported class — no new public symbol, outside the CONFIRM-FIRST API
+surface.
+
+**D3 — Deterministic `abs_auc` tie-break; variance precedes correlation.**
+`prune_by_correlation` sorts `df_feat` by `[abs_auc, abs_mean_dif]` descending
+before pruning, so the stronger feature of a correlated pair is kept and the
+output is byte-identical across runs (mirroring CPP's redundancy ordering).
+Because `np.corrcoef` is undefined (NaN) on constant columns, constant features
+are detected by zero peak-to-peak range and always retained by
+`prune_by_correlation`; variance pruning is the step that removes them, which is
+why the documented order is variance → correlation.
+
+**D4 — Scale path by default, with an optional `X` passthrough.** Both methods
+build `X` from `df_parts` (the scale `CPP.run` path) by default but accept a
+pre-computed `X`, which covers `run_num` feature tables and lets a caller build
+the matrix once and reuse it. No numerical-mode feature-matrix machinery is
+added.
+
+## Rejected alternatives
+
+- **Re-expose CPP's in-run redundancy filter as a post-hoc method.** Rejected:
+  it would repackage shipped logic and correlate scale vectors, not the user's
+  data — the empirical filter is the part that is actually missing.
+- **One strategy-dispatched method** (`prune(df_feat, strategy, param)`, à la
+  `select_features`). Rejected: variance and correlation are a sequential
+  pipeline, not mutually exclusive strategies; dispatch forces awkward disabling
+  to isolate one filter and muddies the "feature selection" term reserved for
+  TreeModel.
+- **Standalone `aa.*` helpers.** Rejected: each new top-level symbol is a
+  CONFIRM-FIRST `__init__.py` re-export for no discoverability gain over methods
+  next to `feature_matrix` / `get_df_feat`.
+- **A public `NumericalFeature.filter_variance` primitive** mirroring
+  `filter_correlation`. Rejected: variance is a one-line `np.var` comparison not
+  worth public surface; it stays a backend helper.
+- **Plain `np.var > threshold` for constant detection.** Rejected: a constant
+  column whose value is not exactly representable yields a tiny float epsilon,
+  not `0.0`, so a `threshold=0` would keep it. Constant columns are snapped to
+  zero variance by zero peak-to-peak range so `threshold=0` removes *exactly*
+  the constant features (the issue KPI).
+
+## Consequences
+
+- New backend helper `_backend/num_feat/filter_variance.py::filter_variance_`;
+  two new `SequenceFeature` methods; two example notebooks under
+  `examples/feature_engineering/`.
+- `CONTEXT.md` gains a **feature pruning** / **variance pruning** / **empirical
+  correlation pruning** vocabulary block plus a pipeline relationship bullet.
+- The pre-existing CPP in-run redundancy filter is unchanged; the two correlation
+  surfaces now coexist by design and are documented as complementary.

--- a/examples/feature_engineering/sf_prune_by_correlation.ipynb
+++ b/examples/feature_engineering/sf_prune_by_correlation.ipynb
@@ -1,0 +1,530 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "af0cb98d",
+   "metadata": {},
+   "source": [
+    ":meth:`SequenceFeature.prune_by_correlation` removes **empirically redundant** features: among features whose realized values are pairwise correlated beyond ``max_cor``, it keeps the one with the higher ``abs_auc`` and drops the others. The correlation is measured over the actual samples, which makes it complementary to CPP's in-run redundancy reduction (that one compares the underlying scale vectors). Use it after :meth:`SequenceFeature.prune_by_variance` and before :meth:`TreeModel.select_features`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f582a911",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T23:03:12.461969Z",
+     "iopub.status.busy": "2026-06-10T23:03:12.461734Z",
+     "iopub.status.idle": "2026-06-10T23:03:18.530047Z",
+     "shell.execute_reply": "2026-06-10T23:03:18.529744Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "features from CPP.run: 50\n"
+     ]
+    }
+   ],
+   "source": [
+    "import aaanalysis as aa\n",
+    "aa.options[\"verbose\"] = False\n",
+    "\n",
+    "df_seq = aa.load_dataset(name=\"DOM_GSEC\", n=20)\n",
+    "labels = df_seq[\"label\"].to_list()\n",
+    "sf = aa.SequenceFeature()\n",
+    "df_parts = sf.get_df_parts(df_seq=df_seq)\n",
+    "df_feat = aa.CPP(df_parts=df_parts).run(labels=labels, n_filter=50)\n",
+    "print(f\"features from CPP.run: {len(df_feat)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "799fdd16",
+   "metadata": {},
+   "source": [
+    "At ``max_cor=0.7`` no retained pair of features has an absolute correlation above 0.7. The output is sorted by descending ``abs_auc`` and is deterministic across runs:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f864725d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T23:03:18.531349Z",
+     "iopub.status.busy": "2026-06-10T23:03:18.531212Z",
+     "iopub.status.idle": "2026-06-10T23:03:18.554275Z",
+     "shell.execute_reply": "2026-06-10T23:03:18.554039Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "kept 21 of 50 features\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>feature</th>\n",
+       "      <th>category</th>\n",
+       "      <th>subcategory</th>\n",
+       "      <th>scale_name</th>\n",
+       "      <th>scale_description</th>\n",
+       "      <th>abs_auc</th>\n",
+       "      <th>abs_mean_dif</th>\n",
+       "      <th>mean_dif</th>\n",
+       "      <th>std_test</th>\n",
+       "      <th>std_ref</th>\n",
+       "      <th>p_val_mann_whitney</th>\n",
+       "      <th>p_val_fdr_bh</th>\n",
+       "      <th>positions</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>TMD-Pattern(C,4,8)-BEGF750101</td>\n",
+       "      <td>Conformation</td>\n",
+       "      <td>α-helix</td>\n",
+       "      <td>α-helix</td>\n",
+       "      <td>Conformational parameter of inner helix (Beghi...</td>\n",
+       "      <td>0.444</td>\n",
+       "      <td>0.299</td>\n",
+       "      <td>0.299</td>\n",
+       "      <td>0.090</td>\n",
+       "      <td>0.196</td>\n",
+       "      <td>0.000002</td>\n",
+       "      <td>0.022853</td>\n",
+       "      <td>23,27</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>TMD_C_JMD_C-PeriodicPattern(C,i+4/4,2)-BEGF750103</td>\n",
+       "      <td>Conformation</td>\n",
+       "      <td>β-turn</td>\n",
+       "      <td>β-turn</td>\n",
+       "      <td>Conformational parameter of beta-turn (Beghin-...</td>\n",
+       "      <td>0.409</td>\n",
+       "      <td>0.139</td>\n",
+       "      <td>-0.139</td>\n",
+       "      <td>0.098</td>\n",
+       "      <td>0.094</td>\n",
+       "      <td>0.000010</td>\n",
+       "      <td>0.011310</td>\n",
+       "      <td>23,27,31,35,39</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>TMD_C_JMD_C-Pattern(C,8,11,14)-ZIMJ680104</td>\n",
+       "      <td>Energy</td>\n",
+       "      <td>Isoelectric point</td>\n",
+       "      <td>Isoelectric point</td>\n",
+       "      <td>Isoelectric point (Zimmerman et al., 1968)</td>\n",
+       "      <td>0.402</td>\n",
+       "      <td>0.130</td>\n",
+       "      <td>0.130</td>\n",
+       "      <td>0.080</td>\n",
+       "      <td>0.088</td>\n",
+       "      <td>0.000013</td>\n",
+       "      <td>0.011349</td>\n",
+       "      <td>27,30,33</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>TMD_C_JMD_C-Pattern(C,10,14)-MUNV940102</td>\n",
+       "      <td>Energy</td>\n",
+       "      <td>Free energy (folding)</td>\n",
+       "      <td>Free energy (α-helix)</td>\n",
+       "      <td>Free energy in alpha-helical region (Munoz-Ser...</td>\n",
+       "      <td>0.391</td>\n",
+       "      <td>0.153</td>\n",
+       "      <td>-0.153</td>\n",
+       "      <td>0.067</td>\n",
+       "      <td>0.130</td>\n",
+       "      <td>0.000023</td>\n",
+       "      <td>0.012601</td>\n",
+       "      <td>27,31</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>TMD-Segment(10,11)-CHAM820102</td>\n",
+       "      <td>Polarity</td>\n",
+       "      <td>Hydrophobicity (interface)</td>\n",
+       "      <td>Free energy (interface)</td>\n",
+       "      <td>Free energy of solution in water, kcal/mole (C...</td>\n",
+       "      <td>0.389</td>\n",
+       "      <td>0.169</td>\n",
+       "      <td>-0.169</td>\n",
+       "      <td>0.050</td>\n",
+       "      <td>0.130</td>\n",
+       "      <td>0.000026</td>\n",
+       "      <td>0.012145</td>\n",
+       "      <td>27,28</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                             feature      category  \\\n",
+       "0                      TMD-Pattern(C,4,8)-BEGF750101  Conformation   \n",
+       "1  TMD_C_JMD_C-PeriodicPattern(C,i+4/4,2)-BEGF750103  Conformation   \n",
+       "2          TMD_C_JMD_C-Pattern(C,8,11,14)-ZIMJ680104        Energy   \n",
+       "3            TMD_C_JMD_C-Pattern(C,10,14)-MUNV940102        Energy   \n",
+       "4                      TMD-Segment(10,11)-CHAM820102      Polarity   \n",
+       "\n",
+       "                  subcategory               scale_name  \\\n",
+       "0                     α-helix                  α-helix   \n",
+       "1                      β-turn                   β-turn   \n",
+       "2           Isoelectric point        Isoelectric point   \n",
+       "3       Free energy (folding)    Free energy (α-helix)   \n",
+       "4  Hydrophobicity (interface)  Free energy (interface)   \n",
+       "\n",
+       "                                   scale_description  abs_auc  abs_mean_dif  \\\n",
+       "0  Conformational parameter of inner helix (Beghi...    0.444         0.299   \n",
+       "1  Conformational parameter of beta-turn (Beghin-...    0.409         0.139   \n",
+       "2         Isoelectric point (Zimmerman et al., 1968)    0.402         0.130   \n",
+       "3  Free energy in alpha-helical region (Munoz-Ser...    0.391         0.153   \n",
+       "4  Free energy of solution in water, kcal/mole (C...    0.389         0.169   \n",
+       "\n",
+       "   mean_dif  std_test  std_ref  p_val_mann_whitney  p_val_fdr_bh  \\\n",
+       "0     0.299     0.090    0.196            0.000002      0.022853   \n",
+       "1    -0.139     0.098    0.094            0.000010      0.011310   \n",
+       "2     0.130     0.080    0.088            0.000013      0.011349   \n",
+       "3    -0.153     0.067    0.130            0.000023      0.012601   \n",
+       "4    -0.169     0.050    0.130            0.000026      0.012145   \n",
+       "\n",
+       "        positions  \n",
+       "0           23,27  \n",
+       "1  23,27,31,35,39  \n",
+       "2        27,30,33  \n",
+       "3           27,31  \n",
+       "4           27,28  "
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_cor = sf.prune_by_correlation(df_feat=df_feat, df_parts=df_parts, max_cor=0.7)\n",
+    "print(f\"kept {len(df_cor)} of {len(df_feat)} features\")\n",
+    "df_cor.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da267036",
+   "metadata": {},
+   "source": [
+    "Lower ``max_cor`` to prune more aggressively. As with variance pruning, a pre-computed ``X`` can be supplied (``df_parts`` / ``df_scales`` then ignored), and ``accept_gaps`` / ``n_jobs`` are forwarded to the matrix build:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a2d5cc47",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T23:03:18.555591Z",
+     "iopub.status.busy": "2026-06-10T23:03:18.555506Z",
+     "iopub.status.idle": "2026-06-10T23:03:18.573717Z",
+     "shell.execute_reply": "2026-06-10T23:03:18.573481Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "max_cor=0.4 kept 2 features; max_cor=0.7 kept 21\n"
+     ]
+    }
+   ],
+   "source": [
+    "X = sf.feature_matrix(features=df_feat, df_parts=df_parts, accept_gaps=False, n_jobs=1)\n",
+    "df_cor_tight = sf.prune_by_correlation(df_feat=df_feat, X=X, max_cor=0.4)\n",
+    "print(f\"max_cor=0.4 kept {len(df_cor_tight)} features; max_cor=0.7 kept {len(df_cor)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27f0381b",
+   "metadata": {},
+   "source": [
+    "The two pruners compose, and the result drops straight into model-based selection (:meth:`TreeModel.select_features`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "d8fef369",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T23:03:18.574757Z",
+     "iopub.status.busy": "2026-06-10T23:03:18.574684Z",
+     "iopub.status.idle": "2026-06-10T23:03:18.611276Z",
+     "shell.execute_reply": "2026-06-10T23:03:18.611049Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "variance -> correlation kept 5 of 50 features\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>feature</th>\n",
+       "      <th>category</th>\n",
+       "      <th>subcategory</th>\n",
+       "      <th>scale_name</th>\n",
+       "      <th>scale_description</th>\n",
+       "      <th>abs_auc</th>\n",
+       "      <th>abs_mean_dif</th>\n",
+       "      <th>mean_dif</th>\n",
+       "      <th>std_test</th>\n",
+       "      <th>std_ref</th>\n",
+       "      <th>p_val_mann_whitney</th>\n",
+       "      <th>p_val_fdr_bh</th>\n",
+       "      <th>positions</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>TMD-Pattern(C,4,8)-BEGF750101</td>\n",
+       "      <td>Conformation</td>\n",
+       "      <td>α-helix</td>\n",
+       "      <td>α-helix</td>\n",
+       "      <td>Conformational parameter of inner helix (Beghi...</td>\n",
+       "      <td>0.444</td>\n",
+       "      <td>0.299</td>\n",
+       "      <td>0.299</td>\n",
+       "      <td>0.090</td>\n",
+       "      <td>0.196</td>\n",
+       "      <td>0.000002</td>\n",
+       "      <td>0.022853</td>\n",
+       "      <td>23,27</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>TMD_C_JMD_C-Pattern(C,8,11,14)-ZIMJ680104</td>\n",
+       "      <td>Energy</td>\n",
+       "      <td>Isoelectric point</td>\n",
+       "      <td>Isoelectric point</td>\n",
+       "      <td>Isoelectric point (Zimmerman et al., 1968)</td>\n",
+       "      <td>0.402</td>\n",
+       "      <td>0.130</td>\n",
+       "      <td>0.130</td>\n",
+       "      <td>0.080</td>\n",
+       "      <td>0.088</td>\n",
+       "      <td>0.000013</td>\n",
+       "      <td>0.011349</td>\n",
+       "      <td>27,30,33</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>TMD_C_JMD_C-PeriodicPattern(N,i+4/3,1)-AURR980108</td>\n",
+       "      <td>Conformation</td>\n",
+       "      <td>α-helix</td>\n",
+       "      <td>α-helix (N-terminal, inside)</td>\n",
+       "      <td>Normalized positional residue frequency at hel...</td>\n",
+       "      <td>0.385</td>\n",
+       "      <td>0.156</td>\n",
+       "      <td>0.156</td>\n",
+       "      <td>0.077</td>\n",
+       "      <td>0.105</td>\n",
+       "      <td>0.000031</td>\n",
+       "      <td>0.012681</td>\n",
+       "      <td>21,25,28,32,35,39</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>JMD_N_TMD_N-Segment(3,8)-NAKH920107</td>\n",
+       "      <td>Composition</td>\n",
+       "      <td>AA composition</td>\n",
+       "      <td>Membrane proteins (multi-spanning, EXT)</td>\n",
+       "      <td>AA composition of EXT of multi-spanning protei...</td>\n",
+       "      <td>0.366</td>\n",
+       "      <td>0.188</td>\n",
+       "      <td>0.188</td>\n",
+       "      <td>0.144</td>\n",
+       "      <td>0.094</td>\n",
+       "      <td>0.000074</td>\n",
+       "      <td>0.009765</td>\n",
+       "      <td>6,7</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>TMD_C_JMD_C-Pattern(C,8,12,15)-GEIM800103</td>\n",
+       "      <td>Conformation</td>\n",
+       "      <td>Unclassified (Conformation)</td>\n",
+       "      <td>α-helix (β-proteins)</td>\n",
+       "      <td>Alpha-helix indices for beta-proteins (Geisow-...</td>\n",
+       "      <td>0.359</td>\n",
+       "      <td>0.163</td>\n",
+       "      <td>-0.163</td>\n",
+       "      <td>0.137</td>\n",
+       "      <td>0.080</td>\n",
+       "      <td>0.000104</td>\n",
+       "      <td>0.009706</td>\n",
+       "      <td>26,29,33</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                             feature      category  \\\n",
+       "0                      TMD-Pattern(C,4,8)-BEGF750101  Conformation   \n",
+       "1          TMD_C_JMD_C-Pattern(C,8,11,14)-ZIMJ680104        Energy   \n",
+       "2  TMD_C_JMD_C-PeriodicPattern(N,i+4/3,1)-AURR980108  Conformation   \n",
+       "3                JMD_N_TMD_N-Segment(3,8)-NAKH920107   Composition   \n",
+       "4          TMD_C_JMD_C-Pattern(C,8,12,15)-GEIM800103  Conformation   \n",
+       "\n",
+       "                   subcategory                               scale_name  \\\n",
+       "0                      α-helix                                  α-helix   \n",
+       "1            Isoelectric point                        Isoelectric point   \n",
+       "2                      α-helix             α-helix (N-terminal, inside)   \n",
+       "3               AA composition  Membrane proteins (multi-spanning, EXT)   \n",
+       "4  Unclassified (Conformation)                     α-helix (β-proteins)   \n",
+       "\n",
+       "                                   scale_description  abs_auc  abs_mean_dif  \\\n",
+       "0  Conformational parameter of inner helix (Beghi...    0.444         0.299   \n",
+       "1         Isoelectric point (Zimmerman et al., 1968)    0.402         0.130   \n",
+       "2  Normalized positional residue frequency at hel...    0.385         0.156   \n",
+       "3  AA composition of EXT of multi-spanning protei...    0.366         0.188   \n",
+       "4  Alpha-helix indices for beta-proteins (Geisow-...    0.359         0.163   \n",
+       "\n",
+       "   mean_dif  std_test  std_ref  p_val_mann_whitney  p_val_fdr_bh  \\\n",
+       "0     0.299     0.090    0.196            0.000002      0.022853   \n",
+       "1     0.130     0.080    0.088            0.000013      0.011349   \n",
+       "2     0.156     0.077    0.105            0.000031      0.012681   \n",
+       "3     0.188     0.144    0.094            0.000074      0.009765   \n",
+       "4    -0.163     0.137    0.080            0.000104      0.009706   \n",
+       "\n",
+       "           positions  \n",
+       "0              23,27  \n",
+       "1           27,30,33  \n",
+       "2  21,25,28,32,35,39  \n",
+       "3                6,7  \n",
+       "4           26,29,33  "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_pruned = sf.prune_by_variance(df_feat=df_feat, df_parts=df_parts, threshold=0.0)\n",
+    "df_pruned = sf.prune_by_correlation(df_feat=df_pruned, df_parts=df_parts, max_cor=0.5)\n",
+    "print(f\"variance -> correlation kept {len(df_pruned)} of {len(df_feat)} features\")\n",
+    "df_pruned.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69a9a65e",
+   "metadata": {},
+   "source": [
+    "**What can go wrong?** A ``df_feat`` with fewer than two features has nothing to compare and is returned unchanged:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "2277608f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T23:03:18.612294Z",
+     "iopub.status.busy": "2026-06-10T23:03:18.612233Z",
+     "iopub.status.idle": "2026-06-10T23:03:18.614358Z",
+     "shell.execute_reply": "2026-06-10T23:03:18.614162Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "single-feature input -> 1 feature\n"
+     ]
+    }
+   ],
+   "source": [
+    "one = df_feat.head(1)\n",
+    "print(f\"single-feature input -> {len(sf.prune_by_correlation(df_feat=one, df_parts=df_parts))} feature\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/feature_engineering/sf_prune_by_variance.ipynb
+++ b/examples/feature_engineering/sf_prune_by_variance.ipynb
@@ -1,0 +1,334 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b11c1daf",
+   "metadata": {},
+   "source": [
+    "**Feature pruning** is the model-free, post-hoc reduction of a ``df_feat`` (here from :meth:`CPP.run`) before model-based selection. :meth:`SequenceFeature.prune_by_variance` drops near-constant features — those whose feature values barely change across the samples — measured on the feature matrix that :meth:`SequenceFeature.feature_matrix` builds from ``df_parts``. The recommended order is **variance -> correlation -> select_features**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "66a8a8ff",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T23:03:02.896304Z",
+     "iopub.status.busy": "2026-06-10T23:03:02.896223Z",
+     "iopub.status.idle": "2026-06-10T23:03:08.963331Z",
+     "shell.execute_reply": "2026-06-10T23:03:08.963081Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "features from CPP.run: 50\n"
+     ]
+    }
+   ],
+   "source": [
+    "import aaanalysis as aa\n",
+    "aa.options[\"verbose\"] = False\n",
+    "\n",
+    "df_seq = aa.load_dataset(name=\"DOM_GSEC\", n=20)\n",
+    "labels = df_seq[\"label\"].to_list()\n",
+    "sf = aa.SequenceFeature()\n",
+    "df_parts = sf.get_df_parts(df_seq=df_seq)\n",
+    "df_feat = aa.CPP(df_parts=df_parts).run(labels=labels, n_filter=50)\n",
+    "print(f\"features from CPP.run: {len(df_feat)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fcc5dd7e",
+   "metadata": {},
+   "source": [
+    "With the default ``threshold=0.0`` only strictly constant features are removed. The result is a row-filtered ``df_feat`` with the same schema:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5b11bcf2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T23:03:08.964621Z",
+     "iopub.status.busy": "2026-06-10T23:03:08.964453Z",
+     "iopub.status.idle": "2026-06-10T23:03:08.987771Z",
+     "shell.execute_reply": "2026-06-10T23:03:08.987547Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "kept 50 of 50 features\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>feature</th>\n",
+       "      <th>category</th>\n",
+       "      <th>subcategory</th>\n",
+       "      <th>scale_name</th>\n",
+       "      <th>scale_description</th>\n",
+       "      <th>abs_auc</th>\n",
+       "      <th>abs_mean_dif</th>\n",
+       "      <th>mean_dif</th>\n",
+       "      <th>std_test</th>\n",
+       "      <th>std_ref</th>\n",
+       "      <th>p_val_mann_whitney</th>\n",
+       "      <th>p_val_fdr_bh</th>\n",
+       "      <th>positions</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>TMD-Pattern(C,4,8)-BEGF750101</td>\n",
+       "      <td>Conformation</td>\n",
+       "      <td>α-helix</td>\n",
+       "      <td>α-helix</td>\n",
+       "      <td>Conformational parameter of inner helix (Beghi...</td>\n",
+       "      <td>0.444</td>\n",
+       "      <td>0.299</td>\n",
+       "      <td>0.299</td>\n",
+       "      <td>0.090</td>\n",
+       "      <td>0.196</td>\n",
+       "      <td>0.000002</td>\n",
+       "      <td>0.022853</td>\n",
+       "      <td>23,27</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>TMD_C_JMD_C-Pattern(N,4,8)-BEGF750101</td>\n",
+       "      <td>Conformation</td>\n",
+       "      <td>α-helix</td>\n",
+       "      <td>α-helix</td>\n",
+       "      <td>Conformational parameter of inner helix (Beghi...</td>\n",
+       "      <td>0.444</td>\n",
+       "      <td>0.299</td>\n",
+       "      <td>0.299</td>\n",
+       "      <td>0.090</td>\n",
+       "      <td>0.196</td>\n",
+       "      <td>0.000002</td>\n",
+       "      <td>0.045706</td>\n",
+       "      <td>24,28</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>TMD_C_JMD_C-Pattern(N,4,8,12)-CRAJ730103</td>\n",
+       "      <td>Conformation</td>\n",
+       "      <td>β-turn</td>\n",
+       "      <td>β-turn</td>\n",
+       "      <td>Normalized frequency of turn (Crawford et al.,...</td>\n",
+       "      <td>0.431</td>\n",
+       "      <td>0.251</td>\n",
+       "      <td>-0.251</td>\n",
+       "      <td>0.088</td>\n",
+       "      <td>0.143</td>\n",
+       "      <td>0.000003</td>\n",
+       "      <td>0.011128</td>\n",
+       "      <td>24,28,32</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>TMD_C_JMD_C-Pattern(N,4,8,12)-MUNV940102</td>\n",
+       "      <td>Energy</td>\n",
+       "      <td>Free energy (folding)</td>\n",
+       "      <td>Free energy (α-helix)</td>\n",
+       "      <td>Free energy in alpha-helical region (Munoz-Ser...</td>\n",
+       "      <td>0.422</td>\n",
+       "      <td>0.148</td>\n",
+       "      <td>-0.148</td>\n",
+       "      <td>0.056</td>\n",
+       "      <td>0.097</td>\n",
+       "      <td>0.000005</td>\n",
+       "      <td>0.009366</td>\n",
+       "      <td>24,28,32</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>TMD_C_JMD_C-PeriodicPattern(C,i+4/4,2)-BEGF750103</td>\n",
+       "      <td>Conformation</td>\n",
+       "      <td>β-turn</td>\n",
+       "      <td>β-turn</td>\n",
+       "      <td>Conformational parameter of beta-turn (Beghin-...</td>\n",
+       "      <td>0.409</td>\n",
+       "      <td>0.139</td>\n",
+       "      <td>-0.139</td>\n",
+       "      <td>0.098</td>\n",
+       "      <td>0.094</td>\n",
+       "      <td>0.000010</td>\n",
+       "      <td>0.011310</td>\n",
+       "      <td>23,27,31,35,39</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                             feature      category  \\\n",
+       "0                      TMD-Pattern(C,4,8)-BEGF750101  Conformation   \n",
+       "1              TMD_C_JMD_C-Pattern(N,4,8)-BEGF750101  Conformation   \n",
+       "2           TMD_C_JMD_C-Pattern(N,4,8,12)-CRAJ730103  Conformation   \n",
+       "3           TMD_C_JMD_C-Pattern(N,4,8,12)-MUNV940102        Energy   \n",
+       "4  TMD_C_JMD_C-PeriodicPattern(C,i+4/4,2)-BEGF750103  Conformation   \n",
+       "\n",
+       "             subcategory             scale_name  \\\n",
+       "0                α-helix                α-helix   \n",
+       "1                α-helix                α-helix   \n",
+       "2                 β-turn                 β-turn   \n",
+       "3  Free energy (folding)  Free energy (α-helix)   \n",
+       "4                 β-turn                 β-turn   \n",
+       "\n",
+       "                                   scale_description  abs_auc  abs_mean_dif  \\\n",
+       "0  Conformational parameter of inner helix (Beghi...    0.444         0.299   \n",
+       "1  Conformational parameter of inner helix (Beghi...    0.444         0.299   \n",
+       "2  Normalized frequency of turn (Crawford et al.,...    0.431         0.251   \n",
+       "3  Free energy in alpha-helical region (Munoz-Ser...    0.422         0.148   \n",
+       "4  Conformational parameter of beta-turn (Beghin-...    0.409         0.139   \n",
+       "\n",
+       "   mean_dif  std_test  std_ref  p_val_mann_whitney  p_val_fdr_bh  \\\n",
+       "0     0.299     0.090    0.196            0.000002      0.022853   \n",
+       "1     0.299     0.090    0.196            0.000002      0.045706   \n",
+       "2    -0.251     0.088    0.143            0.000003      0.011128   \n",
+       "3    -0.148     0.056    0.097            0.000005      0.009366   \n",
+       "4    -0.139     0.098    0.094            0.000010      0.011310   \n",
+       "\n",
+       "        positions  \n",
+       "0           23,27  \n",
+       "1           24,28  \n",
+       "2        24,28,32  \n",
+       "3        24,28,32  \n",
+       "4  23,27,31,35,39  "
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_var = sf.prune_by_variance(df_feat=df_feat, df_parts=df_parts, threshold=0.0)\n",
+    "print(f\"kept {len(df_var)} of {len(df_feat)} features\")\n",
+    "df_var.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6d6b1eb",
+   "metadata": {},
+   "source": [
+    "Raise ``threshold`` to prune low-variance features more aggressively. The feature matrix can also be supplied directly via ``X`` (e.g. to reuse a matrix across several pruning calls, or to prune a :meth:`CPP.run_num` table); then ``df_parts`` / ``df_scales`` are ignored. ``accept_gaps`` and ``n_jobs`` are forwarded to the matrix build, and a custom ``df_scales`` can be passed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "95e9879e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T23:03:08.988889Z",
+     "iopub.status.busy": "2026-06-10T23:03:08.988801Z",
+     "iopub.status.idle": "2026-06-10T23:03:09.006953Z",
+     "shell.execute_reply": "2026-06-10T23:03:09.006673Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "threshold=0.01 kept 48 of 50 features\n"
+     ]
+    }
+   ],
+   "source": [
+    "X = sf.feature_matrix(features=df_feat, df_parts=df_parts, accept_gaps=False, n_jobs=1)\n",
+    "df_var_strict = sf.prune_by_variance(df_feat=df_feat, X=X, threshold=0.01)\n",
+    "print(f\"threshold=0.01 kept {len(df_var_strict)} of {len(df_feat)} features\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78730812",
+   "metadata": {},
+   "source": [
+    "**What can go wrong?** A ``threshold`` above every feature's variance would remove all features, so it raises a ``ValueError`` rather than returning an empty table:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "87ad2263",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T23:03:09.008247Z",
+     "iopub.status.busy": "2026-06-10T23:03:09.008172Z",
+     "iopub.status.idle": "2026-06-10T23:03:09.010348Z",
+     "shell.execute_reply": "2026-06-10T23:03:09.010141Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ValueError: 'threshold' (1000000.0) removed all features. Lower it to retain features.\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    sf.prune_by_variance(df_feat=df_feat, X=X, threshold=1e6)\n",
+    "except ValueError as e:\n",
+    "    print(f\"ValueError: {e}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/unit/sequence_feature_tests/test_sf_prune.py
+++ b/tests/unit/sequence_feature_tests/test_sf_prune.py
@@ -1,0 +1,299 @@
+"""Tests for the SequenceFeature model-free pruning methods (issue #32).
+
+Covers ``prune_by_variance`` and ``prune_by_correlation`` (feature pruning: variance +
+empirical-correlation filtering of a ``df_feat``). Follows the house testing template: a
+normal-case ``Test<Method>`` class (one parameter per test, positive via hypothesis +
+negative via pytest.raises), a ``Test<Method>Complex`` class crossing parameters, and a
+``Test<Method>GoldenValues`` class with hand-computed expectations (the issue KPIs:
+variance-0 removes exactly the constant columns; correlation at ``t`` retains no pair
+above ``t`` and is deterministic).
+"""
+import numpy as np
+import pandas as pd
+import pytest
+from hypothesis import given, settings
+import hypothesis.strategies as some
+import aaanalysis as aa
+import aaanalysis.utils as ut
+
+settings.register_profile("ci", deadline=None)
+settings.load_profile("ci")
+
+aa.options["verbose"] = False
+SF = aa.SequenceFeature
+
+
+# I Helper functions / fixtures
+@pytest.fixture(scope="module")
+def fitted():
+    """Real (sf, df_feat, df_parts, X) from a small DOM_GSEC CPP run, built once."""
+    df_seq = aa.load_dataset(name="DOM_GSEC", n=12)
+    labels = df_seq["label"].to_list()
+    sf = aa.SequenceFeature()
+    df_parts = sf.get_df_parts(df_seq=df_seq)
+    cpp = aa.CPP(df_parts=df_parts)
+    df_feat = cpp.run(labels=labels, n_filter=40)
+    X = sf.feature_matrix(features=df_feat, df_parts=df_parts)
+    return sf, df_feat.reset_index(drop=True), df_parts, np.asarray(X)
+
+
+def _max_abs_offdiag_corr(X):
+    """Maximum absolute off-diagonal Pearson correlation of a feature matrix."""
+    if X.shape[1] < 2:
+        return 0.0
+    cm = np.corrcoef(X, rowvar=False)
+    np.fill_diagonal(cm, 0.0)
+    return float(np.nanmax(np.abs(cm)))
+
+
+# ======================================================================================
+# prune_by_variance
+# ======================================================================================
+class TestPruneByVariance:
+    """Normal cases for prune_by_variance (one parameter per test)."""
+
+    def test_returns_df_feat(self, fitted):
+        sf, df_feat, df_parts, _ = fitted
+        out = sf.prune_by_variance(df_feat=df_feat, df_parts=df_parts)
+        assert isinstance(out, pd.DataFrame)
+        assert list(out.columns) == list(df_feat.columns)
+
+    def test_default_threshold_keeps_non_constant(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        # No constant columns in a real run -> default threshold 0 keeps everything
+        assert (X.var(axis=0) > 0).all()
+        out = sf.prune_by_variance(df_feat=df_feat, df_parts=df_parts, threshold=0.0)
+        assert len(out) == len(df_feat)
+
+    @settings(max_examples=8, deadline=None)
+    @given(threshold=some.floats(min_value=0.0, max_value=0.05))
+    def test_threshold_monotonic(self, fitted, threshold):
+        sf, df_feat, df_parts, X = fitted
+        expected = int((X.var(axis=0) > threshold).sum())
+        if expected == 0:
+            # A threshold above every feature's variance must raise rather than empty-return
+            with pytest.raises(ValueError):
+                sf.prune_by_variance(df_feat=df_feat, X=X, threshold=threshold)
+        else:
+            out = sf.prune_by_variance(df_feat=df_feat, X=X, threshold=threshold)
+            assert len(out) == expected
+
+    def test_reset_index(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        X2 = X.copy()
+        X2[:, 0] = 0.5  # constant -> dropped, so the index would otherwise skip 0
+        out = sf.prune_by_variance(df_feat=df_feat, X=X2, threshold=0.0)
+        assert list(out.index) == list(range(len(out)))
+
+    def test_x_passthrough_matches_df_parts(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        a = sf.prune_by_variance(df_feat=df_feat, df_parts=df_parts, threshold=0.005)
+        b = sf.prune_by_variance(df_feat=df_feat, X=X, threshold=0.005)
+        assert a.equals(b)
+
+    def test_output_passes_schema(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        out = sf.prune_by_variance(df_feat=df_feat, X=X, threshold=0.005)
+        ut.check_df_feat(df_feat=out)  # #18 schema contract
+
+    # --- negative cases (one per parameter) ---
+    def test_invalid_df_feat(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        for bad in [None, pd.DataFrame(), "x", df_feat.drop(columns=[ut.COL_FEATURE])]:
+            with pytest.raises(Exception):
+                sf.prune_by_variance(df_feat=bad, df_parts=df_parts)
+
+    def test_invalid_threshold(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        for bad in [-0.1, "x", None]:
+            with pytest.raises(Exception):
+                sf.prune_by_variance(df_feat=df_feat, X=X, threshold=bad)
+
+    def test_invalid_X_shape(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        for bad in [X[:, :-1], X[:, 0], np.full((X.shape[0], X.shape[1]), np.nan)]:
+            with pytest.raises(ValueError):
+                sf.prune_by_variance(df_feat=df_feat, X=bad)
+
+    def test_missing_df_parts_and_X(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        with pytest.raises(Exception):
+            sf.prune_by_variance(df_feat=df_feat)
+
+    def test_empty_result_raises(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        with pytest.raises(ValueError):
+            sf.prune_by_variance(df_feat=df_feat, X=X, threshold=1e9)
+
+
+class TestPruneByVarianceComplex:
+    """Cross-parameter cases for prune_by_variance."""
+
+    @settings(max_examples=6, deadline=None)
+    @given(k=some.integers(min_value=1, max_value=5))
+    def test_k_injected_constants_dropped(self, fitted, k):
+        sf, df_feat, df_parts, X = fitted
+        k = min(k, len(df_feat) - 1)
+        X2 = X.copy()
+        X2[:, :k] = 0.123  # first k columns constant
+        out = sf.prune_by_variance(df_feat=df_feat, X=X2, threshold=0.0)
+        assert len(out) == len(df_feat) - k
+        # exactly the constant features (the first k after build order) are gone
+        dropped = set(df_feat[ut.COL_FEATURE].iloc[:k])
+        assert dropped.isdisjoint(set(out[ut.COL_FEATURE]))
+
+    def test_accept_gaps_passthrough(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        out = sf.prune_by_variance(df_feat=df_feat, df_parts=df_parts,
+                                   threshold=0.0, accept_gaps=True)
+        assert isinstance(out, pd.DataFrame)
+
+
+class TestPruneByVarianceGoldenValues:
+    """KPI: threshold 0 removes EXACTLY the zero-variance columns and leaves all others."""
+
+    def test_threshold_zero_removes_exactly_constants(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        rng = np.random.default_rng(0)
+        const_idx = sorted(rng.choice(len(df_feat), size=3, replace=False).tolist())
+        X2 = X.copy()
+        for j in const_idx:
+            X2[:, j] = 7.0  # constant value
+        out = sf.prune_by_variance(df_feat=df_feat, X=X2, threshold=0.0)
+        kept_feats = set(out[ut.COL_FEATURE])
+        const_feats = set(df_feat[ut.COL_FEATURE].iloc[const_idx])
+        non_const_feats = set(df_feat[ut.COL_FEATURE]) - const_feats
+        assert kept_feats == non_const_feats  # exactly the constants removed
+
+
+# ======================================================================================
+# prune_by_correlation
+# ======================================================================================
+class TestPruneByCorrelation:
+    """Normal cases for prune_by_correlation (one parameter per test)."""
+
+    def test_returns_df_feat(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        out = sf.prune_by_correlation(df_feat=df_feat, df_parts=df_parts)
+        assert isinstance(out, pd.DataFrame)
+        assert list(out.columns) == list(df_feat.columns)
+
+    @settings(max_examples=8, deadline=None)
+    @given(max_cor=some.floats(min_value=0.1, max_value=0.99))
+    def test_guarantee_no_pair_above_threshold(self, fitted, max_cor):
+        sf, df_feat, df_parts, X = fitted
+        out = sf.prune_by_correlation(df_feat=df_feat, X=X, max_cor=max_cor)
+        Xk = X[:, [df_feat[ut.COL_FEATURE].tolist().index(f) for f in out[ut.COL_FEATURE]]]
+        assert _max_abs_offdiag_corr(Xk) <= max_cor + 1e-9
+
+    def test_sorted_by_abs_auc_desc(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        out = sf.prune_by_correlation(df_feat=df_feat, X=X, max_cor=0.7)
+        aucs = out[ut.COL_ABS_AUC].to_numpy()
+        assert np.all(np.diff(aucs) <= 1e-12)  # non-increasing
+
+    def test_reset_index(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        out = sf.prune_by_correlation(df_feat=df_feat, X=X, max_cor=0.5)
+        assert list(out.index) == list(range(len(out)))
+
+    def test_x_passthrough_matches_df_parts(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        a = sf.prune_by_correlation(df_feat=df_feat, df_parts=df_parts, max_cor=0.6)
+        b = sf.prune_by_correlation(df_feat=df_feat, X=X, max_cor=0.6)
+        assert a.equals(b)
+
+    def test_lower_max_cor_prunes_more(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        loose = sf.prune_by_correlation(df_feat=df_feat, X=X, max_cor=0.9)
+        tight = sf.prune_by_correlation(df_feat=df_feat, X=X, max_cor=0.3)
+        assert len(tight) <= len(loose)
+
+    def test_single_feature_noop(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        out = sf.prune_by_correlation(df_feat=df_feat.head(1), df_parts=df_parts)
+        assert len(out) == 1
+
+    def test_output_passes_schema(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        out = sf.prune_by_correlation(df_feat=df_feat, X=X, max_cor=0.5)
+        ut.check_df_feat(df_feat=out)
+
+    # --- negative cases (one per parameter) ---
+    def test_invalid_df_feat(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        for bad in [None, pd.DataFrame(), "x"]:
+            with pytest.raises(Exception):
+                sf.prune_by_correlation(df_feat=bad, df_parts=df_parts)
+
+    def test_invalid_max_cor(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        for bad in [-0.1, 1.5, "x", None]:
+            with pytest.raises(Exception):
+                sf.prune_by_correlation(df_feat=df_feat, X=X, max_cor=bad)
+
+    def test_invalid_X_shape(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        for bad in [X[:, :-1], np.full((X.shape[0], X.shape[1]), np.nan)]:
+            with pytest.raises(ValueError):
+                sf.prune_by_correlation(df_feat=df_feat, X=bad)
+
+    def test_missing_df_parts_and_X(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        with pytest.raises(ValueError):
+            sf.prune_by_correlation(df_feat=df_feat)
+
+
+class TestPruneByCorrelationComplex:
+    """Cross-parameter and determinism cases for prune_by_correlation."""
+
+    def test_determinism_byte_identical(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        a = sf.prune_by_correlation(df_feat=df_feat, df_parts=df_parts, max_cor=0.7)
+        b = sf.prune_by_correlation(df_feat=df_feat, df_parts=df_parts, max_cor=0.7)
+        assert a.equals(b)
+        assert list(a[ut.COL_FEATURE]) == list(b[ut.COL_FEATURE])
+
+    def test_constant_columns_retained(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        X2 = X.copy()
+        X2[:, 0] = 0.5  # constant -> undefined corr -> retained, no spurious warning
+        out = sf.prune_by_correlation(df_feat=df_feat, X=X2, max_cor=0.5)
+        assert df_feat[ut.COL_FEATURE].iloc[0] in set(out[ut.COL_FEATURE])
+
+    def test_compose_variance_then_correlation(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        step1 = sf.prune_by_variance(df_feat=df_feat, df_parts=df_parts, threshold=0.0)
+        step2 = sf.prune_by_correlation(df_feat=step1, df_parts=df_parts, max_cor=0.5)
+        assert len(step2) <= len(step1) <= len(df_feat)
+        ut.check_df_feat(df_feat=step2)
+
+    def test_max_cor_one_keeps_all_non_constant(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        out = sf.prune_by_correlation(df_feat=df_feat, X=X, max_cor=1.0)
+        assert len(out) == len(df_feat)
+
+
+class TestPruneByCorrelationGoldenValues:
+    """KPI: deterministic abs_auc tie-break keeps the higher-abs_auc feature of a pair."""
+
+    def test_tie_break_keeps_higher_abs_auc(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        sub = df_feat.head(2).copy().reset_index(drop=True)
+        # Make the two feature columns perfectly correlated
+        col = X[:, 0].copy()
+        X2 = np.column_stack([col, col * 2.0 + 1.0])  # corr = 1.0
+        # Row 1 has the higher abs_auc -> it must be the survivor
+        sub.loc[0, ut.COL_ABS_AUC] = 0.10
+        sub.loc[1, ut.COL_ABS_AUC] = 0.90
+        out = sf.prune_by_correlation(df_feat=sub, X=X2, max_cor=0.7)
+        assert len(out) == 1
+        assert out[ut.COL_FEATURE].iloc[0] == sub[ut.COL_FEATURE].iloc[1]
+
+    def test_two_uncorrelated_both_kept(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        sub = df_feat.head(2).copy().reset_index(drop=True)
+        X2 = np.column_stack([np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+                              np.array([6.0, 1.0, 5.0, 2.0, 4.0, 3.0])])
+        out = sf.prune_by_correlation(df_feat=sub, X=X2, max_cor=0.7)
+        assert len(out) == 2


### PR DESCRIPTION
Closes #32 (narrowed scope: variance + correlation filtering only; model-based selection is `TreeModel.select_features`, ADR-0023, already shipped).

## What

Adds two model-free, post-hoc **feature pruning** methods on `SequenceFeature`, returning a row-filtered `df_feat` (same schema) that composes **before** `TreeModel.select_features`:

- **`prune_by_variance(df_feat, df_parts, threshold=0.0)`** — drops near-constant features (column variance over all samples `<= threshold`). Constant columns are detected by zero peak-to-peak range, so `threshold=0` removes **exactly** the constant features (robust to float epsilon).
- **`prune_by_correlation(df_feat, df_parts, max_cor=0.7)`** — drops empirically redundant features (`|corr| > max_cor` over the actual samples), keeping the higher-`abs_auc` feature; deterministic via `[abs_auc, abs_mean_dif]` ordering. Reuses the `NumericalFeature.filter_correlation` primitive.

Both build the feature matrix via `SequenceFeature.feature_matrix` or accept a precomputed `X` (covering `run_num` tables / build-once reuse).

## Key design point

`CPP.run` already redundancy-reduces internally, but on **scale-vector correlation** (`df_scales.corr()`) + position overlap — independent of any dataset. `prune_by_correlation` is **empirical** (sample-level), catching dataset-specific redundancy the in-run filter cannot. The two are complementary by design (ADR-0026).

## Acceptance criteria (issue #32 KPIs)

- ✅ Variance filter at threshold 0 removes exactly the zero-variance columns (golden test).
- ✅ Correlation filter at `t` guarantees no retained pair has `|corr| > t` (property test) and is byte-identical across runs (determinism test).
- ✅ Output passes the `df_feat` schema check (#18); ≥1 unit + property tests; example notebooks run.

## Changes

- Backend helper `_backend/num_feat/filter_variance.py::filter_variance_`.
- `SequenceFeature.prune_by_variance` / `prune_by_correlation` (numpydoc, named Returns, per-method Examples includes).
- 32 tests (unit + hypothesis property + determinism + golden), house hygiene template.
- Two example notebooks under `examples/feature_engineering/` (executed outputs).
- `CONTEXT.md` feature-pruning glossary; **ADR-0026**.

No new public symbols (additive methods on an exported class) → outside CONFIRM-FIRST; no new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)