### PR TITLE
docs(agentic): slim protocol to 7 steps, add ripple checklist + docstring CI gate

### DIFF
--- a/.claude/skills/agentic-engineering/SKILL.md
+++ b/.claude/skills/agentic-engineering/SKILL.md
@@ -27,45 +27,78 @@ From root `CLAUDE.md` §0 — authorization is **per-action, never per-session**
 
 ## Steps
 
-1. **Pick the issue.** Optionally sharpen the wording first with `/triage` or `/to-issues`
-   (house style: `docs/guides/issue_style_guide.rst`). For "what next?", `/github-issue-handoff`
-   produces a prioritized, parallelization-aware plan.
-2. **`/grill-with-docs` — the highest-leverage step.** Sharpen the spec against the *live*
-   codebase and refresh `CONTEXT.md` / ADRs **before any code is written**. Do not skip to
-   implementation on anything non-trivial. (`/init` only bootstraps codebase docs when
-   `CONTEXT.md` is missing — it is not a substitute for the adversarial spec-vs-reality pass.)
-3. **Branch + isolated worktree.** `git switch -c <type>/<slug>` off `master`, **always paired
-   with `git worktree add`** so concurrent streams never share a checkout (`fix/`, `feat/`,
-   `doc/`, `refactor/`). Do the edits in the worktree; remove it (with permission) when done.
-   **Running parallel agents makes this mandatory:** a shared checkout lets one agent's
-   commit/push race another's inspection. Even when you can't use a worktree, re-check
-   `git status` immediately before committing, stage **explicit pathspecs only** (never a blind
-   `git add -A` / `git commit -a`), and never commit, revert, or discard changes you did not
-   make — stop and surface unexpected edits instead.
-4. **Implement.** Use plan mode for multi-file or architectural changes so the approach is
-   approved before commits land; drop to plain edits for trivial diffs. Honor the path-scoped
-   rules in `.claude/rules/` that auto-load for the files you touch.
-5. **Push → draft PR early.** A PR needs ≥1 commit: push a scaffolding commit and open a **draft
-   PR** so CI + the Read the Docs preview run while you build. (Push needs §0 go-ahead.)
-6. **Automated review gate.** Run `/review` (PR diff) and `/security-review` (vulnerability scan).
-   The quality gates in the canonical doc's table must be green first. **Never merge red** — these
-   gate the human review, they do not replace it.
-7. **Refine on the same branch.** Push more commits; the PR and RTD preview update automatically.
-8. **Keep current.** Periodically merge `master` → branch. Good fit for `/schedule`: an auto-**sync**
-   each morning. A scheduled job **syncs only** — it must never resolve conflicts or merge a branch
-   to `master` unattended; it just flags you.
-9. **Arm auto-merge.** Once step-6 is green and you've read the RTD preview + PR diff, enable
-   GitHub-native auto-merge: `gh pr merge --auto --squash`. GitHub merges the moment every required
-   check passes and the branch is conflict-free, so **"never merge red" still holds** — a red check
-   blocks the merge instead of completing it. Skip `--auto` and merge manually for a hard human gate.
-   *Arming auto-merge is a publish action → needs §0 go-ahead.*
-10. **Auto-fix red CI (fix-forward loop).** If GitHub Actions reports a failure (armed or not):
-    - `gh run watch` to follow live, or `gh run view --log-failed` for the failing logs.
-    - **Reproduce locally** before fixing — run the failing gate (see *Local gate commands*).
-    - Fix **forward on the same branch** and push. Armed auto-merge re-arms itself and completes
-      on the green re-run; do not re-issue the merge. Use `gh pr merge --disable-auto` to hold it.
-    - Loop until green. Don't paper over a real failure to force a merge — surface it.
-11. **Delete the branch + worktree.** Plain git, **with permission** (§0).
+Seven steps in three phases. **Full rationale + the quality-gates table live in
+`docs/guides/agentic_engineering.md`** — read it first; this checklist drives it.
+
+**Prepare**
+
+1. **Pick & sharpen the issue.** Optionally `/triage` or `/to-issues` for wording (house style:
+   `docs/guides/issue_style_guide.rst`); `/github-issue-handoff` for a prioritized "what next?" plan.
+2. **`/grill-with-docs`** — sharpen the spec against the *live* codebase and refresh `CONTEXT.md` /
+   ADRs **before any code**. Don't skip on anything non-trivial. (`/init` only bootstraps codebase
+   docs when `CONTEXT.md` is missing — not a substitute for the adversarial spec-vs-reality pass.)
+3. **Branch + isolated worktree.** `git switch -c <type>/<slug>` off `master`, **always paired with
+   `git worktree add`** (`fix/`, `feat/`, `doc/`, `refactor/`) so concurrent streams never share a
+   checkout. Even in a shared checkout, re-check `git status` before committing, stage **explicit
+   pathspecs only** (never a blind `git add -A` / `git commit -a`), and never commit, revert, or
+   discard changes you did not make — stop and surface unexpected edits instead.
+
+**Build**
+
+4. **Implement + open a draft PR early.** Plan mode for multi-file / architectural changes (approve
+   the approach before commits land); plain edits for trivial diffs. Honor the auto-loaded
+   `.claude/rules/` for the files you touch. A PR needs ≥1 commit: push a scaffolding commit and open
+   a **draft PR** so CI + the RTD preview run while you keep pushing to refine. (Push → §0 go-ahead.)
+   **Before a substantive push, run the fast local unit gate** (`pytest tests -m "not regression" -x
+   -n auto -c tests/pytest.ini`) — far faster than a red-CI round-trip. **No change is done until you
+   walk the Ripple checklist below** — the code edit usually lands with its mirrors *in the same PR*.
+5. **Automated review gate.** Run `/review` (PR diff) + `/security-review` (vulnerability scan); for a
+   substantial diff also `/code-review high` (or `ultra` for the deep cloud review) + `/simplify`, and
+   `/docstrings` when public API or docstrings change. The canonical doc's quality gates must be green.
+   **Never merge red** — these gate the human review, they do not replace it. *Meanwhile:* periodically
+   sync `master` → branch (`/schedule` fits) — **sync only**, never resolve conflicts or merge to
+   `master` unattended; it just flags you.
+
+**Merge & clean up**
+
+6. **Arm auto-merge; fix-forward on red.** Once green and you've read the RTD preview + PR diff:
+   `gh pr merge --auto --squash` (*a publish action → §0 go-ahead*). GitHub merges only on all-green
+   + conflict-free, so *never merge red* holds. On red CI: `gh run watch` / `gh run view --log-failed`
+   → **reproduce locally** (see *Local gate commands*) → fix **forward on the same branch** and push;
+   armed auto-merge re-arms and completes on the green re-run. `gh pr merge --disable-auto` to hold;
+   skip `--auto` for a hard human gate. Don't paper over a real failure to force a merge — surface it.
+7. **Clean up — gated on merge + a green `master` (with permission, §0).** Trigger off **merge
+   state, not a CI run**: wait until `gh pr view <n> --json state,mergedAt` shows `MERGED`, then
+   let the push-triggered `master` workflows pass (confirms the squash is clean). An intervening
+   push from any session just re-runs checks; armed auto-merge waits for the new green, so the
+   trigger survives. Confirm no work is lost (`git branch --merged master` lists it; worktree
+   `git status --porcelain` empty), then `git switch master` → `git worktree remove <path>`
+   (uncommitted work needs `--force` → also permission) → `git worktree prune` →
+   `git branch -d <branch>`; remote head branch auto-deletes on squash-merge if the repo setting
+   is on, else `git push origin --delete <branch>` (push → §0). A scheduled/unattended job may
+   *flag* "ready to clean up" but never deletes on its own (§0).
+
+## Ripple checklist (no change is done until its mirrors are in sync)
+
+A code edit almost always lands with its mirrors **in the same PR** (tutorials may trail, but never
+a different release). The package is heavily cross-referenced and meta-tested, so walk this when you
+touch code — full rationale + exact paths are in the guide's *Propagate every change* section:
+
+- **Docstrings** (numpydoc; citations → `references.rst`) — `/docstrings`, now blocking CI.
+- **Public API** — `aaanalysis/__init__.py` `__all__` (CONFIRM-FIRST); API ref + autosummary follow.
+- **Examples** — `examples/<abbr>_<method>.ipynb` (one per method, included in the docstring); cover
+  every param, re-run with executed outputs.
+- **Tutorials** — `tutorials/*.ipynb`; **Protocols** — `protocols/protocol<N>_*.ipynb` (workflow changes).
+- **Tests** — the change's unit tests **+** cross-file meta-tests: `test_param_coverage.py`,
+  `test_class_abbreviation_registry.py`, backend-import-hygiene, extras/stub parity.
+- **Cheat sheet** — `docs/_cheatsheet/content.py` (single source → regen html/pdf; public symbols only).
+- **Tables** — `docs/source/index/tables*.rst` via `create_tables_doc.py` (scales/datasets changes).
+- **Release notes** — `docs/source/index/release_notes.rst` (the changelog; *Unreleased* section).
+- **Contributing** — `CONTRIBUTING.rst` **+** its port `docs/source/index/CONTRIBUTING_COPY.rst`.
+- **Glossary / ADRs** — `CONTEXT.md`; `docs/adr/NNNN-*.md`. **Conventions** — `CLAUDE.md` / `.claude/rules/*`.
+- **Build / deps** — `pyproject.toml` / `config.py` (both CONFIRM-FIRST).
+
+Most surface late (stale cheat sheet, red meta-test, wrong RTD render), not in the fast unit job.
 
 ## Local gate commands (reproduce CI before fixing)
 
