### PR TITLE
docs: agentic-engineering protocol + quality-gate reference

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -15,10 +15,11 @@ pytest tests -x -vv --durations=20
 pytest tests/unit/aa_window_sampler_tests/test_aa_window_sampler_synthetic.py -x -vv
 pytest tests/unit/aaclust_tests/test_aaclust_fit.py::TestAAclustFit::test_valid_min_th -x -vv
 
-# coverage (matches CI gate)
-pytest --cov=aaanalysis --cov-fail-under=70 tests
+# coverage (matches CI gate: test_coverage.yml uses --cov-fail-under=88)
+pytest --cov=aaanalysis --cov-fail-under=88 tests
 
-# run notebooks (matches CI gate)
+# run notebooks — LOCAL gate only (nbmake is NOT in blocking CI; re-run + re-commit
+# outputs before every push; RTD renders committed outputs but does not execute them)
 pytest --nbmake --nbmake-timeout=120 tutorials/ examples/
 
 # build docs
@@ -46,11 +47,23 @@ python dev_scripts/dev_aa_window_sampler.py
 ## Git / PR workflow
 
 - Branch names: `fix/...`, `feat/...`, `doc/...`, `refactor/...`.
+- **One isolated `git worktree` per task.** Pair every `git switch -c` with a
+  `git worktree add` so concurrent task streams never share one working tree /
+  `HEAD` — sharing a checkout lets commits land on the wrong branch and
+  uncommitted work bleed across tasks. Do the edits in the worktree, commit,
+  push, then `git worktree remove`.
 - Keep PRs small and focused; rebase on `master`.
 - Never merge if `pytest tests` fails on Linux *or* Windows. CI runs the
-  full matrix py 3.11–3.14.
+  full matrix py 3.10–3.14 on Linux; Windows brackets min+max (3.10 + 3.14),
+  with the full Windows range in the nightly.
+- **Issue lifecycle / `Closes #NN`.** A closing keyword
+  (`Closes`/`Fixes`/`Resolves #NN`) auto-closes the issue on merge to `master`
+  when it appears in **either the PR body or the merge (squash) commit
+  message**. To **keep an issue open through a merge, remove the keyword from
+  the PR body before merging** — editing only the commit message is not enough.
 - Update `CONTRIBUTING.rst`, any affected `examples/*.ipynb`, and (once it
   exists) `CHANGELOG.md` in the same PR; tutorials may follow in a separate
   PR but never on a different release.
 - Do not push or force-push without explicit approval (hard rule §0 in the
   root CLAUDE.md — scoped per-action, not per-session).
+- Full agentic workflow + all quality gates: `docs/guides/agentic_engineering.md`.

--- a/README.rst
+++ b/README.rst
@@ -142,6 +142,13 @@ planning notes — are the single sources of truth:
 So the authoritative record of *why* the code looks the way it does is the **ADRs + CONTEXT.md +
 CLAUDE.md/.claude/rules**, kept in sync as decisions are made.
 
+The loop for a single change is: pick the issue → ``/grill-with-docs`` (spec vs. reality) →
+branch in an isolated ``git worktree`` → implement → open a draft PR early → pass the automated
+quality gates → human review → merge → delete the branch. The full step-by-step protocol and the
+exact gate each change must clear (test matrix, ≥88 % coverage, RTD docs, architecture and
+parameter-coverage meta-tests, lint/security) are documented in
+`docs/guides/agentic_engineering.md <docs/guides/agentic_engineering.md>`_.
+
 Citations
 =========
 If you use AAanalysis in your work, please cite the respective publication as follows:

