### PR TITLE
chore: prune param-coverage, backend-import guard, agentic-engineering docs

### DIFF
--- a/.claude/rules/frontend-backend.md
+++ b/.claude/rules/frontend-backend.md
@@ -48,3 +48,22 @@ Rules:
   between intermediate arrays". Use `ValueError` for invariants traceable
   to user input, `RuntimeError` for invariants that indicate an internal
   bug.
+
+## Backend module ownership (no cross-class imports)
+
+Backend code is organized as **dedicated subpackages** (`_backend/<subpkg>/`,
+private to one class — e.g. `_backend/num_feat/` is NumericalFeature's,
+`_backend/aaclust/` is AAclust's) plus **shared** modules at the top level of
+`_backend/` (`check_feature.py`, `cpp_run.py`, `feature_filter.py`, …) and the
+deliberately shared `_backend/cpp/` package.
+
+Rule: **a frontend imports backend helpers only from a shared module or from its
+own dedicated subpackage — never from another class's dedicated subpackage.** If
+two frontends need the same helper, it is shared by definition: move it to a
+common top-level `_backend/*.py` and have both import from there. (Concrete
+example: `filter_correlation_` / `filter_variance_` live in
+`_backend/feature_filter.py`, imported by both NumericalFeature and
+SequenceFeature; neither reaches into the other's subpackage.)
+
+Enforced by `tests/unit/api_tests/test_backend_import_hygiene.py` — extend its
+`DEDICATED_OWNERS` map when adding a new dedicated backend subpackage.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,3 +109,9 @@ highest-risk traps worth keeping front-of-mind every session.
 - **No bare `except Exception:` to silence errors.** Let them surface.
 - **No custom exception base** (`AAanalysisError` etc.) — use bare
   `ValueError` / `RuntimeError`.
+- **No cross-class backend imports.** A frontend imports backend helpers only
+  from a shared `_backend/*.py` module (top-level) or its *own* dedicated
+  `_backend/<subpkg>/` — never from another class's dedicated subpackage (e.g.
+  `SequenceFeature` reaching into `_backend/num_feat/`). Put shared helpers in a
+  common `_backend/*.py`. Enforced by
+  `tests/unit/api_tests/test_backend_import_hygiene.py`.

--- a/README.rst
+++ b/README.rst
@@ -122,6 +122,26 @@ We appreciate bug reports, feature requests, or updates on documentation and cod
 `Contributing Guidelines <CONTRIBUTING.rst>`_. These include specifics about AAanalysis and also notes on Test
 Guided Development (TGD) using ChatGPT. For further questions or suggestions, please email stephanbreimann@gmail.com.
 
+Agentic engineering
+===================
+AAanalysis is developed with AI-assisted ("agentic") workflows. Their durable artifacts — not ephemeral
+planning notes — are the single sources of truth:
+
+- **Issue triage & planning.** ``/github-issue-handoff`` audits every open issue against the coding
+  standards and writes one prioritized plan to ``docs/guides/handoff_github_issues.md`` (refreshed on
+  demand). Per-issue scratch files are **not** committed.
+- **Spec & design.** ``/grill-with-docs`` interviews the contributor to resolve each design decision and
+  sharpen terminology against the project glossary. Decisions that are hard to reverse are recorded as
+  **Architecture Decision Records** (``docs/adr/``); the domain vocabulary lives in **CONTEXT.md**; the
+  transient implementation plan stays outside the repo.
+- **Standards & guardrails.** Implementation rules live in ``CLAUDE.md`` and the path-scoped files under
+  ``.claude/rules/`` (frontend/backend split, docstrings, testing, reproducibility, …) and are backed by
+  meta-tests — e.g. per-parameter test coverage and backend-import hygiene
+  (``tests/unit/api_tests/``).
+
+So the authoritative record of *why* the code looks the way it does is the **ADRs + CONTEXT.md +
+CLAUDE.md/.claude/rules**, kept in sync as decisions are made.
+
 Citations
 =========
 If you use AAanalysis in your work, please cite the respective publication as follows:

--- a/examples/feature_engineering/sf_prune_by_correlation.ipynb
+++ b/examples/feature_engineering/sf_prune_by_correlation.ipynb
@@ -2,22 +2,22 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "af0cb98d",
+   "id": "07804e39",
    "metadata": {},
    "source": [
-    ":meth:`SequenceFeature.prune_by_correlation` removes **empirically redundant** features: among features whose realized values are pairwise correlated beyond ``max_cor``, it keeps the one with the higher ``abs_auc`` and drops the others. The correlation is measured over the actual samples, which makes it complementary to CPP's in-run redundancy reduction (that one compares the underlying scale vectors). Use it after :meth:`SequenceFeature.prune_by_variance` and before :meth:`TreeModel.select_features`."
+    ":meth:`SequenceFeature.prune_by_correlation` removes **empirically redundant** features: among features whose realized values are pairwise correlated beyond ``max_cor``, it keeps the one with the higher ``abs_auc`` and drops the others. The correlation is measured over the actual samples, making it complementary to CPP's in-run redundancy reduction (which compares scale vectors). Use it after :meth:`SequenceFeature.prune_by_variance` and before :meth:`TreeModel.select_features`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "f582a911",
+   "id": "923a6035",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T23:03:12.461969Z",
-     "iopub.status.busy": "2026-06-10T23:03:12.461734Z",
-     "iopub.status.idle": "2026-06-10T23:03:18.530047Z",
-     "shell.execute_reply": "2026-06-10T23:03:18.529744Z"
+     "iopub.execute_input": "2026-06-11T09:49:56.386067Z",
+     "iopub.status.busy": "2026-06-11T09:49:56.385913Z",
+     "iopub.status.idle": "2026-06-11T09:50:01.895255Z",
+     "shell.execute_reply": "2026-06-11T09:50:01.895005Z"
     }
    },
    "outputs": [
@@ -36,29 +36,31 @@
     "df_seq = aa.load_dataset(name=\"DOM_GSEC\", n=20)\n",
     "labels = df_seq[\"label\"].to_list()\n",
     "sf = aa.SequenceFeature()\n",
-    "df_parts = sf.get_df_parts(df_seq=df_seq)\n",
+    "# gamma-secretase geometry: the TMD (~20 aa) comes from each protein's tmd_start/tmd_stop,\n",
+    "# flanked by short juxtamembrane domains of 4 residues each.\n",
+    "df_parts = sf.get_df_parts(df_seq=df_seq, jmd_n_len=4, jmd_c_len=4)\n",
     "df_feat = aa.CPP(df_parts=df_parts).run(labels=labels, n_filter=50)\n",
     "print(f\"features from CPP.run: {len(df_feat)}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "799fdd16",
+   "id": "8c69aed0",
    "metadata": {},
    "source": [
-    "At ``max_cor=0.7`` no retained pair of features has an absolute correlation above 0.7. The output is sorted by descending ``abs_auc`` and is deterministic across runs:"
+    "At ``max_cor=0.7`` no retained pair of features has absolute correlation above 0.7. The output is sorted by descending ``abs_auc`` and is deterministic across runs:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "f864725d",
+   "id": "f5b0378b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T23:03:18.531349Z",
-     "iopub.status.busy": "2026-06-10T23:03:18.531212Z",
-     "iopub.status.idle": "2026-06-10T23:03:18.554275Z",
-     "shell.execute_reply": "2026-06-10T23:03:18.554039Z"
+     "iopub.execute_input": "2026-06-11T09:50:01.896593Z",
+     "iopub.status.busy": "2026-06-11T09:50:01.896449Z",
+     "iopub.status.idle": "2026-06-11T09:50:01.917473Z",
+     "shell.execute_reply": "2026-06-11T09:50:01.917269Z"
     }
    },
    "outputs": [
@@ -66,7 +68,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "kept 21 of 50 features\n"
+      "kept 12 of 50 features\n"
      ]
     },
     {
@@ -124,23 +126,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>TMD_C_JMD_C-PeriodicPattern(C,i+4/4,2)-BEGF750103</td>\n",
-       "      <td>Conformation</td>\n",
-       "      <td>β-turn</td>\n",
-       "      <td>β-turn</td>\n",
-       "      <td>Conformational parameter of beta-turn (Beghin-...</td>\n",
-       "      <td>0.409</td>\n",
-       "      <td>0.139</td>\n",
-       "      <td>-0.139</td>\n",
-       "      <td>0.098</td>\n",
-       "      <td>0.094</td>\n",
-       "      <td>0.000010</td>\n",
-       "      <td>0.011310</td>\n",
-       "      <td>23,27,31,35,39</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>TMD_C_JMD_C-Pattern(C,8,11,14)-ZIMJ680104</td>\n",
+       "      <td>TMD_C_JMD_C-Pattern(C,2,5,8)-ZIMJ680104</td>\n",
        "      <td>Energy</td>\n",
        "      <td>Isoelectric point</td>\n",
        "      <td>Isoelectric point</td>\n",
@@ -151,27 +137,27 @@
        "      <td>0.080</td>\n",
        "      <td>0.088</td>\n",
        "      <td>0.000013</td>\n",
-       "      <td>0.011349</td>\n",
-       "      <td>27,30,33</td>\n",
+       "      <td>0.005011</td>\n",
+       "      <td>33,36,39</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>TMD_C_JMD_C-Segment(14,15)-AURR980119</td>\n",
+       "      <td>Conformation</td>\n",
+       "      <td>α-helix (C-term, out)</td>\n",
+       "      <td>α-helix (C-terminal, outside)</td>\n",
+       "      <td>Normalized positional residue frequency at hel...</td>\n",
+       "      <td>0.392</td>\n",
+       "      <td>0.198</td>\n",
+       "      <td>0.198</td>\n",
+       "      <td>0.106</td>\n",
+       "      <td>0.178</td>\n",
+       "      <td>0.000022</td>\n",
+       "      <td>0.005877</td>\n",
+       "      <td>38</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>TMD_C_JMD_C-Pattern(C,10,14)-MUNV940102</td>\n",
-       "      <td>Energy</td>\n",
-       "      <td>Free energy (folding)</td>\n",
-       "      <td>Free energy (α-helix)</td>\n",
-       "      <td>Free energy in alpha-helical region (Munoz-Ser...</td>\n",
-       "      <td>0.391</td>\n",
-       "      <td>0.153</td>\n",
-       "      <td>-0.153</td>\n",
-       "      <td>0.067</td>\n",
-       "      <td>0.130</td>\n",
-       "      <td>0.000023</td>\n",
-       "      <td>0.012601</td>\n",
-       "      <td>27,31</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
        "      <td>TMD-Segment(10,11)-CHAM820102</td>\n",
        "      <td>Polarity</td>\n",
        "      <td>Hydrophobicity (interface)</td>\n",
@@ -183,48 +169,57 @@
        "      <td>0.050</td>\n",
        "      <td>0.130</td>\n",
        "      <td>0.000026</td>\n",
-       "      <td>0.012145</td>\n",
+       "      <td>0.006223</td>\n",
        "      <td>27,28</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>TMD-Pattern(C,4,8,11)-FUKS010106</td>\n",
+       "      <td>Composition</td>\n",
+       "      <td>Membrane proteins (MPs)</td>\n",
+       "      <td>Proteins of mesophiles (INT)</td>\n",
+       "      <td>Interior composition of amino acids in intrace...</td>\n",
+       "      <td>0.384</td>\n",
+       "      <td>0.219</td>\n",
+       "      <td>0.219</td>\n",
+       "      <td>0.166</td>\n",
+       "      <td>0.122</td>\n",
+       "      <td>0.000033</td>\n",
+       "      <td>0.006123</td>\n",
+       "      <td>20,23,27</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                                             feature      category  \\\n",
-       "0                      TMD-Pattern(C,4,8)-BEGF750101  Conformation   \n",
-       "1  TMD_C_JMD_C-PeriodicPattern(C,i+4/4,2)-BEGF750103  Conformation   \n",
-       "2          TMD_C_JMD_C-Pattern(C,8,11,14)-ZIMJ680104        Energy   \n",
-       "3            TMD_C_JMD_C-Pattern(C,10,14)-MUNV940102        Energy   \n",
-       "4                      TMD-Segment(10,11)-CHAM820102      Polarity   \n",
+       "                                   feature      category  \\\n",
+       "0            TMD-Pattern(C,4,8)-BEGF750101  Conformation   \n",
+       "1  TMD_C_JMD_C-Pattern(C,2,5,8)-ZIMJ680104        Energy   \n",
+       "2    TMD_C_JMD_C-Segment(14,15)-AURR980119  Conformation   \n",
+       "3            TMD-Segment(10,11)-CHAM820102      Polarity   \n",
+       "4         TMD-Pattern(C,4,8,11)-FUKS010106   Composition   \n",
        "\n",
-       "                  subcategory               scale_name  \\\n",
-       "0                     α-helix                  α-helix   \n",
-       "1                      β-turn                   β-turn   \n",
-       "2           Isoelectric point        Isoelectric point   \n",
-       "3       Free energy (folding)    Free energy (α-helix)   \n",
-       "4  Hydrophobicity (interface)  Free energy (interface)   \n",
+       "                  subcategory                     scale_name  \\\n",
+       "0                     α-helix                        α-helix   \n",
+       "1           Isoelectric point              Isoelectric point   \n",
+       "2       α-helix (C-term, out)  α-helix (C-terminal, outside)   \n",
+       "3  Hydrophobicity (interface)        Free energy (interface)   \n",
+       "4     Membrane proteins (MPs)   Proteins of mesophiles (INT)   \n",
        "\n",
        "                                   scale_description  abs_auc  abs_mean_dif  \\\n",
        "0  Conformational parameter of inner helix (Beghi...    0.444         0.299   \n",
-       "1  Conformational parameter of beta-turn (Beghin-...    0.409         0.139   \n",
-       "2         Isoelectric point (Zimmerman et al., 1968)    0.402         0.130   \n",
-       "3  Free energy in alpha-helical region (Munoz-Ser...    0.391         0.153   \n",
-       "4  Free energy of solution in water, kcal/mole (C...    0.389         0.169   \n",
+       "1         Isoelectric point (Zimmerman et al., 1968)    0.402         0.130   \n",
+       "2  Normalized positional residue frequency at hel...    0.392         0.198   \n",
+       "3  Free energy of solution in water, kcal/mole (C...    0.389         0.169   \n",
+       "4  Interior composition of amino acids in intrace...    0.384         0.219   \n",
        "\n",
-       "   mean_dif  std_test  std_ref  p_val_mann_whitney  p_val_fdr_bh  \\\n",
-       "0     0.299     0.090    0.196            0.000002      0.022853   \n",
-       "1    -0.139     0.098    0.094            0.000010      0.011310   \n",
-       "2     0.130     0.080    0.088            0.000013      0.011349   \n",
-       "3    -0.153     0.067    0.130            0.000023      0.012601   \n",
-       "4    -0.169     0.050    0.130            0.000026      0.012145   \n",
-       "\n",
-       "        positions  \n",
-       "0           23,27  \n",
-       "1  23,27,31,35,39  \n",
-       "2        27,30,33  \n",
-       "3           27,31  \n",
-       "4           27,28  "
+       "   mean_dif  std_test  std_ref  p_val_mann_whitney  p_val_fdr_bh positions  \n",
+       "0     0.299     0.090    0.196            0.000002      0.022853     23,27  \n",
+       "1     0.130     0.080    0.088            0.000013      0.005011  33,36,39  \n",
+       "2     0.198     0.106    0.178            0.000022      0.005877        38  \n",
+       "3    -0.169     0.050    0.130            0.000026      0.006223     27,28  \n",
+       "4     0.219     0.166    0.122            0.000033      0.006123  20,23,27  "
       ]
      },
      "execution_count": 2,