@@ -81,7 +114,9 @@ pytest --nbmake --nbmake-timeout=120 examples/ tutorials/               # Notebo
 ```
 
 `/docstrings` runs the docstring checkers (`check_docstrings.py`, `doc_signature_drift.py`,
-`check_example_notebooks.py`) — a local gate, not yet a CI job.
+`check_example_notebooks.py`). The first two are **blocking CI** in `codeql_analysis.yml`
+("code-quality" job); `check_example_notebooks` runs there **advisory (non-blocking)** until the
+remaining notebook param-coverage gaps are cleared. All three also run locally via this skill.
 
 ## Notes
 

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -59,3 +59,13 @@ jobs:
 
     - name: Run mypy (check static typing)
       run: mypy aaanalysis/__init__.py --follow-imports=skip
+
+    - name: Check docstring house style
+      run: python .claude/skills/docstrings/scripts/check_docstrings.py
+
+    - name: Check doc/signature drift
+      run: python .claude/skills/docstrings/scripts/doc_signature_drift.py
+
+    - name: Check example-notebook parameter coverage (advisory, non-blocking)
+      continue-on-error: true
+      run: python .claude/skills/docstrings/scripts/check_example_notebooks.py

--- a/docs/guides/agentic_engineering.md
+++ b/docs/guides/agentic_engineering.md
@@ -6,45 +6,112 @@ The durable artifacts of this process (ADRs, `CONTEXT.md`, `CLAUDE.md` / `.claud
 and the code) are the single sources of truth; per-issue planning notes are ephemeral and
 not committed.
 
