### PR TITLE
ci: restore standalone Test Coverage workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - master
-    # Run on EVERY push to master (no paths-ignore). The Codecov badge tracks the
-    # branch-HEAD commit, so a docs-only HEAD with no coverage report renders the
-    # badge as "unknown". Running the suite (and its coverage upload) on every
-    # master commit keeps HEAD reported and the badge fresh. The extra runner
-    # minutes on docs-only pushes are the accepted cost of an always-valid badge.
   pull_request:
     branches:
       - master
@@ -106,88 +101,7 @@ jobs:
       env:
         MPLBACKEND: Agg
 
-  # Coverage runs as its own job (not a matrix leg) so it is independent of the
-  # matrix's fail-fast: a coverage report is still produced and uploaded even
-  # when an unrelated matrix leg fails. Single config (Linux, Python 3.12),
-  # mirroring ADR-0016 (coverage is measured on one canonical environment).
-  coverage:
-    name: Run Tests and Report Coverage
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
-
-    - name: Set up Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: '3.12'
-
-    - name: Cache Python dependencies
-      uses: actions/cache@v5
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-coverage-${{ hashFiles('pyproject.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-coverage-
-
-    - name: Install package and test dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e .[dev]
-
-    - name: Install cd-hit and mmseqs2
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y cd-hit
-        sudo apt-get install -y mmseqs2
-
-    # FIMO (MEME suite) gates the scan_motif end-to-end / parity / golden tests
-    # (@fimo_required). Built from source (not apt, not conda — ADR-0019) and
-    # cached on the version key so the heavy build runs only on a cache miss.
-    - name: Cache MEME suite (FIMO)
-      id: cache-meme
-      uses: actions/cache@v5
-      with:
-        path: ~/meme-install
-        key: ${{ runner.os }}-meme-5.5.8
-
-    - name: Build FIMO from MEME suite
-      if: steps.cache-meme.outputs.cache-hit != 'true'
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y build-essential zlib1g-dev
-        MEME_VERSION=5.5.8
-        curl -sSL "https://meme-suite.org/meme/meme-software/${MEME_VERSION}/meme-${MEME_VERSION}.tar.gz" -o meme.tar.gz
-        tar -xzf meme.tar.gz
-        cd "meme-${MEME_VERSION}"
-        ./configure --prefix="$HOME/meme-install" --enable-build-libxml2 --enable-build-libxslt
-        make -j"$(nproc)"
-        make install
-
-    - name: Add FIMO to PATH
-      run: echo "$HOME/meme-install/bin" >> "$GITHUB_PATH"
-
-    - name: Run tests with coverage and generate XML report
-      env:
-        MPLBACKEND: Agg
-        # Use CPython's sys.monitoring coverage backend (py3.12+): much faster
-        # than the default C-tracer, so the coverage job stops being the long pole.
-        COVERAGE_CORE: sysmon
-      run: |
-        pytest tests -m "not regression" --cov=aaanalysis --cov-branch --cov-report=xml -x -n auto --durations=20
-
-    # Branch coverage cannot be gated by --cov-fail-under once --cov-branch is on
-    # (that flag then checks the *combined* line+branch number, silently redefining
-    # the line floor). Parse coverage.xml for independent line (>=88) and branch
-    # (>=80) gates instead (issue #84, ADR-0016 D4).
-    - name: Enforce line and branch coverage gates
-      run: |
-        python .github/scripts/check_branch_coverage.py
-
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v7
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: ./coverage.xml
-        fail_ci_if_error: true
+  # Coverage is measured and uploaded by the standalone `Test Coverage` workflow
+  # (.github/workflows/test_coverage.yml) — kept separate so it appears as its own
+  # action/check and runs on its own canonical config (Linux, Python 3.12), per
+  # ADR-0016.

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -1,0 +1,106 @@
+name: Test Coverage
+
+on:
+  push:
+    branches:
+      - master
+    # Run on EVERY push to master (no paths-ignore). The Codecov badge tracks the
+    # branch-HEAD commit, so a docs-only HEAD with no coverage report renders the
+    # badge as "unknown". Running the suite (and its coverage upload) on every
+    # master commit keeps HEAD reported and the badge fresh. The extra runner
+    # minutes on docs-only pushes are the accepted cost of an always-valid badge.
+  pull_request:
+    branches:
+      - master
+
+# Cancel a superseded in-progress run on the same branch/PR (saves runner minutes).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Coverage runs as its own workflow (a single canonical config: Linux, Python
+  # 3.12) so a coverage report is still produced and uploaded independently of the
+  # unit-test matrix's fail-fast, mirroring ADR-0016 (coverage is measured on one
+  # canonical environment).
+  test:
+    name: Run Tests and Report Coverage
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+
+    - name: Cache Python dependencies
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-coverage-${{ hashFiles('pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-coverage-
+
+    - name: Install package and test dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+
+    - name: Install cd-hit and mmseqs2
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cd-hit
+        sudo apt-get install -y mmseqs2
+
+    # FIMO (MEME suite) gates the scan_motif end-to-end / parity / golden tests
+    # (@fimo_required). Built from source (not apt, not conda — ADR-0019) and
+    # cached on the version key so the heavy build runs only on a cache miss.
+    - name: Cache MEME suite (FIMO)
+      id: cache-meme
+      uses: actions/cache@v5
+      with:
+        path: ~/meme-install
+        key: ${{ runner.os }}-meme-5.5.8
+
+    - name: Build FIMO from MEME suite
+      if: steps.cache-meme.outputs.cache-hit != 'true'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential zlib1g-dev
+        MEME_VERSION=5.5.8
+        curl -sSL "https://meme-suite.org/meme/meme-software/${MEME_VERSION}/meme-${MEME_VERSION}.tar.gz" -o meme.tar.gz
+        tar -xzf meme.tar.gz
+        cd "meme-${MEME_VERSION}"
+        ./configure --prefix="$HOME/meme-install" --enable-build-libxml2 --enable-build-libxslt
+        make -j"$(nproc)"
+        make install
+
+    - name: Add FIMO to PATH
+      run: echo "$HOME/meme-install/bin" >> "$GITHUB_PATH"
+
+    - name: Run tests with coverage and generate XML report
+      env:
+        MPLBACKEND: Agg
+        # Use CPython's sys.monitoring coverage backend (py3.12+): much faster
+        # than the default C-tracer, so the coverage job stops being the long pole.
+        COVERAGE_CORE: sysmon
+      run: |
+        pytest tests -m "not regression" --cov=aaanalysis --cov-branch --cov-report=xml -x -n auto --durations=20
+
+    # Branch coverage cannot be gated by --cov-fail-under once --cov-branch is on
+    # (that flag then checks the *combined* line+branch number, silently redefining
+    # the line floor). Parse coverage.xml for independent line (>=88) and branch
+    # (>=80) gates instead (issue #84, ADR-0016 D4).
+    - name: Enforce line and branch coverage gates
+      run: |
+        python .github/scripts/check_branch_coverage.py
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v7
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.xml
+        fail_ci_if_error: true


### PR DESCRIPTION
## What

Splits the coverage job back out of `main.yml` into its own `.github/workflows/test_coverage.yml`, so coverage shows as a distinct **Test Coverage** action/check again (you asked to re-introduce it).

- **New `test_coverage.yml`** — single canonical config (Linux, Python 3.12), runs the suite with `--cov=aaanalysis --cov-branch`, enforces line≥88 / branch≥80 via `check_branch_coverage.py`, uploads to Codecov, on **every master push + PR**.
- **`main.yml`** — the `coverage` job removed (now just the unit-test matrix), with a comment pointing to the standalone workflow.

## Why this is safe

- Reverts the `192e6e18` consolidation but **keeps the #146 every-master-push badge fix** (the new workflow carries that trigger), so the Codecov "unknown" badge stays fixed.
- The job is still named **`Run Tests and Report Coverage`**, so any branch-protection required-check keyed on that name keeps matching.
- Coverage now runs **once** (no duplication / double Codecov upload).
- Re-aligns the docs: `workflow.md` ("3 workflows: Unit Tests, Test Coverage, CodeQL") and `agentic_engineering.md`'s `test_coverage.yml` reference were stale after the fold-in — restoring the file makes them correct again.

This PR's own run exercises the new workflow, so a green check here proves it works before it lands on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)