### PR TITLE
ci: run suite + coverage on every master push (fix Codecov "unknown" badge)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,16 +4,11 @@ on:
   push:
     branches:
       - master
-    # Docs-only / notebook-only pushes to master skip the suite (they cannot
-    # change unit-test or coverage results). Mixed commits (code + docs) still
-    # run. paths-ignore is intentionally NOT set on pull_request: a skipped
-    # required check shows as perpetually "pending" and would block PR merges.
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.ipynb'
-      - 'docs/**'
-      - 'tutorials/**'
-      - 'examples/**'
+    # Run on EVERY push to master (no paths-ignore). The Codecov badge tracks the
+    # branch-HEAD commit, so a docs-only HEAD with no coverage report renders the
+    # badge as "unknown". Running the suite (and its coverage upload) on every
+    # master commit keeps HEAD reported and the badge fresh. The extra runner
+    # minutes on docs-only pushes are the accepted cost of an always-valid badge.
   pull_request:
     branches:
       - master


### PR DESCRIPTION
## Problem
The Codecov badge shows **unknown**. Root cause: coverage **does** run (the `Run Tests and Report Coverage` job in `main.yml`), and uploads succeed (queued to Codecov) — but the `push` trigger has a `paths-ignore` (`docs/**`, `tutorials/**`, `examples/**`, `*.ipynb`, `*.md`) that skips the **whole workflow** on docs-only commits. The Codecov badge tracks the **branch-HEAD** commit, and recent master HEADs were docs/cheat-sheet commits with no coverage report → the badge renders "unknown" (it was fine before coverage was folded in with this ignore).

## Change
Drop the `push` `paths-ignore` so every master commit runs the suite and uploads coverage, keeping HEAD reported. `pull_request` is unchanged (it already had no `paths-ignore`). Accepted cost: ~one extra suite run per docs-only push.

## Note (separate, needs maintainer)
The Codecov upload step logs an **empty `CODECOV_TOKEN`** (tokenless OIDC fallback). If the badge stays "unknown" after a code push lands, add a `CODECOV_TOKEN` repo secret from codecov.io and confirm the repo is activated there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)