-## Workflow (step by step)
+## Workflow
 
-1. **Pick the issue.** No skill required. Optionally clean up or generate the issue wording
-   first with `/triage` or `/to-issues` (house style: `docs/guides/issue_style_guide.rst`).
-2. **`/grill-with-docs` — the highest-leverage step.** A custom command that sharpens the
-   spec against the *live* codebase and refreshes `CONTEXT.md` / ADRs **before any code is
-   written**. The closest built-in, `/init`, only (re)generates codebase docs — it does not
-   do the adversarial spec-vs-reality pass. Keep grill for the real work; use `/init` only as
-   a one-time bootstrap when `CONTEXT.md` does not exist yet.
-3. **Branch + isolated worktree.** `git switch -c <type>/<slug>` off `master` (plain git).
-   **Always pair it with `git worktree add` so each task gets its own checkout** — concurrent
-   streams then cannot contaminate each other (see Process notes → *Isolated worktrees*).
-4. **Implement.** Plan mode. Use a structured plan for multi-file or architectural changes;
-   drop to plain edits for trivial diffs. Plan mode is preferable when you want to approve the
-   approach before commits land.
-5. **Push → open PR.** `gh` / `git`. A PR needs ≥1 commit; push a scaffolding commit and open
-   a **draft PR early** so CI + the Read the Docs (RTD) preview run while you build.
-6. **Automated review gate (machine-enforced, not eyeballed).** Run `/review` (reviews the PR
-   diff) and `/security-review` (scans the pending diff for vulnerabilities). The quality gates
-   below must be green first. **Never merge red** — automated checks *gate* the human review,
-   they do not replace it.
-7. **Refine on the same branch.** Back to plan mode; push more commits (the PR and the RTD
-   preview update automatically).
-8. **Keep current.** Periodically merge `master` → branch (plain git). A good fit for the
-   `/schedule` skill: auto-**sync** each morning so you wake to a synced branch or an early
-   conflict warning. **A scheduled job syncs only — it must never resolve conflicts or merge a
-   branch to `master` unattended; it just flags you.** (PR auto-merge in step 9 is a different,
-   safe mechanism — GitHub completes it only when checks are green *and* the branch merges cleanly.)
-9. **Arm auto-merge.** Once the step-6 review is green and you've read the RTD preview + PR diff,
-   enable GitHub-native auto-merge: `gh pr merge --auto --squash`. GitHub then merges the moment
-   every required check passes and the branch is conflict-free, so **"never merge red" still
-   holds** — a red check blocks the merge instead of completing it. For a hard human gate on a
-   given PR, skip `--auto` and merge manually once green.
-10. **Auto-fix red CI.** If GitHub Actions reports a failure (whether or not auto-merge is armed),
-    pull the failing logs (`gh run view --log-failed`, or `gh run watch` to follow live),
-    reproduce locally, fix **forward on the same branch**, and push. Armed auto-merge re-arms
-    itself and completes once the re-run is green — no need to re-issue the merge. Disarm with
-    `gh pr merge --disable-auto` if you need to hold the PR.
-11. **Delete the branch.** Plain git, with permission (root `CLAUDE.md` §0).
+Seven steps in three phases. Phases group the work; within the Build phase you iterate, so the
+order there is natural rather than rigid. The full rationale lives in this section; the
+`agentic-engineering` skill carries a one-line-per-step checklist that points back here.
+
+### Prepare
+
+1. **Pick & sharpen the issue.** No skill required to start. Optionally clean up or generate the
+   wording with `/triage` or `/to-issues` (house style: `docs/guides/issue_style_guide.rst`); for
+   "what next?", `/github-issue-handoff` produces a prioritized, parallelization-aware plan.
+2. **`/grill-with-docs` — the highest-leverage step.** Sharpen the spec against the *live*
+   codebase and refresh `CONTEXT.md` / ADRs **before any code is written**. The closest built-in,
+   `/init`, only (re)generates codebase docs — it does not do the adversarial spec-vs-reality
+   pass; use `/init` only as a one-time bootstrap when `CONTEXT.md` does not exist yet.
+3. **Branch + isolated worktree.** `git switch -c <type>/<slug>` off `master` (`fix/`, `feat/`,
+   `doc/`, `refactor/`), **always paired with `git worktree add`** so concurrent streams never
+   share a checkout (see Process notes → *Isolated worktrees*).
+
+### Build
+
+4. **Implement + open a draft PR early.** Use plan mode for multi-file or architectural changes
+   (approve the approach before commits land); drop to plain edits for trivial diffs. Honor the
+   path-scoped rules in `.claude/rules/` that auto-load for the files you touch. A PR needs ≥1
+   commit, so push a scaffolding commit and open a **draft PR** early — CI and the Read the Docs
+   (RTD) preview then run while you keep pushing to refine. **Before a substantive push, run the
+   fast local unit gate** (`pytest tests -m "not regression" -x -n auto -c tests/pytest.ini`) — a
+   local run catches the obvious break far faster than a red-CI round-trip. **No change is done
+   until you have walked the ripple checklist below** — a code edit almost always has to land
+   alongside its docstring, example, test, and other mirrors *in the same PR*.
+5. **Automated review gate (machine-enforced, not eyeballed).** Run `/review` (reviews the PR
+   diff) and `/security-review` (scans the pending diff for vulnerabilities); for a substantial
+   diff reach for `/code-review high` (or `ultra` for the deep cloud review) and `/simplify`, and
+   when public API or docstrings change run `/docstrings`. The quality gates below must be green.
+   **Never merge red** — automated checks *gate* the human review, they do not replace it.
+   *Meanwhile, as a background concern:* periodically merge `master` → branch to
+   stay current (a good fit for `/schedule`: auto-**sync** each morning so you wake to a synced
+   branch or an early conflict warning). **A scheduled job syncs only — it must never resolve
+   conflicts or merge a branch to `master` unattended; it just flags you.**
+
+### Merge & clean up
+
+6. **Arm auto-merge; fix-forward on red.** Once the review is green and you've read the RTD
+   preview + PR diff, enable GitHub-native auto-merge: `gh pr merge --auto --squash`. GitHub
+   merges the moment every required check passes and the branch is conflict-free, so **"never
+   merge red" still holds** — a red check blocks the merge instead of completing it. If CI goes
+   red, pull the failing logs (`gh run view --log-failed`, or `gh run watch` to follow live),
+   reproduce locally, and fix **forward on the same branch**; armed auto-merge re-arms itself and
+   completes on the green re-run. Disarm with `gh pr merge --disable-auto` to hold the PR, or skip
+   `--auto` for a hard human gate. Arming auto-merge is a publish action → needs the per-action
+   go-ahead in root `CLAUDE.md` §0.
+7. **Clean up — gated on merge + a green `master`.** Key cleanup off the **merge state, never a
+   single CI run**: once `gh pr view <n> --json state,mergedAt` shows `MERGED`, let the
+   push-triggered workflows on `master` run and **wait for them to pass** — that confirms the
+   squash didn't break anything the branch CI couldn't see (master may have moved under it). An
+   intervening push, from this session or another, just re-runs checks and armed auto-merge waits
+   for the *new* green, so the trigger survives the race. Then, **with permission (root
+   `CLAUDE.md` §0, per-action)** and after confirming no work is lost — `git branch --merged
+   master` lists the branch and `git status --porcelain` in the worktree is empty —
+   `git switch master` → `git worktree remove <path>` (a tree with uncommitted work needs
+   `--force`, which also needs permission) → `git worktree prune` → `git branch -d <branch>`. The
+   remote branch is auto-deleted by GitHub on squash-merge when the repo's "automatically delete
+   head branches" setting is on; otherwise `git push origin --delete <branch>` (a push → §0). A
+   scheduled/unattended job may *detect and flag* "ready to clean up" but must never delete on its
+   own (§0) — the same sync-only discipline as the step-5 background sync.
+
+## Propagate every change — the ripple checklist
+
+**No code change is complete until every surface that mirrors it is updated in the same PR**
+(tutorials may trail in a separate PR, but never a different release). The package is heavily
+cross-referenced — docstrings include example notebooks, the cheat sheet and tables are generated
+from the public API, meta-tests assert consistency across files — so "I only touched code" is
+almost never true. When you change code, walk this list and update what applies:
+
+- **Docstrings** — numpydoc on every changed class / method / function; new `[Key]_` citations go
+  in `docs/source/index/references.rst`, new conventions/abbreviations in `docstring_guide.rst`.
+  *Enforced:* the `/docstrings` checkers (now blocking CI).
+- **Public API** — `aaanalysis/__init__.py` `__all__` for any symbol added / removed / renamed
+  (**CONFIRM-FIRST**); the API reference (`docs/source/api.rst` + autosummary `generated/`) flows
+  from `__all__` + docstrings, so it updates with them.
+- **Examples** — `examples/<abbr>_<method>.ipynb` (one per public method, included into the
+  docstring via `.. include:: examples/<name>.rst`): cover every public parameter and re-run with
+  executed outputs (`aa.display_df(...)`, `plt.show()`).
+- **Tutorials** — `tutorials/*.ipynb` when the change alters a taught workflow.
+- **Protocols** — `protocols/protocol<N>_*.ipynb` when an end-to-end workflow changes
+  (`docs/guides/protocol_style_guide.md`); they render under *Examples : Protocols* on RTD.
+- **Tests** — unit tests for the change itself, plus the cross-file meta-tests that catch drift:
+  parameter coverage (`tests/unit/api_tests/test_param_coverage.py`), class-abbreviation registry
+  (`test_class_abbreviation_registry.py`), backend import hygiene, and the extras / missing-stub
+  parity tests.
+- **Cheat sheet** — `docs/_cheatsheet/content.py` (single source of truth → regenerate the html /
+  pdf); every snippet must use only public `__all__` symbols with real signatures.
+- **Tables** — `docs/source/index/tables*.rst` (generated by `docs/source/create_tables_doc.py`)
+  when scales / datasets / overview rows change.
+- **Release notes** — `docs/source/index/release_notes.rst` (the changelog): add an entry under
+  the current *Unreleased* section.
+- **Contributing** — `CONTRIBUTING.rst` **and** its RST port
+  `docs/source/index/CONTRIBUTING_COPY.rst` when the dev process changes.
+- **Glossary / ADRs** — `CONTEXT.md` when terminology shifts; a new `docs/adr/NNNN-*.md` for an
+  architectural decision (ideally settled in step 2 via `/grill-with-docs`).
+- **Conventions** — `CLAUDE.md` / `.claude/rules/*` when the change establishes or alters a rule.
+- **Build / deps** — `pyproject.toml` (**CONFIRM-FIRST**) for dependency, extras, or version bumps;
+  `aaanalysis/config.py` (**CONFIRM-FIRST**) for a new global option.
+
+Most of these surface late — a stale cheat sheet, a red meta-test, a wrong RTD render — not in the
+fast unit job. Check them at implement time (step 4), not after CI goes red.
 
 ## Quality gates — how AAanalysis checks each
 
