### PR TITLE
docs(sequence-feature): document split-bound caps + guardrail tests (#78)

### DIFF
--- a/aaanalysis/feature_engineering/_sequence_feature.py
+++ b/aaanalysis/feature_engineering/_sequence_feature.py
@@ -381,7 +381,7 @@ class SequenceFeature:
         n_split_min: int, default=1
             Number to specify the greatest ``Segment``. Should be > 0.
         n_split_max: int, default=15,
-            Number to specify the smallest ``Segment``. Should be > ``n_split_min``.
+            Number to specify the smallest ``Segment``. Should be >= ``n_split_min``.
         steps_pattern: list of int, default=[3, 4], optional
             Possible steps sizes for ``Pattern``. Should contain at least 1 non-negative integers
             if ``Pattern`` split_type is used. If ``None``, default is used.
@@ -404,6 +404,24 @@ class SequenceFeature:
             - Segment: {n_split_min:1, n_split_max=15}
             - Pattern: {steps=[3, 4], n_min=2, n_max=4, len_max=15}
             - PeriodicPattern: {steps=[3, 4]}
+
+        Notes
+        -----
+        The split bounds returned here are validated for internal consistency
+        (e.g., ``n_split_min <= n_split_max``, ``n_min <= n_max``,
+        ``len_max > min(steps_pattern)``); inconsistent values raise a ``ValueError``.
+
+        Beyond that, the *feasible* maxima are effectively capped by the CPP part
+        lengths used to build ``df_parts`` (``tmd_len``, ``jmd_n_len``, ``jmd_c_len``;
+        defaults 20/10/10): a ``Segment`` cannot be split into more pieces than its
+        part has residues, and a ``Pattern``/``PeriodicPattern`` cannot span beyond
+        the part length. Choosing ``n_split_max``, ``n_max``, or ``len_max`` larger
+        than a part can accommodate does not raise here — those splits simply yield
+        empty feature buckets downstream. The one config that is always degenerate
+        regardless of part length, an empty ``Pattern`` bucket where even the shortest
+        repeat exceeds ``len_max`` (``n_min * min(steps_pattern) > len_max``), emits a
+        ``UserWarning`` naming the offending parameters so it can be fixed by raising
+        ``len_max`` or lowering ``steps_pattern``/``n_min``.
 
         Examples
         --------

--- a/tests/unit/sequence_feature_tests/test_sf_get_split_kws.py
+++ b/tests/unit/sequence_feature_tests/test_sf_get_split_kws.py
@@ -108,7 +108,8 @@ class TestGetSplitKws:
     def test_invalid_n_split_max(self):
         """Test invalid 'n_split_max' values."""
         sf = aa.SequenceFeature()
-        with pytest.raises(ValueError):
+        # Joint constraint: the message names the offending 'n_split_min'/'n_split_max'
+        with pytest.raises(ValueError, match="n_split_min"):
             sf.get_split_kws(n_split_max=1, n_split_min=2)
         with pytest.raises(ValueError):
             sf.get_split_kws(n_split_max=0)
@@ -132,7 +133,8 @@ class TestGetSplitKws:
     def test_invalid_n_min_max(self):
         """Test invalid 'n_min' and 'n_max' values."""
         sf = aa.SequenceFeature()
-        with pytest.raises(ValueError):
+        # Joint constraint: the message names the offending 'n_min'/'n_max'
+        with pytest.raises(ValueError, match="n_min"):
             sf.get_split_kws(n_min=5, n_max=4)
         with pytest.raises(ValueError):
             sf.get_split_kws(n_min=0, n_max=3)
@@ -142,7 +144,8 @@ class TestGetSplitKws:
         sf = aa.SequenceFeature()
         with pytest.raises(ValueError):
             sf.get_split_kws(len_max=0)
-        with pytest.raises(ValueError):
+        # Joint constraint: the message names the offending 'len_max'
+        with pytest.raises(ValueError, match="len_max"):
             sf.get_split_kws(len_max=3, steps_pattern=[4, 5])
 
     def test_invalid_steps_periodicpattern(self):
@@ -261,3 +264,33 @@ class TestGetSplitKwsComplex:
             sf.get_split_kws(n_split_min=10, n_split_max=5, steps_pattern=[5, 2, 3], len_max=1)
         with pytest.raises(ValueError):
             sf.get_split_kws(split_types=["Invalid", "Segment"], n_min=4, n_max=3)
+
+
+class TestGetSplitKwsGoldenValues:
+    """Golden-value and warning regressions for get_split_kws."""
+
+    def test_default_output_unchanged(self):
+        """Default get_split_kws() output is frozen (dict-equality regression)."""
+        sf = aa.SequenceFeature()
+        expected = {
+            "Segment": {"n_split_min": 1, "n_split_max": 15},
+            "Pattern": {"steps": [3, 4], "n_min": 2, "n_max": 4, "len_max": 15},
+            "PeriodicPattern": {"steps": [3, 4]},
+        }
+        assert sf.get_split_kws() == expected
+
+    def test_empty_pattern_bucket_warns_once(self):
+        """A degenerate Pattern config (n_min*min(steps) > len_max) emits exactly one
+        UserWarning naming the offending parameters."""
+        sf = aa.SequenceFeature()
+        # pytest.warns records warnings even though tests/pytest.ini globally ignores
+        # "'Pattern' split config" UserWarnings, so the carve-out stays intact.
+        with pytest.warns(UserWarning) as record:
+            sf.get_split_kws(steps_pattern=[3], n_min=2, len_max=4, split_types="Pattern")
+        pattern_warnings = [
+            w for w in record
+            if issubclass(w.category, UserWarning) and "'Pattern' split config" in str(w.message)
+        ]
+        assert len(pattern_warnings) == 1
+        msg = str(pattern_warnings[0].message)
+        assert "len_max" in msg and "n_min" in msg and "steps" in msg


### PR DESCRIPTION
Closes #78

## Summary

Issue #78 asks `SequenceFeature.get_split_kws` to surface clear errors/warnings on
inconsistent or infeasible split bounds and to document how the maxima relate to CPP
part length. A grill-with-docs pass found the issue's premise was **largely stale**:
all four functional KPIs were already enforced.

The method ends with `check_split_kws(split_kws=split_kws)` (`_sequence_feature.py:434`),
and that **shared backend validator already enforces every joint constraint** plus the
Pattern warning:

| KPI | Status before this PR |
|---|---|
| `get_split_kws(n_split_min=10, n_split_max=2)` → `ValueError` | already raises (`check_feature.py:95-97`) |
| `n_min > n_max` → `ValueError` | already raises (`106-107`) |
| `len_max <= min(steps)` → `ValueError` | already raises (`113-115`) |
| empty-Pattern bucket → 1 `UserWarning` naming params | already fires (`127-130`) |
| valid default output unchanged | unchanged |

`check_split_kws` is the **shared** validator reached by `get_split_kws` (434),
`get_features` (938), **and `CPP.run` (`_cpp.py:362`)** — so requirement #4 ("does the
message reach CPP users?") was already satisfied: the check is upstream/shared.

So the remaining gaps were **docs + tests, not logic**:

### Docstring (`aaanalysis/feature_engineering/_sequence_feature.py`)
- Fix stale line: `n_split_max` "Should be > `n_split_min`" → "Should be **>=**" (the
  check allows equality).
- Add a **Notes** block: the feasible maxima are effectively capped by the CPP part
  lengths (`tmd_len`/`jmd_n_len`/`jmd_c_len`, defaults 20/10/10); over-large
  `n_split_max`/`n_max`/`len_max` yield empty feature buckets rather than erroring, and
  the always-degenerate empty-Pattern case (`n_min*min(steps) > len_max`) emits a
  `UserWarning`.

### Tests (`tests/unit/sequence_feature_tests/test_sf_get_split_kws.py`)
- Add `match=` to the three joint-constraint error tests so each asserts the offending
  parameter name (`n_split_min`, `n_min`, `len_max`).
- New `TestGetSplitKwsGoldenValues`: a default-output **dict-equality regression** and a
  `pytest.warns` test asserting **exactly one** empty-Pattern `UserWarning` naming the
  params.

## Deliberate deviation from the issue checklist

Issue #78 pre-ticked *"joint constraints in `check_match_*` helpers"* (frontend). We
**kept them in the shared `check_split_kws`** instead of adding duplicate frontend
helpers: it is the single validation point already reached by `get_split_kws`,
`get_features`, **and `CPP.run`**, so duplicating would violate DRY and the
backend-trusts-frontend single-validation spirit. This is exactly the "cross-reference if
the check belongs upstream" outcome requirement #4 invites. No error-message strings and
no `tests/pytest.ini` carve-out were changed.

## Local gates (all green)
- `pytest test_sf_get_split_kws.py -c tests/pytest.ini` → 22 passed
- `pytest tests -m "not regression" -n auto -c tests/pytest.ini` → 3538 passed, 6 skipped
- `check_docstrings.py _sequence_feature.py` → 0 defects
- `cd docs && make html` → build succeeded, no new warnings on `get_split_kws`

🤖 Generated with [Claude Code](https://claude.com/claude-code)