### PR TITLE
feat(cpp): standardized human-readable feature descriptions (#20)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,6 +34,13 @@ A named region of a protein over which a **split** operates and a scale is avera
 First-class user-defined / renamed regions are tracked by **#27** (region abstraction); today a part is chosen from the predefined family.
 _Avoid_: region (reserved for the #27 abstraction), domain (a part may be a window or sub-region, not a whole domain), segment (a split type).
 
+**part label**:
+The fixed, human-readable display string for a `part` token (e.g. `tmd` → "TMD", `jmd_n_tmd_n` → "JMD-N+TMD-N"), defined once in `ut.DICT_PART_LABEL` and used when rendering a feature id as prose. Deliberately *not* called a "region" (that noun is reserved for #27); a part label is purely cosmetic and changes no behavior.
+
+**feature description**:
+One standardized, human-readable sentence built deterministically from a `PART-SPLIT-SCALE` feature id by `SequenceFeature.get_feature_descriptions`: it joins the **part label**, the **split** rendered as a phrase (e.g. "segment 2 of 4"), the residue positions, and the scale's AAontology name / category / subcategory from `df_cat`. Additive only — the `feature` id string is unchanged — and optionally carried as the `feature_description` (`ut.COL_FEAT_DES`) column of `df_feat`. Distinct from the compact **feature name** (`get_feature_names`, `'subcategory [positions]'`), which drops the part and category.
+_Avoid_: feature name (that is the shorter label form), scale description (that is the per-scale `scale_description` field, only one ingredient).
+
 **assembled reference df_parts**:
 A `df_parts` whose rows are **chimeras** of independent per-part windows — each part column is filled from its own window set (e.g. a separate `AAWindowSampler.sample_synthetic` call with its own generator and window size), rather than sliced from one contiguous protein. Built by `SequenceFeature.get_df_parts_from_windows` (windows aligned by position: the i-th window of every part forms the i-th row) and used as the **reference** class for `CPP`. Because a row stitches windows from different sources it has no single source `entry_win`; rows are ided by a per-row `REF{i}` index instead.
 _Avoid_: synthetic df_parts (the windows need not be synthetic), reference window (that is the per-window term, not the assembled table).

--- a/aaanalysis/feature_engineering/_backend/cpp/sequence_feature.py
+++ b/aaanalysis/feature_engineering/_backend/cpp/sequence_feature.py
@@ -64,6 +64,44 @@ def get_feature_names_(features=None, df_cat=None, tmd_len=20, jmd_c_len=10, jmd
     return feat_names
 
 
+def _split_to_phrase(split=None):
+    """Turn a SPLIT token into a readable phrase; flag whether its positions are contiguous."""
+    # Parse the SPLIT string locally (like get_feature_names_ above) rather than reusing the
+    # file-private _get_split_info in utils_feature.py: it lives in another module and only the
+    # display wording — not the parsed ints — is needed here.
+    split_type = split.split("(")[0]
+    args = split.split("(")[1].replace(")", "")
+    if split_type == ut.STR_SEGMENT:
+        i_th, n_split = [int(x) for x in args.split(",")]
+        return f"segment {i_th} of {n_split}", True
+    terminus = args.split(",")[0]
+    term = "N-terminus" if terminus == "N" else "C-terminus"
+    if split_type == ut.STR_PERIODIC_PATTERN:
+        steps = split.split("i+")[1].split(",")[0]  # e.g. '3/4'
+        return f"periodic pattern (steps {steps} from {term})", False
+    return f"pattern (from {term})", False
+
+
+def get_feature_descriptions_(features=None, df_cat=None, tmd_len=20, jmd_c_len=10, jmd_n_len=10, start=1):
+    """Build one standardized, human-readable description per feature id (PART-SPLIT-SCALE)."""
+    feat_positions = get_positions_(features=features, tmd_len=tmd_len, jmd_n_len=jmd_n_len,
+                                    jmd_c_len=jmd_c_len, start=start)
+    dict_name = dict(zip(df_cat[ut.COL_SCALE_ID], df_cat[ut.COL_SCALE_NAME]))
+    dict_cat = dict(zip(df_cat[ut.COL_SCALE_ID], df_cat[ut.COL_CAT]))
+    dict_subcat = dict(zip(df_cat[ut.COL_SCALE_ID], df_cat[ut.COL_SUBCAT]))
+    descriptions = []
+    for feat_id, pos in zip(features, feat_positions):
+        part, split, scale = ut.split_feat_id(feat_id=feat_id)
+        part_label = ut.DICT_PART_LABEL[part.lower()]
+        phrase, contiguous = _split_to_phrase(split=split)
+        list_pos = pos.split(",")
+        pos_str = f"{list_pos[0]}-{list_pos[-1]}" if (contiguous and len(list_pos) > 2) else ", ".join(list_pos)
+        des = (f"{part_label}, {phrase} (positions {pos_str}) — "
+               f"{dict_name[scale]} [{dict_cat[scale]}: {dict_subcat[scale]}]")
+        descriptions.append(des)
+    return descriptions
+
+
 def get_df_feat_(features=None, df_parts=None, labels=None,
                  label_test=1, label_ref=0, df_scales=None, df_cat=None,
                  accept_gaps=False, parametric=False,

--- a/aaanalysis/feature_engineering/_sequence_feature.py
+++ b/aaanalysis/feature_engineering/_sequence_feature.py
@@ -24,7 +24,8 @@ from ._backend.cpp.utils_feature import (get_df_parts_,
                                          replace_non_canonical_aa_,
                                          get_positions_, get_amino_acids_,
                                          get_df_pos_, get_df_pos_parts_)
-from ._backend.cpp.sequence_feature import (get_split_kws_, get_features_, get_feature_names_, get_df_feat_,
+from ._backend.cpp.sequence_feature import (get_split_kws_, get_features_, get_feature_names_,
+                                            get_feature_descriptions_, get_df_feat_,
                                             get_labels_ovr_, get_labels_ovo_, get_labels_quantile_,
                                             get_labels_tiered_)
 from ._backend.cpp_run import _pick_feature_matrix_builder
@@ -1033,6 +1034,87 @@ class SequenceFeature:
                                         jmd_c_len=jmd_c_len,
                                         jmd_n_len=jmd_n_len)
         return feat_names
+
+    @staticmethod
+    def get_feature_descriptions(features: Union[ut.ArrayLike1D, pd.DataFrame] = None,
+                                 df_cat: Optional[pd.DataFrame] = None,
+                                 start: int = 1,
+                                 tmd_len: int = 20,
+                                 jmd_n_len: int = 10,
+                                 jmd_c_len: int = 10,
+                                 ) -> List[str]:
+        """
+        Build a standardized, human-readable description for each feature id (PART-SPLIT-SCALE).
+
+        Complements the compact :meth:`SequenceFeature.get_feature_names` label
+        (``'scale name [positions]'``) with one self-contained sentence per
+        feature that spells out all three id fields: the sequence part as a
+        readable label, the Split as a phrase (e.g. ``'segment 2 of 4'``),
+        and the scale as its AAontology name together with the category and
+        subcategory from ``df_cat``. Terminology is drawn from fixed vocabularies
+        (the part labels and the AAontology category/subcategory wording), so the
+        output is deterministic and consistent across runs. The result can be
+        assigned to a ``df_feat`` column (``'feature_description'``) for readable
+        :class:`CPP` output without changing the ``'feature'`` id string.
+
+        .. versionadded:: 1.1.0
+
+        Parameters
+        ----------
+        features : array-like, shape (n_features,) or pd.DataFrame
+            List of feature ids (``'PART-SPLIT-SCALE'``). Alternatively, a ``df_feat`` DataFrame,
+            in which case its ``'feature'`` column is used.
+        df_cat : pd.DataFrame, shape (n_scales, n_scales_info), optional
+            DataFrame of categories for physicochemical scales. Must contain all scales from ``df_scales``.
+            Default from :meth:`load_scales` with ``name='scales_cat'``, unless specified in ``options['df_cat']``.
+        start : int, default=1
+            Position label of first residue position (starting at N-terminus).
+        tmd_len : int, default=20
+            Length of target middle domain (TMD) (>0).
+        jmd_n_len : int, default=10
+            Length of JMD-N (>=0).
+        jmd_c_len : int, default=10
+            Length of JMD-C (>=0).
+
+        Returns
+        -------
+        feat_descriptions : list of str
+            Human-readable description for each feature, one per feature id.
+
+        Notes
+        -----
+        * Length parameters (``tmd_len``, ``jmd_n_len``, ``jmd_c_len``) must match with ids in ``features``.
+        * Part labels come from a fixed vocabulary; category and subcategory wording is taken
+          verbatim from ``df_cat`` (the AAontology scale categories table).
+
+        See Also
+        --------
+        * :meth:`SequenceFeature.get_feature_names` for the compact label form.
+
+        Examples
+        --------
+        .. include:: examples/sf_get_feature_descriptions.rst
+        """
+        # Load defaults
+        if df_cat is None:
+            df_cat = ut.load_default_scales(scale_cat=True)
+        # Check input
+        features = ut.check_features(features=features)
+        check_df_cat(df_cat=df_cat)
+        ut.check_number_val(name="start", val=start, just_int=True, accept_none=False)
+        jmd_n_len = ut.check_jmd_n_len(jmd_n_len=jmd_n_len)
+        jmd_c_len = ut.check_jmd_c_len(jmd_c_len=jmd_c_len)
+        args_len, _ = check_parts_len(tmd_len=tmd_len, jmd_n_len=jmd_n_len, jmd_c_len=jmd_c_len)
+        check_match_df_cat_features(df_cat=df_cat, features=features)
+        check_match_features_seq_parts(features=features, **args_len)
+        # Get feature descriptions
+        feat_descriptions = get_feature_descriptions_(features=features,
+                                                      df_cat=df_cat,
+                                                      start=start,
+                                                      tmd_len=tmd_len,
+                                                      jmd_c_len=jmd_c_len,
+                                                      jmd_n_len=jmd_n_len)
+        return feat_descriptions
 
     @staticmethod
     def get_feature_positions(features: Union[ut.ArrayLike1D, pd.DataFrame] = None,

--- a/aaanalysis/utils.py
+++ b/aaanalysis/utils.py
@@ -132,6 +132,24 @@ LIST_ALL_PARTS = ["tmd", "tmd_e", "tmd_n", "tmd_c", "jmd_n", "jmd_c", "ext_c", "
                   "tmd_jmd", "jmd_n_tmd_n", "tmd_c_jmd_c", "ext_n_tmd_n", "tmd_c_ext_c"]
 LIST_PARTS = ["tmd", "jmd_n_tmd_n", "tmd_c_jmd_c"]
 
+# Canonical, human-readable label per sequence part (the PART field of a
+# PART-SPLIT-SCALE feature id). Single source of the part-label vocabulary used by
+# SequenceFeature.get_feature_descriptions; keys cover every part in LIST_ALL_PARTS.
+# ('region' is deliberately avoided here — reserved for the #27 region abstraction.)
+DICT_PART_LABEL = {"tmd": "TMD",
+                   "tmd_e": "extended TMD",
+                   "tmd_n": "TMD-N",
+                   "tmd_c": "TMD-C",
+                   "jmd_n": "JMD-N",
+                   "jmd_c": "JMD-C",
+                   "ext_c": "C-terminal extension",
+                   "ext_n": "N-terminal extension",
+                   "tmd_jmd": "JMD-N+TMD+JMD-C",
+                   "jmd_n_tmd_n": "JMD-N+TMD-N",
+                   "tmd_c_jmd_c": "TMD-C+JMD-C",
+                   "ext_n_tmd_n": "N-terminal extension+TMD-N",
+                   "tmd_c_ext_c": "TMD-C+C-terminal extension"}
+
 # Split names
 STR_SEGMENT = "Segment"
 STR_PATTERN = "Pattern"
@@ -309,6 +327,7 @@ COL_PVAL_FDR = "p_val_fdr_bh"
 COL_POSITION = "positions"
 COL_AA_TEST = "amino_acids_test"
 COL_AA_REF = "amino_acids_ref"
+COL_FEAT_DES = "feature_description"  # optional, additive: one readable sentence per feature id
 
 # Columns for df_feat after processing with explainable AI methods
 COL_FEAT_IMPORT = "feat_importance"

--- a/docs/source/index/release_notes.rst
+++ b/docs/source/index/release_notes.rst
@@ -63,6 +63,12 @@ Added
 - **SequenceFeature.get_df_parts_from_windows**: Assemble a reference ``df_parts``
   from per-part window sets (e.g. ``AAWindowSampler.sample_synthetic`` output), so
   each sequence part can be generated with its own recipe.
+- **SequenceFeature.get_feature_descriptions**: Build one standardized,
+  human-readable sentence per ``PART-SPLIT-SCALE`` feature id, combining the
+  sequence region, the split (e.g. ``"segment 2 of 4"``), and the AAontology scale
+  name, category, and subcategory. Complements the compact ``get_feature_names``
+  label; the description is additive (the ``'feature'`` id is unchanged) and can be
+  assigned to an optional ``'feature_description'`` ``df_feat`` column.
 - **AAclust.select_scales**: Convenience wrapper around ``AAclust.fit`` that takes
   an amino acid scales DataFrame (rows = amino acids, columns = scale IDs) and
   returns the redundancy-reduced subset of its columns (one medoid scale per

--- a/examples/feature_engineering/sf_get_feature_descriptions.ipynb
+++ b/examples/feature_engineering/sf_get_feature_descriptions.ipynb
@@ -1,0 +1,351 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d1f9f6a9",
+   "metadata": {},
+   "source": [
+    "The ``SequenceFeature().get_feature_descriptions()`` method turns each compact ``PART-SPLIT-SCALE`` feature id into one standardized, human-readable sentence. It complements the shorter labels from ``get_feature_names()`` by also spelling out the sequence region and the split, and by adding the AAontology scale name, category, and subcategory."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7d8604e",
+   "metadata": {},
+   "source": [
+    "First, we retrieve feature ids using the ``SequenceFeature().get_features()`` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "db77a61c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-12T18:59:54.294945Z",
+     "iopub.status.busy": "2026-06-12T18:59:54.294699Z",
+     "iopub.status.idle": "2026-06-12T18:59:55.523097Z",
+     "shell.execute_reply": "2026-06-12T18:59:55.522850Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['TMD-Segment(1,1)-ANDN920101', 'TMD-Segment(1,1)-ARGP820101', 'TMD-Segment(1,1)-ARGP820102']\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "import aaanalysis as aa\n",
+    "aa.options[\"verbose\"] = False\n",
+    "sf = aa.SequenceFeature()\n",
+    "features = sf.get_features()\n",
+    "print(features[0:3])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e9335b1",
+   "metadata": {},
+   "source": [
+    "A readable description per feature id is then created with ``SequenceFeature().get_feature_descriptions()``:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7ecdfc88",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-12T18:59:55.524263Z",
+     "iopub.status.busy": "2026-06-12T18:59:55.524196Z",
+     "iopub.status.idle": "2026-06-12T18:59:58.705775Z",
+     "shell.execute_reply": "2026-06-12T18:59:58.705536Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TMD, segment 1 of 1 (positions 11-30) — α-CH chemical shifts (backbone-dynamics) [Structure-Activity: Backbone-dynamics (-CH)]\n",
+      "TMD, segment 1 of 1 (positions 11-30) — Hydrophobicity [Polarity: Hydrophobicity]\n",
+      "TMD, segment 1 of 1 (positions 11-30) — Signal sequence helical potential [Polarity: Amphiphilicity (α-helix)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "feature_descriptions = sf.get_feature_descriptions(features=features)\n",
+    "for d in feature_descriptions[0:3]:\n",
+    "    print(d)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf22a7ae",
+   "metadata": {},
+   "source": [
+    "Instead of a list of feature ids, a ``df_feat`` DataFrame (e.g. from :meth:`load_features` or :class:`CPP` output) can be passed directly — its ``'feature'`` column is used automatically:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "3800a302",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-12T18:59:58.706908Z",
+     "iopub.status.busy": "2026-06-12T18:59:58.706842Z",
+     "iopub.status.idle": "2026-06-12T18:59:58.726138Z",
+     "shell.execute_reply": "2026-06-12T18:59:58.725919Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TMD-C+JMD-C, segment 3 of 4 (positions 31-35) — Charge [Energy: Charge]\n",
+      "TMD-C+JMD-C, segment 3 of 4 (positions 31-35) — α-helix termination [Conformation: α-helix (C-cap)]\n",
+      "TMD-C+JMD-C, segment 6 of 9 (positions 32, 33) — Side chain length [Shape: Side chain length]\n"
+     ]
+    }
+   ],
+   "source": [
+    "df_feat = aa.load_features(name=\"DOM_GSEC\")\n",
+    "feature_descriptions = sf.get_feature_descriptions(features=df_feat)\n",
+    "for d in feature_descriptions[0:3]:\n",
+    "    print(d)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "894b03f2",
+   "metadata": {},
+   "source": [
+    "Because descriptions are additive (the ``'feature'`` id is unchanged), they can be assigned to an optional ``'feature_description'`` column for readable ``df_feat`` output:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b7001aa4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-12T18:59:58.727137Z",
+     "iopub.status.busy": "2026-06-12T18:59:58.727079Z",
+     "iopub.status.idle": "2026-06-12T18:59:58.754173Z",
+     "shell.execute_reply": "2026-06-12T18:59:58.753975Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DataFrame shape: (5, 2)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "#T_a35b2 thead th {\n",
+       "  background-color: white;\n",
+       "  color: black;\n",
+       "}\n",
+       "#T_a35b2 tbody tr:nth-child(odd) {\n",
+       "  background-color: #f2f2f2;\n",
+       "}\n",
+       "#T_a35b2 tbody tr:nth-child(even) {\n",
+       "  background-color: white;\n",
+       "}\n",
+       "#T_a35b2 th {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "#T_a35b2  td {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "</style>\n",
+       "<table id=\"T_a35b2\" style='display:block; max-height: 300px; max-width: 100%; overflow-x: auto; overflow-y: auto;'>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_a35b2_level0_col0\" class=\"col_heading level0 col0\" >feature</th>\n",
+       "      <th id=\"T_a35b2_level0_col1\" class=\"col_heading level0 col1\" >feature_description</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a35b2_level0_row0\" class=\"row_heading level0 row0\" >1</th>\n",
+       "      <td id=\"T_a35b2_row0_col0\" class=\"data row0 col0\" >TMD_C_JMD_C-Seg...3,4)-KLEP840101</td>\n",
+       "      <td id=\"T_a35b2_row0_col1\" class=\"data row0 col1\" >TMD-C+JMD-C, se...Energy: Charge]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a35b2_level0_row1\" class=\"row_heading level0 row1\" >2</th>\n",
+       "      <td id=\"T_a35b2_row1_col0\" class=\"data row1 col0\" >TMD_C_JMD_C-Seg...3,4)-FINA910104</td>\n",
+       "      <td id=\"T_a35b2_row1_col1\" class=\"data row1 col1\" >TMD-C+JMD-C, se...-helix (C-cap)]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a35b2_level0_row2\" class=\"row_heading level0 row2\" >3</th>\n",
+       "      <td id=\"T_a35b2_row2_col0\" class=\"data row2 col0\" >TMD_C_JMD_C-Seg...6,9)-LEVM760105</td>\n",
+       "      <td id=\"T_a35b2_row2_col1\" class=\"data row2 col1\" >TMD-C+JMD-C, se...e chain length]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a35b2_level0_row3\" class=\"row_heading level0 row3\" >4</th>\n",
+       "      <td id=\"T_a35b2_row3_col0\" class=\"data row3 col0\" >TMD_C_JMD_C-Seg...3,4)-HUTJ700102</td>\n",
+       "      <td id=\"T_a35b2_row3_col1\" class=\"data row3 col1\" >TMD-C+JMD-C, se...nergy: Entropy]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a35b2_level0_row4\" class=\"row_heading level0 row4\" >5</th>\n",
+       "      <td id=\"T_a35b2_row4_col0\" class=\"data row4 col0\" >TMD_C_JMD_C-Seg...6,9)-RADA880106</td>\n",
+       "      <td id=\"T_a35b2_row4_col1\" class=\"data row4 col1\" >TMD-C+JMD-C, se...Volume: Volume]</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "df_feat = df_feat.head(5).copy()\n",
+    "df_feat[\"feature_description\"] = sf.get_feature_descriptions(features=df_feat)\n",
+    "aa.display_df(df_feat[[\"feature\", \"feature_description\"]], n_rows=5, show_shape=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58ff2e8e",
+   "metadata": {},
+   "source": [
+    "The ``start`` position and the lengths of the sequence parts (``tmd_len``, ``jmd_n_len``, and ``jmd_c_len``) can be adjusted; they must match the lengths used to build the feature ids so that the reported residue positions are correct:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "874877e0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-12T18:59:58.755162Z",
+     "iopub.status.busy": "2026-06-12T18:59:58.755085Z",
+     "iopub.status.idle": "2026-06-12T19:00:01.984782Z",
+     "shell.execute_reply": "2026-06-12T19:00:01.984495Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TMD, segment 1 of 1 (positions 30-49) — α-CH chemical shifts (backbone-dynamics) [Structure-Activity: Backbone-dynamics (-CH)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Shift the first residue position label from 1 to 20\n",
+    "feature_descriptions = sf.get_feature_descriptions(features=features, start=20)\n",
+    "print(feature_descriptions[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "7a8e3881",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-12T19:00:01.985832Z",
+     "iopub.status.busy": "2026-06-12T19:00:01.985762Z",
+     "iopub.status.idle": "2026-06-12T19:00:05.317336Z",
+     "shell.execute_reply": "2026-06-12T19:00:05.317097Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TMD, segment 1 of 1 (positions 11-110) — α-CH chemical shifts (backbone-dynamics) [Structure-Activity: Backbone-dynamics (-CH)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Change TMD length from 20 to 100 (and JMD lengths)\n",
+    "feature_descriptions = sf.get_feature_descriptions(features=features, tmd_len=100,\n",
+    "                                                   jmd_n_len=10, jmd_c_len=10)\n",
+    "print(feature_descriptions[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5948c89",
+   "metadata": {},
+   "source": [
+    "If features with customized scales are used, provide a matching ``df_cat`` containing the ``scale_id``, ``category``, ``subcategory``, and ``scale_name`` columns:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "100ce193",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-12T19:00:05.318428Z",
+     "iopub.status.busy": "2026-06-12T19:00:05.318359Z",
+     "iopub.status.idle": "2026-06-12T19:00:05.338576Z",
+     "shell.execute_reply": "2026-06-12T19:00:05.338366Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TMD, segment 1 of 1 (positions 11-30) — scale_name1 [Scale1_category: Scale1_subcategory]\n",
+      "JMD-N, pattern (from N-terminus) (positions 1, 3) — scale_name1 [Scale1_category: Scale1_subcategory]\n"
+     ]
+    }
+   ],
+   "source": [
+    "features_custom = [\"TMD-Segment(1,1)-Scale1\", \"JMD_N-Pattern(N,1,3)-Scale1\"]\n",
+    "cols = [\"scale_id\", \"category\", \"subcategory\", \"scale_name\"]\n",
+    "vals = [\"Scale1\", \"Scale1_category\", \"Scale1_subcategory\", \"scale_name1\"]\n",
+    "df_cat = pd.DataFrame([vals], columns=cols)\n",
+    "feature_descriptions = sf.get_feature_descriptions(features=features_custom, df_cat=df_cat)\n",
+    "for d in feature_descriptions:\n",
+    "    print(d)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/unit/sequence_feature_tests/test_sf_get_feature_descriptions.py
+++ b/tests/unit/sequence_feature_tests/test_sf_get_feature_descriptions.py
@@ -1,0 +1,243 @@
+"""This is a script to test the SequenceFeature().get_feature_descriptions() method ."""
+from hypothesis import given, settings, strategies as st
+import pytest
+import random
+import pandas as pd
+import aaanalysis as aa
+import aaanalysis.utils as ut
+
+aa.options["verbose"] = False
+
+# Set default deadline from 200 to 400
+settings.register_profile("ci", deadline=None)
+settings.load_profile("ci")
+
+
+def get_random_features(n_feat=100):
+    """Draw a random sample of feature ids from the default feature space."""
+    sf = aa.SequenceFeature()
+    features = sf.get_features()
+    return random.sample(features, n_feat)
+
+
+class TestGetFeatureDescriptions:
+    """Class for testing get_feature_descriptions function in positive scenarios."""
+
+    def test_valid_features(self):
+        """Test valid 'features' input."""
+        sf = aa.SequenceFeature()
+        features = get_random_features()
+        result = sf.get_feature_descriptions(features=features)
+        assert isinstance(result, list) and all(isinstance(des, str) for des in result)
+        assert len(result) == len(features)
+
+    def test_valid_df_cat(self):
+        """Test valid 'df_cat' DataFrame input."""
+        sf = aa.SequenceFeature()
+        features = get_random_features()
+        df_cat = aa.load_scales(name="scales_cat")
+        result = sf.get_feature_descriptions(features=features, df_cat=df_cat)
+        assert isinstance(result, list) and all(isinstance(des, str) for des in result)
+
+    @settings(max_examples=5, deadline=None)
+    @given(start=st.integers(min_value=1))
+    def test_valid_start(self, start):
+        """Test valid 'start' input."""
+        sf = aa.SequenceFeature()
+        features = get_random_features(n_feat=20)
+        result = sf.get_feature_descriptions(features=features, start=start)
+        assert isinstance(result, list) and all(isinstance(des, str) for des in result)
+
+    @settings(max_examples=5, deadline=None)
+    @given(tmd_len=st.integers(min_value=20, max_value=2000))
+    def test_valid_tmd_len(self, tmd_len):
+        """Test valid 'tmd_len' input."""
+        sf = aa.SequenceFeature()
+        features = get_random_features(n_feat=20)
+        result = sf.get_feature_descriptions(features=features, tmd_len=tmd_len)
+        assert isinstance(result, list) and all(isinstance(des, str) for des in result)
+
+    @settings(max_examples=5, deadline=None)
+    @given(jmd_c_len=st.integers(min_value=10, max_value=2000))
+    def test_valid_jmd_c_len(self, jmd_c_len):
+        """Test valid 'jmd_c_len' input."""
+        sf = aa.SequenceFeature()
+        features = get_random_features(n_feat=20)
+        result = sf.get_feature_descriptions(features=features, jmd_c_len=jmd_c_len)
+        assert isinstance(result, list) and all(isinstance(des, str) for des in result)
+
+    @settings(max_examples=5, deadline=None)
+    @given(jmd_n_len=st.integers(min_value=10, max_value=2000))
+    def test_valid_jmd_n_len(self, jmd_n_len):
+        """Test valid 'jmd_n_len' input."""
+        sf = aa.SequenceFeature()
+        features = get_random_features(n_feat=20)
+        result = sf.get_feature_descriptions(features=features, jmd_n_len=jmd_n_len)
+        assert isinstance(result, list) and all(isinstance(des, str) for des in result)
+
+    # Negative Tests
+    def test_invalid_features(self):
+        """Negative test for invalid 'features' input."""
+        sf = aa.SequenceFeature()
+        invalid_features = [None, 123, "invalid_input", {}]
+        for features in invalid_features:
+            with pytest.raises(ValueError):
+                sf.get_feature_descriptions(features=features)
+
+    def test_invalid_df_cat(self):
+        """Negative test for invalid 'df_cat' input."""
+        sf = aa.SequenceFeature()
+        features = get_random_features()
+        invalid_df_cats = [123, "invalid_input", [], {}]
+        for df_cat in invalid_df_cats:
+            with pytest.raises(ValueError):
+                sf.get_feature_descriptions(features=features, df_cat=df_cat)
+
+    @settings(max_examples=5, deadline=None)
+    @given(start=st.one_of(st.none(), st.text(), st.floats()))
+    def test_invalid_start(self, start):
+        """Negative test for invalid 'start' input."""
+        sf = aa.SequenceFeature()
+        features = get_random_features()
+        with pytest.raises(ValueError):
+            sf.get_feature_descriptions(features=features, start=start)
+
+    @settings(max_examples=5, deadline=None)
+    @given(tmd_len=st.one_of(st.none(), st.text(), st.floats(), st.integers(max_value=0)))
+    def test_invalid_tmd_len(self, tmd_len):
+        """Negative test for invalid 'tmd_len' input."""
+        sf = aa.SequenceFeature()
+        features = get_random_features()
+        with pytest.raises(ValueError):
+            sf.get_feature_descriptions(features=features, tmd_len=tmd_len)
+
+    @settings(max_examples=5, deadline=None)
+    @given(jmd_c_len=st.one_of(st.none(), st.text(), st.floats(), st.integers(max_value=0)))
+    def test_invalid_jmd_c_len(self, jmd_c_len):
+        """Negative test for invalid 'jmd_c_len' input."""
+        sf = aa.SequenceFeature()
+        features = get_random_features()
+        with pytest.raises(ValueError):
+            sf.get_feature_descriptions(features=features, jmd_c_len=jmd_c_len)
+
+    @settings(max_examples=5, deadline=None)
+    @given(jmd_n_len=st.one_of(st.none(), st.text(), st.floats(), st.integers(max_value=0)))
+    def test_invalid_jmd_n_len(self, jmd_n_len):
+        """Negative test for invalid 'jmd_n_len' input."""
+        sf = aa.SequenceFeature()
+        features = get_random_features()
+        with pytest.raises(ValueError):
+            sf.get_feature_descriptions(features=features, jmd_n_len=jmd_n_len)
+
+    # df_feat DataFrame accepted for 'features'
+    def test_valid_features_df_feat(self):
+        """A df_feat DataFrame is accepted and equals the list-of-ids form."""
+        sf = aa.SequenceFeature()
+        features = get_random_features(n_feat=20)
+        df_feat = pd.DataFrame({"feature": features})
+        assert sf.get_feature_descriptions(features=df_feat) == sf.get_feature_descriptions(features=features)
+
+    def test_invalid_features_df_feat_missing_col(self):
+        """A DataFrame without a 'feature' column raises ValueError."""
+        sf = aa.SequenceFeature()
+        features = get_random_features(n_feat=20)
+        with pytest.raises(ValueError, match="feature"):
+            sf.get_feature_descriptions(features=pd.DataFrame({"wrong": features}))
+
+
+class TestGetFeatureDescriptionsComplex:
+    """Class for testing get_feature_descriptions in complex scenarios (KPIs from issue #20)."""
+
+    def test_all_three_split_types_covered(self):
+        """Each split type (Segment, Pattern, PeriodicPattern) yields a readable phrase."""
+        sf = aa.SequenceFeature()
+        feats = ["TMD-Segment(2,4)-ANDN920101",
+                 "JMD_N_TMD_N-Pattern(N,3,7,11)-CHAM820101",
+                 "TMD-PeriodicPattern(N,i+3/4,1)-KLEP840101"]
+        des = sf.get_feature_descriptions(features=feats)
+        assert "segment 2 of 4" in des[0]
+        assert "pattern (from N-terminus)" in des[1]
+        assert "periodic pattern (steps 3/4 from N-terminus)" in des[2]
+
+    def test_part_label_present(self):
+        """The readable part label (not the raw part token) appears in the description."""
+        sf = aa.SequenceFeature()
+        des = sf.get_feature_descriptions(features=["TMD_C_JMD_C-Segment(1,1)-FAUJ880109"])[0]
+        assert des.startswith("TMD-C+JMD-C")
+        assert "tmd_c_jmd_c" not in des.lower()
+
+    def test_scale_name_and_category_present(self):
+        """The AAontology scale name, category, and subcategory all appear in the description."""
+        sf = aa.SequenceFeature()
+        df_cat = aa.load_scales(name="scales_cat")
+        row = df_cat[df_cat[ut.COL_SCALE_ID] == "ANDN920101"].iloc[0]
+        des = sf.get_feature_descriptions(features=["TMD-Segment(2,4)-ANDN920101"])[0]
+        assert row[ut.COL_SCALE_NAME] in des
+        assert row[ut.COL_CAT] in des
+        assert row[ut.COL_SUBCAT] in des
+
+    # KPI: determinism
+    def test_deterministic_byte_identical(self):
+        """Identical id + metadata produce a byte-identical string across repeated runs."""
+        sf = aa.SequenceFeature()
+        features = get_random_features(n_feat=50)
+        first = sf.get_feature_descriptions(features=features)
+        for _ in range(3):
+            assert sf.get_feature_descriptions(features=features) == first
+
+    def test_deterministic_order_independent(self):
+        """A feature's description does not depend on its neighbours in the list."""
+        sf = aa.SequenceFeature()
+        feats = ["TMD-Segment(2,4)-ANDN920101", "JMD_N_TMD_N-Pattern(N,3,7,11)-CHAM820101"]
+        des_forward = sf.get_feature_descriptions(features=feats)
+        des_reverse = sf.get_feature_descriptions(features=list(reversed(feats)))
+        assert des_forward[0] == des_reverse[1]
+        assert des_forward[1] == des_reverse[0]
+
+    # KPI: 100% non-empty coverage on a real DOM_GSEC df_feat
+    def test_dom_gsec_full_coverage(self):
+        """Every feature in the bundled DOM_GSEC df_feat gets a non-empty description."""
+        sf = aa.SequenceFeature()
+        df_feat = aa.load_features(name="DOM_GSEC")
+        des = sf.get_feature_descriptions(features=df_feat)
+        assert len(des) == len(df_feat)
+        assert all(isinstance(d, str) and d.strip() != "" for d in des)
+
+    def test_assignable_as_df_feat_column(self):
+        """The description list can be assigned to the canonical df_feat column."""
+        sf = aa.SequenceFeature()
+        df_feat = aa.load_features(name="DOM_GSEC").head(20).copy()
+        df_feat[ut.COL_FEAT_DES] = sf.get_feature_descriptions(features=df_feat)
+        assert ut.COL_FEAT_DES in df_feat.columns
+        assert df_feat[ut.COL_FEAT_DES].notna().all()
+
+    # KPI: terminology consistency
+    def test_part_label_vocabulary_subset(self):
+        """Part labels used are a subset of the canonical DICT_PART_LABEL vocabulary."""
+        sf = aa.SequenceFeature()
+        df_feat = aa.load_features(name="DOM_GSEC")
+        part_labels = set(ut.DICT_PART_LABEL.values())
+        des = sf.get_feature_descriptions(features=df_feat)
+        for d in des:
+            part_label = d.split(",")[0]
+            assert part_label in part_labels
+
+    def test_category_matches_scales_cat(self):
+        """Category tokens in descriptions match the categories in scales_cat.tsv."""
+        sf = aa.SequenceFeature()
+        df_cat = aa.load_scales(name="scales_cat")
+        valid_cats = set(df_cat[ut.COL_CAT])
+        df_feat = aa.load_features(name="DOM_GSEC")
+        des = sf.get_feature_descriptions(features=df_feat)
+        for d in des:
+            # AAontology classification is the trailing '[category: subcategory]' bracket
+            cat = d.rsplit("[", 1)[1].rstrip("]").split(": ")[0]
+            assert cat in valid_cats
+
+    def test_distinguishes_parts_that_get_feature_names_drops(self):
+        """Two ids differing only in PART get distinct descriptions (get_feature_names would not)."""
+        sf = aa.SequenceFeature()
+        feat_tmd = "TMD-Segment(1,1)-ANDN920101"
+        feat_jmd = "JMD_N-Segment(1,1)-ANDN920101"
+        des = sf.get_feature_descriptions(features=[feat_tmd, feat_jmd])
+        assert des[0] != des[1]


### PR DESCRIPTION
Closes #20

## What

Adds `SequenceFeature.get_feature_descriptions(features, df_cat=None, start=1, tmd_len=20, jmd_n_len=10, jmd_c_len=10)` — a sibling of `get_feature_names` that turns each compact `PART-SPLIT-SCALE` feature id into **one standardized, human-readable sentence**:

```
TMD, segment 2 of 4 (positions 16-20) — α-CH chemical shifts (backbone-dynamics) [Structure-Activity: Backbone-dynamics (-CH)]
JMD-N+TMD-N, pattern (from N-terminus) (positions 3, 7, 11) — Polarizability [Polarity: Amphiphilicity]
TMD, periodic pattern (steps 3/4 from N-terminus) (positions 11, 14, 18, 21, 25, 28) — Charge [Energy: Charge]
```

It combines all three id fields — the **part** (as a readable label), the **split** (as a phrase like "segment 2 of 4"), the residue positions, and the **scale**'s AAontology name / category / subcategory from `df_cat`. This is what `get_feature_names` (`'subcategory [positions]'`) deliberately *omits*: it drops the part and the category entirely.

## Why a sibling, not a rewrite

`get_feature_names` covers only ~⅓ of #20 (positions only) and is public + semver-strict, so its output can't change. The new method **reuses its backend** (`get_positions_`, the `df_cat` lookups) so terminology stays consistent — one source, two granularities (short label vs full description).

## Design notes

- **Additive only** — the `feature` id string is unchanged. The description is opt-in: assign it to the `feature_description` (`ut.COL_FEAT_DES`) column of `df_feat` when you want it. Default `CPP.run` output is untouched (no #18-schema / regression-anchor impact).
- **"part label", not "region"** — the CONTEXT.md glossary reserves *region* for the #27 abstraction, so the fixed part vocabulary is `ut.DICT_PART_LABEL`.
- **`CPPPlot` label wiring is a deliberate follow-up** (it changes committed plot outputs); this PR ships the builder + tests + docs.

## Tests / KPIs (from the issue)

24 new unit tests, incl.:
- **100% coverage** — every feature in the bundled `DOM_GSEC` `df_feat` gets a non-empty description.
- **Determinism** — byte-identical strings across repeated and reordered runs.
- **Terminology consistency** — part labels ⊆ `DICT_PART_LABEL`; category tokens ⊆ `scales_cat.tsv` categories.

## Ripple

Docstring (numpydoc + `versionadded`), example notebook with executed outputs (`sf_get_feature_descriptions.ipynb`), release note, CONTEXT.md glossary (`part label`, `feature description`).

## Local gates

Full fast unit suite `4062 passed`; param-coverage / backend-import-hygiene / abbreviation-registry green; docstring checker 0 defects / 0 drift; notebook executes clean; `/code-review high` + security review clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)