@@ -57,10 +124,10 @@ not committed.
 | **Tests** | full matrix passes | `.github/workflows/main.yml` ("Unit Tests"): `pytest tests -m "not regression" -x -n auto` on **Ubuntu py3.10–3.14** + **Windows py3.10 & 3.14** (Windows brackets min+max; the full Windows range and the `-m regression` exact-value CPP anchor run in the nightly — ADR-0015). |
 | **Coverage** | **≥ 88 %** line coverage, package-only | `.github/workflows/test_coverage.yml`: `pytest … --cov=aaanalysis --cov-fail-under=88` (+ Codecov `patch` / `project` / `project/cpp_core`). Measured on the package only (`--cov=aaanalysis`, never `--cov=./`) — ADR-0016. |
 | **Docs** | RTD builds; API + examples render | `docs/readthedocs.org` check: Sphinx + nbsphinx. `docs/source/conf.py` runs `export_example_notebooks_to_rst` with `nbsphinx_execute='never'` — it **renders committed notebook outputs, it does not execute them**. |
-| **Docstrings** | numpydoc shape, named `Returns`, per-method `Examples` include, no doc-vs-signature drift | the `/docstrings` skill: `check_docstrings.py`, `doc_signature_drift.py`, `check_example_notebooks.py` under `.claude/skills/docstrings/scripts/`. **Local gate** (not yet a CI job). |
+| **Docstrings** | numpydoc shape, named `Returns`, per-method `Examples` include, no doc-vs-signature drift | the `/docstrings` skill: `check_docstrings.py`, `doc_signature_drift.py`, `check_example_notebooks.py` under `.claude/skills/docstrings/scripts/`. `check_docstrings` + `doc_signature_drift` are **blocking CI** in the `codeql_analysis.yml` "code-quality" job; `check_example_notebooks` runs there **advisory (non-blocking)** until the remaining notebook param-coverage gaps are cleared. All three also run locally via the skill. |
 | **Notebooks execute** | every `examples/` + `tutorials/` notebook runs clean with embedded outputs | `pytest --nbmake --nbmake-timeout=120 examples/ tutorials/`. **Local gate only — NOT in blocking CI.** Re-run and re-commit outputs before every push (see Process notes). |
 | **Architecture** | matches `CONTEXT.md` / ADRs; no cross-class backend imports or layering violations | machine: `tests/unit/api_tests/test_backend_import_hygiene.py` (runs inside `pytest tests`). Spec / ADR conformance is human + `/grill-with-docs`. |