@@ -240,22 +235,22 @@
   },
   {
    "cell_type": "markdown",
-   "id": "da267036",
+   "id": "a7a2bc5a",
    "metadata": {},
    "source": [
-    "Lower ``max_cor`` to prune more aggressively. As with variance pruning, a pre-computed ``X`` can be supplied (``df_parts`` / ``df_scales`` then ignored), and ``accept_gaps`` / ``n_jobs`` are forwarded to the matrix build:"
+    "As with variance pruning, ``df_scales`` / ``accept_gaps`` / ``n_jobs`` configure the matrix build, and a pre-computed ``X`` (aligned column-for-column with ``df_feat``) can be supplied instead of ``df_parts``:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "a2d5cc47",
+   "id": "a581a4e7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T23:03:18.555591Z",
-     "iopub.status.busy": "2026-06-10T23:03:18.555506Z",
-     "iopub.status.idle": "2026-06-10T23:03:18.573717Z",
-     "shell.execute_reply": "2026-06-10T23:03:18.573481Z"
+     "iopub.execute_input": "2026-06-11T09:50:01.918485Z",
+     "iopub.status.busy": "2026-06-11T09:50:01.918430Z",
+     "iopub.status.idle": "2026-06-11T09:50:01.949557Z",
+     "shell.execute_reply": "2026-06-11T09:50:01.949365Z"
     }
    },
    "outputs": [
@@ -263,19 +258,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "max_cor=0.4 kept 2 features; max_cor=0.7 kept 21\n"
+      "via df_parts+params: 3 | via pre-computed X: 3\n"
      ]
     }
    ],
    "source": [
-    "X = sf.feature_matrix(features=df_feat, df_parts=df_parts, accept_gaps=False, n_jobs=1)\n",
-    "df_cor_tight = sf.prune_by_correlation(df_feat=df_feat, X=X, max_cor=0.4)\n",
-    "print(f\"max_cor=0.4 kept {len(df_cor_tight)} features; max_cor=0.7 kept {len(df_cor)}\")"
+    "df_scales = aa.load_scales()\n",
+    "df_cor_full = sf.prune_by_correlation(df_feat=df_feat, df_parts=df_parts, df_scales=df_scales,\n",
+    "                                      max_cor=0.5, accept_gaps=True, n_jobs=1)\n",
+    "X = sf.feature_matrix(features=df_feat, df_parts=df_parts)\n",
+    "df_cor_X = sf.prune_by_correlation(df_feat=df_feat, X=X, max_cor=0.5)\n",
+    "print(f\"via df_parts+params: {len(df_cor_full)} | via pre-computed X: {len(df_cor_X)}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "27f0381b",
+   "id": "a1283e59",
    "metadata": {},
    "source": [
     "The two pruners compose, and the result drops straight into model-based selection (:meth:`TreeModel.select_features`):"
@@ -284,13 +282,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "d8fef369",
+   "id": "58571f1e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T23:03:18.574757Z",
-     "iopub.status.busy": "2026-06-10T23:03:18.574684Z",
-     "iopub.status.idle": "2026-06-10T23:03:18.611276Z",
-     "shell.execute_reply": "2026-06-10T23:03:18.611049Z"
+     "iopub.execute_input": "2026-06-11T09:50:01.950655Z",
+     "iopub.status.busy": "2026-06-11T09:50:01.950570Z",
+     "iopub.status.idle": "2026-06-11T09:50:01.983499Z",
+     "shell.execute_reply": "2026-06-11T09:50:01.983263Z"
     }
    },
    "outputs": [
@@ -298,7 +296,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "variance -> correlation kept 5 of 50 features\n"
+      "variance -> correlation kept 3 of 50 features\n"
      ]
     },
     {
@@ -356,7 +354,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>TMD_C_JMD_C-Pattern(C,8,11,14)-ZIMJ680104</td>\n",
+       "      <td>TMD_C_JMD_C-Pattern(C,2,5,8)-ZIMJ680104</td>\n",
        "      <td>Energy</td>\n",
        "      <td>Isoelectric point</td>\n",
        "      <td>Isoelectric point</td>\n",
@@ -367,44 +365,12 @@
        "      <td>0.080</td>\n",
        "      <td>0.088</td>\n",
        "      <td>0.000013</td>\n",
-       "      <td>0.011349</td>\n",
-       "      <td>27,30,33</td>\n",
+       "      <td>0.005011</td>\n",
+       "      <td>33,36,39</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>TMD_C_JMD_C-PeriodicPattern(N,i+4/3,1)-AURR980108</td>\n",
-       "      <td>Conformation</td>\n",
-       "      <td>α-helix</td>\n",
-       "      <td>α-helix (N-terminal, inside)</td>\n",
-       "      <td>Normalized positional residue frequency at hel...</td>\n",
-       "      <td>0.385</td>\n",
-       "      <td>0.156</td>\n",
-       "      <td>0.156</td>\n",
-       "      <td>0.077</td>\n",
-       "      <td>0.105</td>\n",
-       "      <td>0.000031</td>\n",
-       "      <td>0.012681</td>\n",
-       "      <td>21,25,28,32,35,39</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>JMD_N_TMD_N-Segment(3,8)-NAKH920107</td>\n",
-       "      <td>Composition</td>\n",
-       "      <td>AA composition</td>\n",
-       "      <td>Membrane proteins (multi-spanning, EXT)</td>\n",
-       "      <td>AA composition of EXT of multi-spanning protei...</td>\n",
-       "      <td>0.366</td>\n",
-       "      <td>0.188</td>\n",
-       "      <td>0.188</td>\n",
-       "      <td>0.144</td>\n",
-       "      <td>0.094</td>\n",
-       "      <td>0.000074</td>\n",
-       "      <td>0.009765</td>\n",
-       "      <td>6,7</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>TMD_C_JMD_C-Pattern(C,8,12,15)-GEIM800103</td>\n",
+       "      <td>TMD_C_JMD_C-Pattern(C,2,6,9)-GEIM800103</td>\n",
        "      <td>Conformation</td>\n",
        "      <td>Unclassified (Conformation)</td>\n",
        "      <td>α-helix (β-proteins)</td>\n",
@@ -415,48 +381,33 @@
        "      <td>0.137</td>\n",
        "      <td>0.080</td>\n",
        "      <td>0.000104</td>\n",
-       "      <td>0.009706</td>\n",
-       "      <td>26,29,33</td>\n",
+       "      <td>0.005900</td>\n",
+       "      <td>32,35,39</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                                             feature      category  \\\n",
-       "0                      TMD-Pattern(C,4,8)-BEGF750101  Conformation   \n",
-       "1          TMD_C_JMD_C-Pattern(C,8,11,14)-ZIMJ680104        Energy   \n",
-       "2  TMD_C_JMD_C-PeriodicPattern(N,i+4/3,1)-AURR980108  Conformation   \n",
-       "3                JMD_N_TMD_N-Segment(3,8)-NAKH920107   Composition   \n",
-       "4          TMD_C_JMD_C-Pattern(C,8,12,15)-GEIM800103  Conformation   \n",
+       "                                   feature      category  \\\n",
+       "0            TMD-Pattern(C,4,8)-BEGF750101  Conformation   \n",
+       "1  TMD_C_JMD_C-Pattern(C,2,5,8)-ZIMJ680104        Energy   \n",
+       "2  TMD_C_JMD_C-Pattern(C,2,6,9)-GEIM800103  Conformation   \n",
        "\n",
-       "                   subcategory                               scale_name  \\\n",
-       "0                      α-helix                                  α-helix   \n",
-       "1            Isoelectric point                        Isoelectric point   \n",
-       "2                      α-helix             α-helix (N-terminal, inside)   \n",
-       "3               AA composition  Membrane proteins (multi-spanning, EXT)   \n",
-       "4  Unclassified (Conformation)                     α-helix (β-proteins)   \n",
+       "                   subcategory            scale_name  \\\n",
+       "0                      α-helix               α-helix   \n",
+       "1            Isoelectric point     Isoelectric point   \n",
+       "2  Unclassified (Conformation)  α-helix (β-proteins)   \n",
        "\n",
        "                                   scale_description  abs_auc  abs_mean_dif  \\\n",
        "0  Conformational parameter of inner helix (Beghi...    0.444         0.299   \n",
        "1         Isoelectric point (Zimmerman et al., 1968)    0.402         0.130   \n",
-       "2  Normalized positional residue frequency at hel...    0.385         0.156   \n",
-       "3  AA composition of EXT of multi-spanning protei...    0.366         0.188   \n",
-       "4  Alpha-helix indices for beta-proteins (Geisow-...    0.359         0.163   \n",
+       "2  Alpha-helix indices for beta-proteins (Geisow-...    0.359         0.163   \n",
        "\n",
-       "   mean_dif  std_test  std_ref  p_val_mann_whitney  p_val_fdr_bh  \\\n",
-       "0     0.299     0.090    0.196            0.000002      0.022853   \n",
-       "1     0.130     0.080    0.088            0.000013      0.011349   \n",
-       "2     0.156     0.077    0.105            0.000031      0.012681   \n",
-       "3     0.188     0.144    0.094            0.000074      0.009765   \n",
-       "4    -0.163     0.137    0.080            0.000104      0.009706   \n",
-       "\n",
-       "           positions  \n",
-       "0              23,27  \n",
-       "1           27,30,33  \n",
-       "2  21,25,28,32,35,39  \n",
-       "3                6,7  \n",
-       "4           26,29,33  "
+       "   mean_dif  std_test  std_ref  p_val_mann_whitney  p_val_fdr_bh positions  \n",
+       "0     0.299     0.090    0.196            0.000002      0.022853     23,27  \n",
+       "1     0.130     0.080    0.088            0.000013      0.005011  33,36,39  \n",
+       "2    -0.163     0.137    0.080            0.000104      0.005900  32,35,39  "
       ]
      },
      "execution_count": 4,
