### PR TITLE
fix(tests): force UTF-8 when reading source files in backend-import-hygiene test

### DIFF
--- a/tests/unit/api_tests/test_backend_import_hygiene.py
+++ b/tests/unit/api_tests/test_backend_import_hygiene.py
@@ -40,7 +40,7 @@ def _frontend_files(pkg_dir):
 
 def _backend_subpkg_imports(py_file):
     """Yield the ``_backend/<subpkg>`` subpackage names a file imports from (relative)."""
-    tree = ast.parse(py_file.read_text(), filename=str(py_file))
+    tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom) and node.level >= 1 and node.module:
             parts = node.module.split(".")


### PR DESCRIPTION
## Problem

Windows CI fails in the blocking matrix with:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 18912
```

`tests/unit/api_tests/test_backend_import_hygiene.py` parsed each frontend module with `py_file.read_text()` (no `encoding`), so on Windows it used the `cp1252` default codec and choked on frontend files containing non-ASCII bytes (e.g. em-dashes in `_shap_model.py`, `_embed_preproc.py`).

This is the **same class of Windows-only failure** just fixed for `test_class_abbreviation_registry.py` (commit `67d6ad8`). That one surfaced first; this one was the next domino, masked by `pytest -x` stopping at the first failure.

## Fix

Add `encoding="utf-8"` to the `read_text()` call. All `aaanalysis/**/*.py` files are valid UTF-8, so this is the correct, sufficient cross-platform fix.

```python
tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
```

## Verification

- `pytest tests/unit/api_tests/test_backend_import_hygiene.py tests/unit/api_tests/test_class_abbreviation_registry.py` → 7 passed locally.
- The Windows jobs in this PR's CI exercise the previously-failing path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)