--- a/docs/guides/agentic_engineering.md
+++ b/docs/guides/agentic_engineering.md
@@ -1,0 +1,72 @@
+# Agentic engineering protocol
+
+How AAanalysis is developed with AI-assisted ("agentic") workflows — and, just as
+importantly, the **automated gates every change must pass before a human merges it**.
+The durable artifacts of this process (ADRs, `CONTEXT.md`, `CLAUDE.md` / `.claude/rules`,
+and the code) are the single sources of truth; per-issue planning notes are ephemeral and
+not committed.
+
+## Workflow (step by step)
+
+1. **Pick the issue.** No skill required. Optionally clean up or generate the issue wording
+   first with `/triage` or `/to-issues` (house style: `docs/guides/issue_style_guide.rst`).
+2. **`/grill-with-docs` — the highest-leverage step.** A custom command that sharpens the
+   spec against the *live* codebase and refreshes `CONTEXT.md` / ADRs **before any code is
+   written**. The closest built-in, `/init`, only (re)generates codebase docs — it does not
+   do the adversarial spec-vs-reality pass. Keep grill for the real work; use `/init` only as
+   a one-time bootstrap when `CONTEXT.md` does not exist yet.
+3. **Branch + isolated worktree.** `git switch -c <type>/<slug>` off `master` (plain git).
+   **Always pair it with `git worktree add` so each task gets its own checkout** — concurrent
+   streams then cannot contaminate each other (see Process notes → *Isolated worktrees*).
+4. **Implement.** Plan mode / the goal skill. Use a structured plan for multi-file or
+   architectural changes; drop to plain edits for trivial diffs. Plan mode is preferable when
+   you want to approve the approach before commits land.
+5. **Push → open PR.** `gh` / `git`. A PR needs ≥1 commit; push a scaffolding commit and open
+   a **draft PR early** so CI + the Read the Docs (RTD) preview run while you build.
+6. **Automated review gate (machine-enforced, not eyeballed).** Run `/review` (reviews the PR
+   diff) and `/security-review` (scans the pending diff for vulnerabilities). The quality gates
+   below must be green first. **Never merge red** — automated checks *gate* the human review,
+   they do not replace it.
+7. **Refine on the same branch.** Back to plan / goal mode; push more commits (the PR and the
+   RTD preview update automatically).
+8. **Keep current.** Periodically merge `master` → branch (plain git). A good fit for the
+   `/schedule` skill: auto-**sync** each morning so you wake to a synced branch or an early
+   conflict warning. **Schedule the sync only — never an auto-merge to master** (a scheduled
+   job can sync when clean but cannot resolve conflicts; it should just flag you).
+9. **Manual review → merge.** No skill, and that is correct: read the RTD preview + PR diff
+   (informed by the step-6 findings) and make the call with `gh pr merge`.
+10. **Delete the branch.** Plain git, with permission (root `CLAUDE.md` §0).
+
+## Quality gates — how AAanalysis checks each
+
+> **Rule: never merge red.** These automated checks gate the human review.
+
+| Gate | "Green" means | AAanalysis mechanism |
+|---|---|---|
+| **Tests** | full matrix passes | `.github/workflows/main.yml` ("Unit Tests"): `pytest tests -m "not regression" -x -n auto` on **Ubuntu py3.10–3.14** + **Windows py3.10 & 3.14** (Windows brackets min+max; the full Windows range and the `-m regression` exact-value CPP anchor run in the nightly — ADR-0015). |
+| **Coverage** | **≥ 88 %** line coverage, package-only | `.github/workflows/test_coverage.yml`: `pytest … --cov=aaanalysis --cov-fail-under=88` (+ Codecov `patch` / `project` / `project/cpp_core`). Measured on the package only (`--cov=aaanalysis`, never `--cov=./`) — ADR-0016. |
+| **Docs** | RTD builds; API + examples render | `docs/readthedocs.org` check: Sphinx + nbsphinx. `docs/source/conf.py` runs `export_example_notebooks_to_rst` with `nbsphinx_execute='never'` — it **renders committed notebook outputs, it does not execute them**. |
+| **Docstrings** | numpydoc shape, named `Returns`, per-method `Examples` include, no doc-vs-signature drift | the `/docstrings` skill: `check_docstrings.py`, `doc_signature_drift.py`, `check_example_notebooks.py` under `.claude/skills/docstrings/scripts/`. **Local gate** (not yet a CI job). |
+| **Notebooks execute** | every `examples/` + `tutorials/` notebook runs clean with embedded outputs | `pytest --nbmake --nbmake-timeout=120 examples/ tutorials/`. **Local gate only — NOT in blocking CI.** Re-run and re-commit outputs before every push (see Process notes). |
+| **Architecture** | matches `CONTEXT.md` / ADRs; no cross-class backend imports or layering violations | machine: `tests/unit/api_tests/test_backend_import_hygiene.py` (runs inside `pytest tests`). Spec / ADR conformance is human + `/grill-with-docs`. |
+| **Parameter coverage** | every public parameter is exercised by name in tests | `tests/unit/api_tests/test_param_coverage.py` — **landing via PR #111**; not yet on master. |
+| **Lint (errors)** | no syntax errors / undefined names | `.github/workflows/codeql_analysis.yml` ("code-quality" job): `flake8 . --select=E9,F63,F7,F82`. |
+| **Style / types (full)** | black (88) / isort / flake8 (88) / mypy clean | **manual at review** — no pre-commit, ruff, or type-checker in CI (v2 target; `.claude/rules/sharp-edges.md`). |
+| **Security** | CodeQL clean | `.github/workflows/codeql_analysis.yml` ("Analyze" job). No separate dependency-scan PR gate yet — worth adding. |
+| **Issue linkage** | the PR's lifecycle keyword is set per policy | `Closes #NN` in the **PR body** (see Process notes → *Issue lifecycle*). |
+
+## Process notes (hard-won)
+
+- **Isolated worktrees per task.** Create a `git worktree` per branch so two concurrent
+  streams never share one working tree / `HEAD`. Sharing a single checkout caused commits to
+  land on the wrong branch and uncommitted work to bleed across tasks. A worktree also lets you
+  build and verify one branch without disturbing another in-flight branch — do the edits in the
+  worktree, commit, push, then `git worktree remove`.
+- **Issue lifecycle — `Closes #NN`.** GitHub auto-closes a referenced issue on merge to the
+  default branch when a closing keyword (`Closes` / `Fixes` / `Resolves #NN`) appears in **either
+  the PR body or the merge (squash) commit message**. To **keep an issue open through a merge,
+  remove the keyword from the PR body before merging** — fixing only the commit-message text is
+  not enough. To auto-close, keep `Closes #NN` in the PR body.
+- **Notebooks are a local-only gate.** Because nbmake is not in blocking CI, a broken example
+  surfaces only on RTD (as wrong/un-rendered output) or in a local run. Always run
+  `pytest --nbmake examples/ tutorials/` and commit fresh outputs before pushing.