@@ -473,7 +424,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69a9a65e",
+   "id": "d40707b3",
    "metadata": {},
    "source": [
     "**What can go wrong?** A ``df_feat`` with fewer than two features has nothing to compare and is returned unchanged:"
@@ -482,13 +433,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "2277608f",
+   "id": "32e829b7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T23:03:18.612294Z",
-     "iopub.status.busy": "2026-06-10T23:03:18.612233Z",
-     "iopub.status.idle": "2026-06-10T23:03:18.614358Z",
-     "shell.execute_reply": "2026-06-10T23:03:18.614162Z"
+     "iopub.execute_input": "2026-06-11T09:50:01.984583Z",
+     "iopub.status.busy": "2026-06-11T09:50:01.984511Z",
+     "iopub.status.idle": "2026-06-11T09:50:01.986502Z",
+     "shell.execute_reply": "2026-06-11T09:50:01.986290Z"
     }
    },
    "outputs": [

--- a/examples/feature_engineering/sf_prune_by_variance.ipynb
+++ b/examples/feature_engineering/sf_prune_by_variance.ipynb
@@ -2,22 +2,22 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b11c1daf",
+   "id": "b73c55b5",
    "metadata": {},
    "source": [
-    "**Feature pruning** is the model-free, post-hoc reduction of a ``df_feat`` (here from :meth:`CPP.run`) before model-based selection. :meth:`SequenceFeature.prune_by_variance` drops near-constant features — those whose feature values barely change across the samples — measured on the feature matrix that :meth:`SequenceFeature.feature_matrix` builds from ``df_parts``. The recommended order is **variance -> correlation -> select_features**."
+    "**Feature pruning** is the model-free, post-hoc reduction of a ``df_feat`` (here from :meth:`CPP.run` on the gamma-secretase ``DOM_GSEC`` dataset) before model-based selection. :meth:`SequenceFeature.prune_by_variance` drops near-constant features — those whose feature values barely change across the samples — measured on the feature matrix that :meth:`SequenceFeature.feature_matrix` builds from ``df_parts``. Recommended order: **variance -> correlation -> select_features**."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "66a8a8ff",
+   "id": "8f2715cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T23:03:02.896304Z",
-     "iopub.status.busy": "2026-06-10T23:03:02.896223Z",
-     "iopub.status.idle": "2026-06-10T23:03:08.963331Z",
-     "shell.execute_reply": "2026-06-10T23:03:08.963081Z"
+     "iopub.execute_input": "2026-06-11T09:49:47.323408Z",
+     "iopub.status.busy": "2026-06-11T09:49:47.323073Z",
+     "iopub.status.idle": "2026-06-11T09:49:52.967394Z",
+     "shell.execute_reply": "2026-06-11T09:49:52.967103Z"
     }
    },
    "outputs": [
@@ -36,29 +36,31 @@
     "df_seq = aa.load_dataset(name=\"DOM_GSEC\", n=20)\n",
     "labels = df_seq[\"label\"].to_list()\n",
     "sf = aa.SequenceFeature()\n",
-    "df_parts = sf.get_df_parts(df_seq=df_seq)\n",
+    "# gamma-secretase geometry: the TMD (~20 aa) comes from each protein's tmd_start/tmd_stop,\n",
+    "# flanked by short juxtamembrane domains of 4 residues each.\n",
+    "df_parts = sf.get_df_parts(df_seq=df_seq, jmd_n_len=4, jmd_c_len=4)\n",
     "df_feat = aa.CPP(df_parts=df_parts).run(labels=labels, n_filter=50)\n",
     "print(f\"features from CPP.run: {len(df_feat)}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "fcc5dd7e",
+   "id": "f15621e0",
    "metadata": {},
    "source": [
-    "With the default ``threshold=0.0`` only strictly constant features are removed. The result is a row-filtered ``df_feat`` with the same schema:"
+    "With the default ``threshold=0.0`` only strictly constant features are removed (population variance over all samples; ``threshold`` is in variance units). The result is a row-filtered ``df_feat`` with the same schema:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "5b11bcf2",
+   "id": "e4b484b9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T23:03:08.964621Z",
-     "iopub.status.busy": "2026-06-10T23:03:08.964453Z",
-     "iopub.status.idle": "2026-06-10T23:03:08.987771Z",
-     "shell.execute_reply": "2026-06-10T23:03:08.987547Z"
+     "iopub.execute_input": "2026-06-11T09:49:52.968575Z",
+     "iopub.status.busy": "2026-06-11T09:49:52.968453Z",
+     "iopub.status.idle": "2026-06-11T09:49:52.988755Z",
+     "shell.execute_reply": "2026-06-11T09:49:52.988523Z"
     }
    },
    "outputs": [
@@ -140,6 +142,22 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
+       "      <td>TMD_C_JMD_C-Pattern(C,4,8,12)-CRAJ730103</td>\n",
+       "      <td>Conformation</td>\n",
+       "      <td>β-turn</td>\n",
+       "      <td>β-turn</td>\n",
+       "      <td>Normalized frequency of turn (Crawford et al.,...</td>\n",
+       "      <td>0.431</td>\n",
+       "      <td>0.251</td>\n",
+       "      <td>-0.251</td>\n",
+       "      <td>0.088</td>\n",
+       "      <td>0.143</td>\n",
+       "      <td>0.000003</td>\n",
+       "      <td>0.006359</td>\n",
+       "      <td>29,33,37</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
        "      <td>TMD_C_JMD_C-Pattern(N,4,8,12)-CRAJ730103</td>\n",
        "      <td>Conformation</td>\n",
        "      <td>β-turn</td>\n",
@@ -151,12 +169,12 @@
        "      <td>0.088</td>\n",
        "      <td>0.143</td>\n",
        "      <td>0.000003</td>\n",
-       "      <td>0.011128</td>\n",
+       "      <td>0.008903</td>\n",
        "      <td>24,28,32</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>TMD_C_JMD_C-Pattern(N,4,8,12)-MUNV940102</td>\n",
+       "      <th>4</th>\n",
+       "      <td>TMD_C_JMD_C-Pattern(C,4,8,12)-MUNV940102</td>\n",
        "      <td>Energy</td>\n",
        "      <td>Free energy (folding)</td>\n",
        "      <td>Free energy (α-helix)</td>\n",
@@ -167,64 +185,41 @@
        "      <td>0.056</td>\n",
        "      <td>0.097</td>\n",
        "      <td>0.000005</td>\n",
-       "      <td>0.009366</td>\n",
-       "      <td>24,28,32</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>TMD_C_JMD_C-PeriodicPattern(C,i+4/4,2)-BEGF750103</td>\n",
-       "      <td>Conformation</td>\n",
-       "      <td>β-turn</td>\n",
-       "      <td>β-turn</td>\n",
-       "      <td>Conformational parameter of beta-turn (Beghin-...</td>\n",
-       "      <td>0.409</td>\n",
-       "      <td>0.139</td>\n",
-       "      <td>-0.139</td>\n",
-       "      <td>0.098</td>\n",
-       "      <td>0.094</td>\n",
-       "      <td>0.000010</td>\n",
-       "      <td>0.011310</td>\n",
-       "      <td>23,27,31,35,39</td>\n",
+       "      <td>0.004132</td>\n",
+       "      <td>29,33,37</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                                             feature      category  \\\n",
-       "0                      TMD-Pattern(C,4,8)-BEGF750101  Conformation   \n",
-       "1              TMD_C_JMD_C-Pattern(N,4,8)-BEGF750101  Conformation   \n",
-       "2           TMD_C_JMD_C-Pattern(N,4,8,12)-CRAJ730103  Conformation   \n",
-       "3           TMD_C_JMD_C-Pattern(N,4,8,12)-MUNV940102        Energy   \n",
-       "4  TMD_C_JMD_C-PeriodicPattern(C,i+4/4,2)-BEGF750103  Conformation   \n",
+       "                                    feature      category  \\\n",
+       "0             TMD-Pattern(C,4,8)-BEGF750101  Conformation   \n",
+       "1     TMD_C_JMD_C-Pattern(N,4,8)-BEGF750101  Conformation   \n",
+       "2  TMD_C_JMD_C-Pattern(C,4,8,12)-CRAJ730103  Conformation   \n",
+       "3  TMD_C_JMD_C-Pattern(N,4,8,12)-CRAJ730103  Conformation   \n",
+       "4  TMD_C_JMD_C-Pattern(C,4,8,12)-MUNV940102        Energy   \n",
        "\n",
        "             subcategory             scale_name  \\\n",
        "0                α-helix                α-helix   \n",
        "1                α-helix                α-helix   \n",
        "2                 β-turn                 β-turn   \n",
-       "3  Free energy (folding)  Free energy (α-helix)   \n",
-       "4                 β-turn                 β-turn   \n",
+       "3                 β-turn                 β-turn   \n",
+       "4  Free energy (folding)  Free energy (α-helix)   \n",
        "\n",
        "                                   scale_description  abs_auc  abs_mean_dif  \\\n",
        "0  Conformational parameter of inner helix (Beghi...    0.444         0.299   \n",
        "1  Conformational parameter of inner helix (Beghi...    0.444         0.299   \n",
        "2  Normalized frequency of turn (Crawford et al.,...    0.431         0.251   \n",
-       "3  Free energy in alpha-helical region (Munoz-Ser...    0.422         0.148   \n",
-       "4  Conformational parameter of beta-turn (Beghin-...    0.409         0.139   \n",
+       "3  Normalized frequency of turn (Crawford et al.,...    0.431         0.251   \n",
+       "4  Free energy in alpha-helical region (Munoz-Ser...    0.422         0.148   \n",
        "\n",
-       "   mean_dif  std_test  std_ref  p_val_mann_whitney  p_val_fdr_bh  \\\n",
-       "0     0.299     0.090    0.196            0.000002      0.022853   \n",
-       "1     0.299     0.090    0.196            0.000002      0.045706   \n",
-       "2    -0.251     0.088    0.143            0.000003      0.011128   \n",
-       "3    -0.148     0.056    0.097            0.000005      0.009366   \n",
-       "4    -0.139     0.098    0.094            0.000010      0.011310   \n",
-       "\n",
-       "        positions  \n",
-       "0           23,27  \n",
-       "1           24,28  \n",
-       "2        24,28,32  \n",
-       "3        24,28,32  \n",
-       "4  23,27,31,35,39  "
+       "   mean_dif  std_test  std_ref  p_val_mann_whitney  p_val_fdr_bh positions  \n",
+       "0     0.299     0.090    0.196            0.000002      0.022853     23,27  \n",
+       "1     0.299     0.090    0.196            0.000002      0.045706     24,28  \n",
+       "2    -0.251     0.088    0.143            0.000003      0.006359  29,33,37  \n",
+       "3    -0.251     0.088    0.143            0.000003      0.008903  24,28,32  \n",
+       "4    -0.148     0.056    0.097            0.000005      0.004132  29,33,37  "
       ]
      },
      "execution_count": 2,
