### PR TITLE
fix(tests): de-flake test_feat_rank_selects_expected (CPPPlot.feature)

### DIFF
--- a/tests/unit/cpp_plot_tests/test_cpp_plot_feature.py
+++ b/tests/unit/cpp_plot_tests/test_cpp_plot_feature.py
@@ -70,13 +70,34 @@ class TestCPPPlotFeature:
 
     def test_feat_rank_selects_expected(self):
         # feature=list with feat_rank=k plots the SAME data as passing the k-th id directly
-        # (as-given order, 1-based), and a different rank plots different data.
+        # (as-given order, 1-based), and distinct features plot distinct curves.
         def _kde_signature(ax):
-            return tuple(tuple(round(float(x), 6) for x in ln.get_xdata()) for ln in ax.lines)
+            # Fingerprint each plotted curve by both grid (x) AND density (y): x alone only
+            # encodes the data range, so two distinct features sharing a range would collide.
+            return tuple(
+                (tuple(round(float(x), 6) for x in ln.get_xdata()),
+                 tuple(round(float(y), 6) for y in ln.get_ydata()))
+                for ln in ax.lines
+            )
 
         df_seq, labels, df_feat = get_input()
-        features = random.sample(df_feat["feature"].to_list(), 4)
         cpp_plot = aa.CPPPlot()
+        # Deterministically gather 4 features whose plotted curves are pairwise distinct, so the
+        # distinctness assertion below is a valid precondition rather than a sampling coin flip.
+        rng = random.Random(0)
+        pool = df_feat["feature"].to_list()
+        rng.shuffle(pool)
+        features, seen = [], set()
+        for feature in pool:
+            sig = _kde_signature(cpp_plot.feature(feature=feature, df_seq=df_seq, labels=labels))
+            plt.close("all")
+            if sig not in seen:
+                seen.add(sig)
+                features.append(feature)
+            if len(features) == 4:
+                break
+        assert len(features) == 4
+
         sigs = []
         for k in range(1, len(features) + 1):
             ax_rank = cpp_plot.feature(feature=features, df_seq=df_seq, labels=labels, feat_rank=k)


### PR DESCRIPTION
## Problem

The coverage job failed on `tests/unit/cpp_plot_tests/test_cpp_plot_feature.py::TestCPPPlotFeature::test_feat_rank_selects_expected` with `assert 3 == 4`, while every matrix `test (...)` job passed — the signature of a low-probability flake.

Root cause: the test samples 4 random features and asserts all 4 plot **distinct** curves, but its `_kde_signature` fingerprinted only `get_xdata()` — the KDE support grid, which depends solely on the data's min/max **range**. Two distinct features sharing a value range collide, so unseeded `random.sample` made the final `len(set(sigs)) == len(sigs)` assertion intermittently fail. The per-rank behavioral assertions (`feature=list, feat_rank=k` ≡ k-th id direct) always passed — so this was a flaky **test**, not a `CPPPlot.feature` bug.

## Fix

- Fingerprint each curve by both grid (`x`) **and** density (`y`).
- Pick the 4 features **deterministically** (`random.Random(0)`) so they are pairwise distinct **by construction** — the distinctness assertion becomes a valid precondition rather than a sampling coin flip.
- The core per-rank equality assertion is unchanged.

## Verification

Ran the test **25×** locally — 0 failures (was intermittent). Full `test_cpp_plot_feature.py` green (33 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)