### PR DESCRIPTION
Documents the agentic development workflow and — the main ask — maps each quality gate to the **concrete AAanalysis mechanism** that enforces it.

## New: docs/guides/agentic_engineering.md
- Step-by-step workflow: pick issue → `/grill-with-docs` → branch in an isolated `git worktree` → implement → draft PR early → automated gates → review → merge → delete.
- **Quality-gate table** with the real mechanisms: `main.yml` matrix (Ubuntu py3.10–3.14 + Windows 3.10/3.14), `test_coverage.yml` `--cov-fail-under=88` + Codecov, RTD (renders committed notebook outputs, doesn't execute), the `/docstrings` skill scripts, `pytest --nbmake` (local-only), `test_backend_import_hygiene.py` (architecture), `test_param_coverage.py` (incoming via #111), CodeQL + flake8 error subset, manual full lint/types.

## Process notes (your two)
- **`Closes #NN` lifecycle:** a closing keyword in *either* the PR body or the squash commit auto-closes the issue — to keep one open, drop it from the **PR body** before merging.
- **One isolated `git worktree` per task** to prevent cross-stream tangles.

## Fixes to stale `workflow.md`
- coverage gate `70 → 88`; matrix `3.11 → 3.10–3.14`; "notebooks match CI gate" corrected to **local-only** (nbmake is not in blocking CI).

README's *Agentic engineering* section now links the full guide. RST parses clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)