@@ -240,22 +235,22 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6d6b1eb",
+   "id": "9519758f",
    "metadata": {},
    "source": [
-    "Raise ``threshold`` to prune low-variance features more aggressively. The feature matrix can also be supplied directly via ``X`` (e.g. to reuse a matrix across several pruning calls, or to prune a :meth:`CPP.run_num` table); then ``df_parts`` / ``df_scales`` are ignored. ``accept_gaps`` and ``n_jobs`` are forwarded to the matrix build, and a custom ``df_scales`` can be passed:"
+    "The remaining parameters control how the feature matrix is built or let you reuse one. A custom ``df_scales`` overrides the default scale set; ``accept_gaps`` tolerates gapped parts; ``n_jobs`` parallelizes the build. A pre-computed ``X`` (column ``i`` = feature in row ``i``) skips the build entirely and also covers a :meth:`CPP.run_num` ``df_feat``:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "95e9879e",
+   "id": "a36bf4de",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T23:03:08.988889Z",
-     "iopub.status.busy": "2026-06-10T23:03:08.988801Z",
-     "iopub.status.idle": "2026-06-10T23:03:09.006953Z",
-     "shell.execute_reply": "2026-06-10T23:03:09.006673Z"
+     "iopub.execute_input": "2026-06-11T09:49:52.989804Z",
+     "iopub.status.busy": "2026-06-11T09:49:52.989729Z",
+     "iopub.status.idle": "2026-06-11T09:49:53.020659Z",
+     "shell.execute_reply": "2026-06-11T09:49:53.020453Z"
     }
    },
    "outputs": [
@@ -263,19 +258,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "threshold=0.01 kept 48 of 50 features\n"
+      "via df_parts+params: 50 | via pre-computed X: 50\n"
      ]
     }
    ],
    "source": [
-    "X = sf.feature_matrix(features=df_feat, df_parts=df_parts, accept_gaps=False, n_jobs=1)\n",
-    "df_var_strict = sf.prune_by_variance(df_feat=df_feat, X=X, threshold=0.01)\n",
-    "print(f\"threshold=0.01 kept {len(df_var_strict)} of {len(df_feat)} features\")"
+    "df_scales = aa.load_scales()\n",
+    "df_var_full = sf.prune_by_variance(df_feat=df_feat, df_parts=df_parts, df_scales=df_scales,\n",
+    "                                   threshold=0.005, accept_gaps=True, n_jobs=1)\n",
+    "X = sf.feature_matrix(features=df_feat, df_parts=df_parts)\n",
+    "df_var_X = sf.prune_by_variance(df_feat=df_feat, X=X, threshold=0.005)\n",
+    "print(f\"via df_parts+params: {len(df_var_full)} | via pre-computed X: {len(df_var_X)}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "78730812",
+   "id": "e2008e58",
    "metadata": {},
    "source": [
     "**What can go wrong?** A ``threshold`` above every feature's variance would remove all features, so it raises a ``ValueError`` rather than returning an empty table:"
@@ -284,13 +282,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "87ad2263",
+   "id": "60c3d080",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T23:03:09.008247Z",
-     "iopub.status.busy": "2026-06-10T23:03:09.008172Z",
-     "iopub.status.idle": "2026-06-10T23:03:09.010348Z",
-     "shell.execute_reply": "2026-06-10T23:03:09.010141Z"
+     "iopub.execute_input": "2026-06-11T09:49:53.021904Z",
+     "iopub.status.busy": "2026-06-11T09:49:53.021827Z",
+     "iopub.status.idle": "2026-06-11T09:49:53.024008Z",
+     "shell.execute_reply": "2026-06-11T09:49:53.023805Z"
     }
    },
    "outputs": [

--- a/tests/unit/api_tests/test_backend_import_hygiene.py
+++ b/tests/unit/api_tests/test_backend_import_hygiene.py
@@ -1,0 +1,73 @@
+"""Architecture guard: frontends must not import from another class's dedicated backend.
+
+A frontend module (``aaanalysis/<subpkg>/_<file>.py``) may import backend helpers only
+from a **shared** backend module (a top-level ``_backend/*.py`` or an explicitly shared
+subpackage) or from its **own** dedicated ``_backend/<subpkg>/`` package — never from a
+sibling class's dedicated backend subpackage. Shared helpers belong in a common
+``_backend/*.py`` module instead.
+
+This codifies the PR #110/#113 fix (``SequenceFeature`` had reached into
+``_backend/num_feat/``, NumericalFeature's dedicated backend). To extend the guard to a
+new dedicated backend subpackage, add it to ``DEDICATED_OWNERS`` below.
+"""
+import ast
+import pathlib
+
+import aaanalysis
+
+ROOT = pathlib.Path(aaanalysis.__file__).resolve().parent
+
+# Backend subpackages that are intentionally SHARED across frontends of a subpackage
+# (any frontend in that subpackage may import them). Top-level ``_backend/*.py`` modules
+# are always treated as shared.
+SHARED_BACKEND_SUBPKGS = {
+    "feature_engineering": {"cpp"},  # the CPP feature backend is shared by CPP/SequenceFeature/...
+}
+
+# Dedicated backend subpackages -> the set of frontend module stems allowed to import them.
+DEDICATED_OWNERS = {
+    "feature_engineering": {
+        "num_feat": {"_numerical_feature"},
+        "aaclust": {"_aaclust", "_aaclust_plot"},
+    },
+}
+
+
+def _frontend_files(pkg_dir):
+    """Frontend modules of a subpackage (``_*.py`` directly under it, excluding dunders)."""
+    return [p for p in pkg_dir.glob("_*.py") if not p.name.startswith("__")]
+
+
+def _backend_subpkg_imports(py_file):
+    """Yield the ``_backend/<subpkg>`` subpackage names a file imports from (relative)."""
+    tree = ast.parse(py_file.read_text(), filename=str(py_file))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.level >= 1 and node.module:
+            parts = node.module.split(".")
+            if parts[0] == "_backend" and len(parts) >= 2:
+                yield parts[1]
+
+
+def test_no_cross_class_backend_imports():
+    violations = []
+    for pkg, owners in DEDICATED_OWNERS.items():
+        shared = SHARED_BACKEND_SUBPKGS.get(pkg, set())
+        for f in _frontend_files(ROOT / pkg):
+            for subpkg in _backend_subpkg_imports(f):
+                if subpkg in shared:
+                    continue
+                if subpkg in owners and f.stem not in owners[subpkg]:
+                    violations.append(
+                        f"{pkg}/{f.name} imports from dedicated '_backend/{subpkg}/' "
+                        f"(allowed only for {sorted(owners[subpkg])}). "
+                        f"Move shared helpers to a common '_backend/*.py' module."
+                    )
+    assert not violations, "Cross-class backend imports:\n" + "\n".join(violations)
+
+
+def test_owner_config_points_to_real_dirs():
+    """Guard against the config rotting: every configured subpackage must exist on disk."""
+    for pkg, owners in DEDICATED_OWNERS.items():
+        for subpkg in owners:
+            assert (ROOT / pkg / "_backend" / subpkg).is_dir(), \
+                f"DEDICATED_OWNERS references missing '_backend/{subpkg}/' in {pkg}"

--- a/tests/unit/sequence_feature_tests/test_sf_prune.py
+++ b/tests/unit/sequence_feature_tests/test_sf_prune.py
@@ -30,7 +30,8 @@ def fitted():
     df_seq = aa.load_dataset(name="DOM_GSEC", n=12)
     labels = df_seq["label"].to_list()
     sf = aa.SequenceFeature()
-    df_parts = sf.get_df_parts(df_seq=df_seq)
+    # gamma-secretase geometry: TMD ~20 aa (from the data), short JMDs of 4
+    df_parts = sf.get_df_parts(df_seq=df_seq, jmd_n_len=4, jmd_c_len=4)
     cpp = aa.CPP(df_parts=df_parts)
     df_feat = cpp.run(labels=labels, n_filter=40)
     X = sf.feature_matrix(features=df_feat, df_parts=df_parts)
@@ -124,6 +125,17 @@ class TestPruneByVariance:
         sf, df_feat, df_parts, X = fitted
         with pytest.raises(ValueError):
             sf.prune_by_variance(df_feat=df_feat, X=X, threshold=1e9)
+
+    def test_df_scales_passthrough(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        out = sf.prune_by_variance(df_feat=df_feat, df_parts=df_parts,
+                                   df_scales=ut.load_default_scales(), threshold=0.0)
+        ut.check_df_feat(df_feat=out)
+
+    def test_n_jobs_passthrough(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        out = sf.prune_by_variance(df_feat=df_feat, df_parts=df_parts, threshold=0.0, n_jobs=2)
+        assert len(out) == len(df_feat)
 
 
 class TestPruneByVarianceComplex:
@@ -242,6 +254,23 @@ class TestPruneByCorrelation:
         sf, df_feat, df_parts, X = fitted
         with pytest.raises(ValueError):
             sf.prune_by_correlation(df_feat=df_feat)
+
+    def test_df_scales_passthrough(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        out = sf.prune_by_correlation(df_feat=df_feat, df_parts=df_parts,
+                                      df_scales=ut.load_default_scales(), max_cor=0.7)
+        ut.check_df_feat(df_feat=out)
+
+    def test_n_jobs_passthrough(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        a = sf.prune_by_correlation(df_feat=df_feat, df_parts=df_parts, max_cor=0.7, n_jobs=1)
+        b = sf.prune_by_correlation(df_feat=df_feat, df_parts=df_parts, max_cor=0.7, n_jobs=2)
+        assert list(a[ut.COL_FEATURE]) == list(b[ut.COL_FEATURE])
+
+    def test_accept_gaps_passthrough(self, fitted):
+        sf, df_feat, df_parts, X = fitted
+        out = sf.prune_by_correlation(df_feat=df_feat, df_parts=df_parts, max_cor=0.7, accept_gaps=True)
+        assert isinstance(out, pd.DataFrame)
 
 
 class TestPruneByCorrelationComplex:


### PR DESCRIPTION
Follow-up hardening after the #32 feature-pruning work (review items).

## Tests — every prune parameter now covered by name
`test_sf_prune.py` previously missed `df_scales`, `n_jobs` (both methods) and `accept_gaps` (correlation). Added passthrough tests for each. The fixture now uses the documented **γ-secretase geometry** (`DOM_GSEC`, TMD ~20 aa from the data, JMDs of 4 via `get_df_parts(jmd_n_len=4, jmd_c_len=4)`).

## Examples — same geometry + full parameter coverage
Both prune notebooks rebuilt (executed outputs) using `DOM_GSEC` + JMD=4, with a cell exercising `df_scales` / `accept_gaps` / `n_jobs` / pre-computed `X`.

## Architecture guard (so the backend-import slip can't recur)
New `tests/unit/api_tests/test_backend_import_hygiene.py`: asserts no frontend imports from another class's dedicated `_backend/<subpkg>/` (codifies the #110/#113 fix). Explicit owner map; `cpp/` and top-level `_backend/*.py` are shared/exempt. Extend `DEDICATED_OWNERS` for new dedicated backends.

## Docs
- Backend-import rule added to `CLAUDE.md` anti-patterns + `.claude/rules/frontend-backend.md` (new "Backend module ownership" section).
- New **Agentic engineering** section in `README.rst` documenting the `github-issue-handoff → grill-with-docs → ADR/CONTEXT` workflow (no committed per-issue kickoffs).

Verification: prune + arch-guard + NumericalFeature.filter_correlation tests → **45 passed** locally; notebooks execute clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)