-| **Parameter coverage** | every public parameter is exercised by name in tests | `tests/unit/api_tests/test_param_coverage.py` — **landing via PR #111**; not yet on master. |
+| **Parameter coverage** | every public parameter is exercised by name in tests | `tests/unit/api_tests/test_param_coverage.py` — runs in the "Unit Tests" job (it is an ordinary test under `tests/`, picked up by `pytest tests`). |
 | **Lint (errors)** | no syntax errors / undefined names | `.github/workflows/codeql_analysis.yml` ("code-quality" job): `flake8 . --select=E9,F63,F7,F82`. |
 | **Style / types (full)** | black (88) / isort / flake8 (88) / mypy clean | **manual at review** — no pre-commit, ruff, or type-checker in CI (v2 target; `.claude/rules/sharp-edges.md`). |
 | **Security** | CodeQL clean | `.github/workflows/codeql_analysis.yml` ("Analyze" job). No separate dependency-scan PR gate yet — worth adding. |

--- a/docs/source/index/CONTRIBUTING_COPY.rst
+++ b/docs/source/index/CONTRIBUTING_COPY.rst
@@ -390,40 +390,108 @@ committed. The canonical version of this protocol lives in
 
 Workflow (step by step)
 -----------------------
-1. **Pick the issue.** No skill required. Optionally clean up or generate the issue wording
-   first with ``/triage`` or ``/to-issues`` (house style: ``docs/guides/issue_style_guide.rst``).
-2. **``/grill-with-docs`` — the highest-leverage step.** A custom command that sharpens the
-   spec against the *live* codebase and refreshes ``CONTEXT.md`` / ADRs **before any code is
-   written**. The closest built-in, ``/init``, only (re)generates codebase docs — it does not
-   do the adversarial spec-vs-reality pass. Keep grill for the real work; use ``/init`` only as
-   a one-time bootstrap when ``CONTEXT.md`` does not exist yet.
-3. **Branch + isolated worktree.** ``git switch -c <type>/<slug>`` off ``master`` (plain git).
-   **Always pair it with** ``git worktree add`` **so each task gets its own checkout** —
-   concurrent streams then cannot contaminate each other.
-4. **Implement.** Plan mode. Use a structured plan for multi-file or architectural changes; drop
-   to plain edits for trivial diffs. Plan mode is preferable when you want to approve the
-   approach before commits land.
-5. **Push → open PR.** ``gh`` / ``git``. A PR needs ≥1 commit; push a scaffolding commit and open
-   a **draft PR early** so CI + the Read the Docs (RTD) preview run while you build.
-6. **Automated review gate (machine-enforced, not eyeballed).** Run ``/review`` (reviews the PR
-   diff) and ``/security-review`` (scans the pending diff for vulnerabilities). The quality gates
-   below must be green first. **Never merge red** — automated checks *gate* the human review,
-   they do not replace it.
-7. **Refine on the same branch.** Back to plan mode; push more commits (the PR and the RTD
-   preview update automatically).
-8. **Keep current.** Periodically merge ``master`` → branch (plain git). A good fit for the
-   ``/schedule`` skill: auto-**sync** each morning so you wake to a synced branch or an early
-   conflict warning. **A scheduled job syncs only — it must never resolve conflicts or merge a
-   branch to** ``master`` **unattended; it just flags you.**
-9. **Arm auto-merge.** Once the step-6 review is green and you've read the RTD preview + PR diff,
-   enable GitHub-native auto-merge: ``gh pr merge --auto --squash``. GitHub then merges the moment
-   every required check passes and the branch is conflict-free, so **"never merge red" still
-   holds** — a red check blocks the merge instead of completing it.
-10. **Auto-fix red CI.** If GitHub Actions reports a failure, pull the failing logs
-    (``gh run view --log-failed``, or ``gh run watch`` to follow live), reproduce locally, fix
-    **forward on the same branch**, and push. Armed auto-merge re-arms itself and completes once
-    the re-run is green. Disarm with ``gh pr merge --disable-auto`` if you need to hold the PR.
-11. **Delete the branch.** Plain git, with permission.
+Seven steps in three phases. Phases group the work; within the Build phase you iterate, so the
+order there is natural rather than rigid.
+
+**Prepare**
+
+1. **Pick & sharpen the issue.** No skill required to start. Optionally clean up or generate the
+   wording with ``/triage`` or ``/to-issues`` (house style: ``docs/guides/issue_style_guide.rst``);
+   for "what next?", ``/github-issue-handoff`` produces a prioritized, parallelization-aware plan.
+2. **``/grill-with-docs`` — the highest-leverage step.** Sharpen the spec against the *live*
+   codebase and refresh ``CONTEXT.md`` / ADRs **before any code is written**. The closest built-in,
+   ``/init``, only (re)generates codebase docs — it does not do the adversarial spec-vs-reality
+   pass; use ``/init`` only as a one-time bootstrap when ``CONTEXT.md`` does not exist yet.
+3. **Branch + isolated worktree.** ``git switch -c <type>/<slug>`` off ``master`` (``fix/``,
+   ``feat/``, ``doc/``, ``refactor/``), **always paired with** ``git worktree add`` so concurrent
+   streams never share a checkout (see Process notes → *Isolated worktrees*).
+
+**Build**
+
+4. **Implement + open a draft PR early.** Use plan mode for multi-file or architectural changes
+   (approve the approach before commits land); drop to plain edits for trivial diffs. Honor the
+   path-scoped rules in ``.claude/rules/`` that auto-load for the files you touch. A PR needs ≥1
+   commit, so push a scaffolding commit and open a **draft PR** early — CI and the Read the Docs
+   (RTD) preview then run while you keep pushing to refine. **Before a substantive push, run the
+   fast local unit gate** (``pytest tests -m "not regression" -x -n auto -c tests/pytest.ini``) — a
+   local run catches the obvious break far faster than a red-CI round-trip. **No change is done
+   until you have walked the ripple checklist below** — a code edit almost always lands alongside
+   its docstring, example, test, and other mirrors *in the same PR*.
+5. **Automated review gate (machine-enforced, not eyeballed).** Run ``/review`` (reviews the PR
+   diff) and ``/security-review`` (scans the pending diff for vulnerabilities); for a substantial
+   diff reach for ``/code-review high`` (or ``ultra`` for the deep cloud review) and ``/simplify``,
+   and when public API or docstrings change run ``/docstrings``. The quality gates below must be
+   green. **Never merge red** — automated checks *gate* the human review, they do not replace it.
+   *Meanwhile, as a background concern:* periodically merge ``master`` → branch to
+   stay current (a good fit for the ``/schedule`` skill: auto-**sync** each morning so you wake to
+   a synced branch or an early conflict warning). **A scheduled job syncs only — it must never
+   resolve conflicts or merge a branch to** ``master`` **unattended; it just flags you.**
+
+**Merge & clean up**
+
+6. **Arm auto-merge; fix-forward on red.** Once the review is green and you've read the RTD
+   preview + PR diff, enable GitHub-native auto-merge: ``gh pr merge --auto --squash``. GitHub
+   merges the moment every required check passes and the branch is conflict-free, so **"never
+   merge red" still holds** — a red check blocks the merge instead of completing it. If CI goes
+   red, pull the failing logs (``gh run view --log-failed``, or ``gh run watch`` to follow live),
+   reproduce locally, and fix **forward on the same branch**; armed auto-merge re-arms itself and
+   completes on the green re-run. Disarm with ``gh pr merge --disable-auto`` to hold the PR, or
+   skip ``--auto`` for a hard human gate.
+7. **Clean up — gated on merge + a green** ``master``. Key cleanup off the **merge state, never a
+   single CI run**: once ``gh pr view <n> --json state,mergedAt`` shows ``MERGED``, let the
+   push-triggered workflows on ``master`` run and **wait for them to pass** — that confirms the
+   squash didn't break anything the branch CI couldn't see (master may have moved under it). An
+   intervening push, from this session or another, just re-runs checks and armed auto-merge waits
+   for the *new* green, so the trigger survives the race. Then, **with permission** and after
+   confirming no work is lost — ``git branch --merged master`` lists the branch and
+   ``git status --porcelain`` in the worktree is empty — ``git switch master`` →
+   ``git worktree remove <path>`` (a tree with uncommitted work needs ``--force``, which also
+   needs permission) → ``git worktree prune`` → ``git branch -d <branch>``. The remote branch is
+   auto-deleted by GitHub on squash-merge when the repo's "automatically delete head branches"
+   setting is on; otherwise ``git push origin --delete <branch>``. A scheduled/unattended job may
+   *detect and flag* "ready to clean up" but must never delete on its own — the same sync-only
+   discipline as the step-5 background sync.
+
+Propagate every change — the ripple checklist
+----------------------------------------------
+**No code change is complete until every surface that mirrors it is updated in the same PR**
+(tutorials may trail in a separate PR, but never a different release). The package is heavily
+cross-referenced — docstrings include example notebooks, the cheat sheet and tables are generated
+from the public API, meta-tests assert consistency across files — so "I only touched code" is
+almost never true. When you change code, walk this list and update what applies:
+
+- **Docstrings** — numpydoc on every changed class / method / function; new ``[Key]_`` citations
+  go in ``docs/source/index/references.rst``, new conventions in ``docstring_guide.rst``.
+  *Enforced:* the ``/docstrings`` checkers (now blocking CI).
+- **Public API** — ``aaanalysis/__init__.py`` ``__all__`` for any symbol added / removed / renamed
+  (**CONFIRM-FIRST**); the API reference (``docs/source/api.rst`` + autosummary ``generated/``)
+  flows from ``__all__`` + docstrings.
+- **Examples** — ``examples/<abbr>_<method>.ipynb`` (one per public method, included into the
+  docstring via ``.. include:: examples/<name>.rst``): cover every public parameter and re-run with
+  executed outputs (``aa.display_df(...)``, ``plt.show()``).
+- **Tutorials** — ``tutorials/*.ipynb`` when the change alters a taught workflow.
+- **Protocols** — ``protocols/protocol<N>_*.ipynb`` when an end-to-end workflow changes
+  (``docs/guides/protocol_style_guide.md``); they render under *Examples : Protocols* on RTD.
+- **Tests** — unit tests for the change, plus the cross-file meta-tests that catch drift: parameter
+  coverage (``tests/unit/api_tests/test_param_coverage.py``), class-abbreviation registry
+  (``test_class_abbreviation_registry.py``), backend import hygiene, and the extras / missing-stub
+  parity tests.
+- **Cheat sheet** — ``docs/_cheatsheet/content.py`` (single source of truth → regenerate the html /
+  pdf); every snippet must use only public ``__all__`` symbols with real signatures.
+- **Tables** — ``docs/source/index/tables*.rst`` (generated by ``docs/source/create_tables_doc.py``)
+  when scales / datasets / overview rows change.
+- **Release notes** — ``docs/source/index/release_notes.rst`` (the changelog): add an entry under
+  the current *Unreleased* section.
+- **Contributing** — ``CONTRIBUTING.rst`` **and** its RST port
+  ``docs/source/index/CONTRIBUTING_COPY.rst`` when the dev process changes.
+- **Glossary / ADRs** — ``CONTEXT.md`` when terminology shifts; a new ``docs/adr/NNNN-*.md`` for an
+  architectural decision (ideally settled in step 2 via ``/grill-with-docs``).
+- **Conventions** — ``CLAUDE.md`` / ``.claude/rules/*`` when the change establishes or alters a rule.
+- **Build / deps** — ``pyproject.toml`` (**CONFIRM-FIRST**) for dependency, extras, or version
+  bumps; ``aaanalysis/config.py`` (**CONFIRM-FIRST**) for a new global option.
+
+Most of these surface late — a stale cheat sheet, a red meta-test, a wrong RTD render — not in the
+fast unit job. Check them at implement time (step 4), not after CI goes red.
 
 Quality gates
 -------------
@@ -451,7 +519,7 @@ Quality gates
      - ``readthedocs.org`` check: Sphinx + nbsphinx. ``docs/source/conf.py`` runs ``export_example_notebooks_to_rst`` with ``nbsphinx_execute='never'`` — it renders committed notebook outputs, it does not execute them.
    * - **Docstrings**
      - numpydoc shape, named ``Returns``, per-method ``Examples`` include, no doc-vs-signature drift
-     - the ``/docstrings`` skill: ``check_docstrings.py``, ``doc_signature_drift.py``, ``check_example_notebooks.py``. **Local gate** (not yet a CI job).
+     - the ``/docstrings`` skill: ``check_docstrings.py``, ``doc_signature_drift.py``, ``check_example_notebooks.py``. The first two are **blocking CI** in the ``codeql_analysis.yml`` "code-quality" job; ``check_example_notebooks`` runs there **advisory (non-blocking)** until the remaining notebook param-coverage gaps are cleared. All three also run locally via the skill.
    * - **Notebooks execute**
      - every ``examples/`` + ``tutorials/`` notebook runs clean with embedded outputs
      - ``pytest --nbmake --nbmake-timeout=120 examples/ tutorials/``. **Local gate only — NOT in blocking CI.** Re-run and re-commit outputs before every push.
@@ -460,7 +528,7 @@ Quality gates
      - machine: ``tests/unit/api_tests/test_backend_import_hygiene.py``. Spec / ADR conformance is human + ``/grill-with-docs``.
    * - **Parameter coverage**
      - every public parameter is exercised by name in tests
-     - ``tests/unit/api_tests/test_param_coverage.py``.
+     - ``tests/unit/api_tests/test_param_coverage.py`` — runs in the "Unit Tests" job (an ordinary test under ``tests/``, picked up by ``pytest tests``).
    * - **Lint (errors)**
      - no syntax errors / undefined names
      - ``.github/workflows/codeql_analysis.yml`` ("code-quality" job): ``flake8 . --select=E9,F63,F7,F82``.


### PR DESCRIPTION
Slims and hardens the agentic-engineering protocol, and promotes the docstring checkers to CI.

## Changes
- **Slim the workflow**: 11 steps → **7 steps in 3 phases** (Prepare / Build / Merge & clean up); resolves the 4 inline TODOs in `agentic_engineering.md`.
- **Race-safe cleanup rule**: cleanup is gated on *merge-state* + a green `master`, so an intervening push from any session can't strand it.
- **Ripple checklist**: explicit rule that no code change is done until its docstring / examples / tutorials / protocols / tests / cheat sheet / tables / release-notes mirrors are updated in the same PR.
- **De-duplication**: the skill is now a thin executor of the canonical guide; the RST port (`CONTRIBUTING_COPY.rst`) is re-synced.
- **Docstring CI gate** (`codeql_analysis.yml`): `check_docstrings` + `doc_signature_drift` blocking; `check_example_notebooks` advisory (non-blocking) until the 12 flagged notebooks are cleared.

Docs/skill/CI only — no library code touched.