### PR TITLE
fix(struct): version-agnostic fetch_alphafold + live online-fetch test (AlphaFold v4→v6)

### DIFF
--- a/.github/workflows/mutation_nightly.yml
+++ b/.github/workflows/mutation_nightly.yml
@@ -1,10 +1,14 @@
 name: Nightly (mutation + regression)
 
 # NON-GATING nightly job (ADR-0015 / ADR-0016). Runs on a schedule and on
-# manual dispatch — never on push/PR, so it never blocks merges. It does two
+# manual dispatch — never on push/PR, so it never blocks merges. It does three
 # things on the canonical cell (Linux + py3.11):
 #   1. Re-verifies the exact-value CPP regression anchor (`-m regression`).
-#   2. Runs a scoped, non-gating mutmut audit of the CPP numeric core; surviving
+#   2. Runs the live online-fetch tests (`-m network --run-network`) so an
+#      upstream API/version change (e.g. AlphaFold's v4->v6 file rename, which
+#      silently broke fetch_alphafold) surfaces as a red nightly instead of
+#      slipping past the mocked unit tests.
+#   3. Runs a scoped, non-gating mutmut audit of the CPP numeric core; surviving
 #      mutants are a TODO list for stronger golden/property tests, not a gate.
 
 on:
@@ -33,6 +37,11 @@ jobs:
         env:
           MPLBACKEND: Agg
         run: pytest tests -m regression -vv
+
+      - name: Verify live online fetches (AlphaFold etc.)
+        env:
+          MPLBACKEND: Agg
+        run: pytest tests -m network --run-network -vv
 
       - name: Mutation audit of CPP numeric core (non-gating)
         continue-on-error: true

--- a/aaanalysis/data_handling_pro/_backend/struct_preproc/_alphafold.py
+++ b/aaanalysis/data_handling_pro/_backend/struct_preproc/_alphafold.py
@@ -25,6 +25,10 @@ from ._file_format import _af_canonical_pae_name
 
 # I Helper Functions
 AF_FILES_URL = "https://alphafold.ebi.ac.uk/files/"
+# Version-agnostic source of truth for download URLs. The /files/ names carry a
+# data-version suffix (…_v4 -> …_v6 -> …) that changes without notice; the API
+# always reports the current URLs, so we resolve through it instead of guessing.
+AF_API_URL = "https://alphafold.ebi.ac.uk/api/prediction/"
 
 # Column order for the per-entry status table built by ``fetch_alphafold_bulk``.
 # Positional-list rows are wrapped into a DataFrame with these columns.
@@ -45,14 +49,51 @@ def _af_model_filename(entry: str, file_format: str) -> str:
     return f"{entry}.{file_format}"
 
 
-def _af_model_url(entry: str, file_format: str) -> str:
-    """AlphaFold-DB URL for the F1 model file of a UniProt accession."""
-    return f"{AF_FILES_URL}AF-{entry}-F1-model_v4.{file_format}"
+def _af_resolve_urls(entry: str, file_format: str, timeout: float = 30.0):
+    """Resolve the current AlphaFold-DB model + PAE download URLs for an accession.
 
+    Queries the AlphaFold prediction API, which always returns the URLs for the
+    latest data version, so this survives AlphaFold-DB version bumps (the file
+    naming moved ``v4`` -> ``v6`` and will move again). Returns
+    ``(model_url, pae_url)``, or ``None`` when the accession is not in
+    AlphaFold DB (the soft, ``on_failure``-governed case). ``pae_url`` may be
+    ``None`` if the API record has no PAE sidecar.
 
-def _af_pae_url(entry: str) -> str:
-    """AlphaFold-DB URL for the F1 PAE sidecar of a UniProt accession."""
-    return f"{AF_FILES_URL}{_af_canonical_pae_name(entry)}"
+    Raises
+    ------
+    RuntimeError
+        On a non-404 API failure, or if the record lacks the requested model URL
+        (an unexpected API-shape change worth surfacing rather than silently
+        falling back to a guessed, possibly-stale URL).
+    """
+    api_url = f"{AF_API_URL}{entry}"
+    try:
+        resp = requests.get(api_url, timeout=timeout)
+    except requests.RequestException as e:
+        raise RuntimeError(
+            f"AlphaFold API request for '{entry}' ('{api_url}') failed: {e}") from e
+    # The API answers an accession it has no model for with 404 or 400 (the
+    # latter for malformed/unknown accessions); both are the soft "not in
+    # AlphaFold DB" case governed by on_failure, not a transport error.
+    if resp.status_code in (400, 404):
+        return None
+    if resp.status_code != 200:
+        raise RuntimeError(
+            f"AlphaFold API request for '{entry}' returned HTTP "
+            f"{resp.status_code} (expected 200)")
+    records = resp.json()
+    if not records:
+        return None
+    record = records[0]
+    model_key = "cifUrl" if file_format == "cif" else "pdbUrl"
+    model_url = record.get(model_key)
+    if model_url is None:
+        raise RuntimeError(
+            f"AlphaFold API record for '{entry}' has no '{model_key}' "
+            f"(unexpected API shape; available URL keys: "
+            f"{[k for k in record if k.endswith('Url')]})")
+    pae_url = record.get("paeDocUrl")
+    return model_url, pae_url
 
 
 def fetch_af_file(url: str, dest_path: Path, timeout: float = 30.0) -> bool:
@@ -122,10 +163,16 @@ def fetch_alphafold_bulk(
         if verbose:
             ut.print_out(
                 f"Fetching AlphaFold {file_format} + PAE for '{entry}'")
-        model_ok = model_present or fetch_af_file(
-            _af_model_url(entry, file_format), model_path, timeout)
-        pae_ok = pae_present or fetch_af_file(
-            _af_pae_url(entry), pae_path, timeout)
+        # Resolve current download URLs via the API (version-agnostic). None =>
+        # the accession is not in AlphaFold DB; both files are then not-ok.
+        resolved = _af_resolve_urls(entry, file_format, timeout)
+        if resolved is None:
+            model_ok, pae_ok = model_present, pae_present
+        else:
+            model_url, pae_url = resolved
+            model_ok = model_present or fetch_af_file(model_url, model_path, timeout)
+            pae_ok = pae_present or (
+                pae_url is not None and fetch_af_file(pae_url, pae_path, timeout))
         if not model_ok:
             warnings.warn(
                 f"AlphaFold model for '{entry}' not found in AlphaFold DB "

--- a/aaanalysis/data_handling_pro/_struct_preproc.py
+++ b/aaanalysis/data_handling_pro/_struct_preproc.py
@@ -460,14 +460,16 @@ class StructurePreprocessor:
         """Download AlphaFold model + Predicted Aligned Error (PAE) files for
         every entry into a folder.
 
-        Fetches each entry's structure (``AF-<entry>-F1-model_v4``) and PAE sidecar
-        from the AlphaFold Protein Structure Database [Varadi22]_
-        (https://alphafold.ebi.ac.uk), saving them under the canonical filenames
-        :meth:`encode_pdb` / :meth:`encode_pae` / :meth:`get_dssp` already
-        resolve — so a single call populates the ``pdb_folder`` / ``pae_folder``
-        those methods consume. This is the ``fetch_`` (web) acquisition
-        counterpart to the local ``get_`` tools; it downloads all entries in
-        one bulk call.
+        Fetches each entry's F1 structure and PAE sidecar from the AlphaFold
+        Protein Structure Database [Varadi22]_ (https://alphafold.ebi.ac.uk),
+        saving them under the canonical filenames :meth:`encode_pdb` /
+        :meth:`encode_pae` / :meth:`get_dssp` already resolve — so a single call
+        populates the ``pdb_folder`` / ``pae_folder`` those methods consume. The
+        download URLs are resolved through the AlphaFold API, so the fetch tracks
+        the current data version automatically (the file naming moved
+        ``v4`` → ``v6`` and will move again). This is the ``fetch_`` (web)
+        acquisition counterpart to the local ``get_`` tools; it downloads all
+        entries in one bulk call.
 
         .. versionadded:: 1.1.0
 

--- a/docs/source/index/release_notes.rst
+++ b/docs/source/index/release_notes.rst
@@ -184,6 +184,13 @@ Improved
 
 Fixed
 ~~~~~
+- **StructurePreprocessor.fetch_alphafold**: Resolve download URLs through the
+  AlphaFold API instead of a hardcoded file version. AlphaFold DB renamed its
+  files ``v4`` → ``v6``, which had silently broken every fetch (all entries
+  returned ``alphafold_ok=False``); the fetch now tracks the current version
+  automatically. Added a ``network``-marked live test (``tests/integration/``)
+  so an upstream API/version change is caught instead of slipping past the
+  mocked unit tests.
 - **General Bug Fixes**: Minor fixes related to dependency resolution and edge-case behavior.
 - **Documentation**: Removed inconsistencies in documentation for selected functions and plotting options.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,25 @@ import aaanalysis as aa
 from aaanalysis.config import _dict_options
 
 
+# Live-endpoint ('network'-marked) tests are skipped by default so they never run
+# in the blocking matrix (a per-job 'pytest -m "not regression"' would otherwise
+# hit AlphaFold/UniProt live on every push). Run them with '--run-network' (the
+# nightly does) to catch upstream API/version breakage. A code-side regression is
+# still caught networklessly by the mocked unit tests.
+def pytest_addoption(parser):
+    parser.addoption("--run-network", action="store_true", default=False,
+                     help="run 'network'-marked tests against live endpoints")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-network"):
+        return
+    skip_network = pytest.mark.skip(reason="live endpoint; pass --run-network to run")
+    for item in items:
+        if "network" in item.keywords:
+            item.add_marker(skip_network)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def _warm_matplotlib():
     """Prime matplotlib's font cache + first-figure cost ONCE per session.

--- a/tests/integration/test_online_fetches.py
+++ b/tests/integration/test_online_fetches.py
@@ -1,0 +1,50 @@
+"""Live network tests for the package's online fetches.
+
+Deselected by default (``-m "not network"``); run on demand or in the nightly so
+that an upstream API / file-version change — e.g. AlphaFold DB's ``v4`` -> ``v6``
+file rename, which silently broke ``fetch_alphafold`` because the URL version was
+hardcoded — is caught here instead of slipping past the mocked unit tests.
+
+Add a live test here for every method that reaches an external endpoint.
+"""
+import tempfile
+
+import pandas as pd
+import pytest
+
+import aaanalysis as aa
+from aaanalysis.data_handling_pro._backend.struct_preproc import _alphafold as af
+
+pytestmark = pytest.mark.network
+
+# A small, stable, reviewed UniProt accession that is in AlphaFold DB.
+KNOWN_ENTRY = "P05067"  # human amyloid precursor protein (APP)
+
+
+class TestAlphaFoldFetchLive:
+    """fetch_alphafold against the real AlphaFold-DB endpoint."""
+
+    def test_resolve_urls_returns_a_current_model_url(self):
+        # Pins the API contract fetch_alphafold depends on. If AlphaFold renames
+        # fields or bumps the file version again, this fails loudly.
+        resolved = af._af_resolve_urls(KNOWN_ENTRY, "pdb", timeout=30.0)
+        assert resolved is not None, (
+            "AlphaFold API returned no record for a known entry "
+            f"({KNOWN_ENTRY}) — the API endpoint/shape may have changed")
+        model_url, pae_url = resolved
+        assert model_url.endswith(".pdb")
+        assert f"AF-{KNOWN_ENTRY}-F1-model" in model_url
+        assert pae_url is not None and pae_url.endswith(".json")
+
+    def test_unknown_accession_is_soft_not_found(self):
+        # A malformed accession is the soft "not in AF-DB" case, not a crash.
+        assert af._af_resolve_urls("NOTAREALACCESSION", "pdb", timeout=30.0) is None
+
+    def test_fetch_alphafold_downloads_a_real_structure(self):
+        df = pd.DataFrame({"entry": [KNOWN_ENTRY], "sequence": ["MKV"], "label": [1]})
+        stp = aa.StructurePreprocessor(verbose=False)
+        out = tempfile.mkdtemp()
+        status = stp.fetch_alphafold(df_seq=df, out_folder=out, on_failure="nan")
+        assert bool(status.iloc[0]["alphafold_ok"]) is True, (
+            f"fetch_alphafold failed for a known AlphaFold-DB entry ({KNOWN_ENTRY}) "
+            "— the upstream file naming/version likely changed; see _af_resolve_urls")

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -18,3 +18,4 @@ minversion = 6.0
 markers =
     regression: frozen exact-value CPP anchor; pinned to the canonical cell (Linux/py3.11) and skipped elsewhere (ADR-0015).
     slow: opt-in heavy test; deselect with -m "not slow" in fast CI runs.
+    network: hits a live external endpoint (AlphaFold/UniProt/HF); deselected by default with -m "not network", run on demand / in the nightly to catch upstream API breakage.

--- a/tests/unit/data_handling_pro_tests/test_alphafold_backend.py
+++ b/tests/unit/data_handling_pro_tests/test_alphafold_backend.py
@@ -35,26 +35,82 @@ def _seq_responses(*statuses):
 
 
 # II Test Classes
+def _api_resp(status=200,
+              pdb_url="https://alphafold.ebi.ac.uk/files/AF-P1-F1-model_v6.pdb",
+              pae_url="https://alphafold.ebi.ac.uk/files/AF-P1-F1-predicted_aligned_error_v6.json",
+              records="default"):
+    """Mock an AlphaFold prediction-API response (carries .json())."""
+    m = MagicMock()
+    m.status_code = status
+    if records == "default":
+        records = [{"pdbUrl": pdb_url, "cifUrl": pdb_url.replace(".pdb", ".cif"),
+                    "paeDocUrl": pae_url}] if status == 200 else None
+    m.json.return_value = records
+    return m
+
+
 class TestUrlAndFilenameHelpers:
-    """URL templates + local filename helpers."""
-
-    def test_model_url_pdb(self):
-        assert af._af_model_url("P12345", "pdb") == (
-            "https://alphafold.ebi.ac.uk/files/AF-P12345-F1-model_v4.pdb")
-
-    def test_model_url_cif(self):
-        assert af._af_model_url("P12345", "cif").endswith(
-            "AF-P12345-F1-model_v4.cif")
-
-    def test_pae_url(self):
-        assert af._af_pae_url("P12345").endswith(
-            "AF-P12345-F1-predicted_aligned_error_v4.json")
+    """Local filename helpers (download URLs are resolved via the API now)."""
 
     def test_model_filename_pdb(self):
         assert af._af_model_filename("P1", "pdb") == "P1.pdb"
 
     def test_model_filename_cif(self):
         assert af._af_model_filename("P1", "cif") == "P1.cif"
+
+
+class TestResolveUrls:
+    """_af_resolve_urls: version-agnostic URL resolution via the API.
+
+    This is the regression guard for the v4 -> v6 breakage: it pins the API
+    fields the resolver reads, so a code-side change is caught networklessly
+    (the live-endpoint guard is the network test in tests/integration/)."""
+
+    def test_valid_returns_pdb_and_pae_urls(self):
+        with patch(f"{MODULE}.requests.get", return_value=_api_resp()):
+            model_url, pae_url = af._af_resolve_urls("P1", "pdb", 5.0)
+        assert model_url.endswith("model_v6.pdb")
+        assert pae_url.endswith("predicted_aligned_error_v6.json")
+
+    def test_valid_cif_uses_cif_url(self):
+        with patch(f"{MODULE}.requests.get", return_value=_api_resp()):
+            model_url, _ = af._af_resolve_urls("P1", "cif", 5.0)
+        assert model_url.endswith("model_v6.cif")
+
+    def test_valid_404_returns_none(self):
+        with patch(f"{MODULE}.requests.get", return_value=_api_resp(404)):
+            assert af._af_resolve_urls("P1", "pdb", 5.0) is None
+
+    def test_valid_400_returns_none(self):
+        with patch(f"{MODULE}.requests.get", return_value=_api_resp(400)):
+            assert af._af_resolve_urls("BADACC", "pdb", 5.0) is None
+
+    def test_valid_empty_records_returns_none(self):
+        with patch(f"{MODULE}.requests.get", return_value=_api_resp(records=[])):
+            assert af._af_resolve_urls("P1", "pdb", 5.0) is None
+
+    def test_valid_no_pae_doc_url(self):
+        with patch(f"{MODULE}.requests.get",
+                   return_value=_api_resp(records=[{"pdbUrl": "http://m.pdb"}])):
+            model_url, pae_url = af._af_resolve_urls("P1", "pdb", 5.0)
+        assert model_url == "http://m.pdb" and pae_url is None
+
+    def test_invalid_500_raises(self):
+        with patch(f"{MODULE}.requests.get", return_value=_api_resp(500)):
+            with pytest.raises(RuntimeError, match="HTTP 500"):
+                af._af_resolve_urls("P1", "pdb", 5.0)
+
+    def test_invalid_missing_model_key_raises(self):
+        with patch(f"{MODULE}.requests.get",
+                   return_value=_api_resp(records=[{"paeDocUrl": "x"}])):
+            with pytest.raises(RuntimeError, match="no 'pdbUrl'"):
+                af._af_resolve_urls("P1", "pdb", 5.0)
+
+    def test_invalid_transport_error_raises(self):
+        with patch(f"{MODULE}.requests.get",
+                   side_effect=requests.RequestException("boom")):
+            with pytest.raises(RuntimeError, match="failed"):
+                af._af_resolve_urls("P1", "pdb", 5.0)
 
 
 class TestFetchAfFile:
@@ -100,7 +156,25 @@ class TestFetchAfFile:
 
 
 class TestFetchAlphafoldBulk:
-    """fetch_alphafold_bulk: single/multiple/skip/partial/mixed/verbose."""
+    """fetch_alphafold_bulk: single/multiple/skip/partial/mixed/verbose.
+
+    URL resolution is stubbed here so these exercise the download/skip/404-file
+    logic; _af_resolve_urls itself is covered by TestResolveUrls."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_resolve_urls(self):
+        with patch(f"{MODULE}._af_resolve_urls",
+                   return_value=("https://af/model", "https://af/pae")):
+            yield
+
+    def test_valid_accession_not_in_afdb(self, tmp_path):
+        # API resolves to None (404/400) -> both files not-ok, no crash.
+        with patch(f"{MODULE}._af_resolve_urls", return_value=None):
+            with pytest.warns(UserWarning):
+                df = af.fetch_alphafold_bulk(["P1"], tmp_path, "pdb",
+                                             30.0, True, False)
+        assert not bool(df.iloc[0]["alphafold_ok"])
+        assert not bool(df.iloc[0]["model_ok"]) and not bool(df.iloc[0]["pae_ok"])
 
     def test_valid_single_entry_both_ok(self, tmp_path):
         with patch(f"{MODULE}.requests.get",
@@ -199,6 +273,12 @@ class TestFetchAlphafoldBulk:
 
 class TestFetchAlphafoldBulkComplex:
     """Cross-cutting: parity with the resolvers + path bookkeeping."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_resolve_urls(self):
+        with patch(f"{MODULE}._af_resolve_urls",
+                   return_value=("https://af/model", "https://af/pae")):
+            yield
 
     def test_written_names_resolve_via_resolvers(self, tmp_path):
         # The no-glue contract: backend-written filenames are exactly what

--- a/tests/unit/data_handling_pro_tests/test_structure_preprocessor_fetch_alphafold.py
+++ b/tests/unit/data_handling_pro_tests/test_structure_preprocessor_fetch_alphafold.py
@@ -36,6 +36,17 @@ def _patch_get(*statuses):
     return patch(f"{BACKEND}.requests.get", side_effect=_responses(*statuses))
 
 
+@pytest.fixture(autouse=True)
+def _stub_af_resolve_urls():
+    """Resolve URLs without the network so the ``requests.get`` mocks below
+    drive only the two file downloads (model + PAE). The resolver itself is
+    unit-tested in test_alphafold_backend.py::TestResolveUrls and live-checked
+    by the network test."""
+    with patch(f"{BACKEND}._af_resolve_urls",
+               return_value=("https://af/model", "https://af/pae")):
+        yield
+
+
 # II Test Classes
 class TestFetchAlphafold:
     """Normal cases and per-parameter validation (one parameter per test)."""


### PR DESCRIPTION
## The bug
`StructurePreprocessor.fetch_alphafold` was **silently broken**: it built download URLs with a hardcoded data version (`AF-<entry>-F1-model_v4.pdb`), but AlphaFold DB renamed its files **`v4` → `v6`**, so every fetch 404'd and returned `alphafold_ok=False` for all entries. Nothing caught it because **no test made a real network call** (integration/e2e were deferred per sharp-edges — exactly the gap).

## The fix
- **Resolve URLs via the AlphaFold prediction API** (`_af_resolve_urls`) instead of guessing the file version. The API always reports the current `pdbUrl`/`cifUrl`/`paeDocUrl`, so the fetch tracks `v6` and any future bump automatically. A `400`/`404` from the API is the soft "not in AF-DB" case (`on_failure` governs); other statuses raise `RuntimeError`. Local filenames are unchanged, so the existing resolvers still feed `encode_pdb`/`encode_pae`/`get_dssp` with no glue.

## Tests (the missing guard)
- **Networkless unit tests** (`TestResolveUrls`) pin the API fields the resolver reads — a code-side regression is caught without a network call. Bulk-download tests stub the resolver, so the download/skip/404-file logic is unchanged (752 pro tests green).
- **A real `network`-marked test** (`tests/integration/test_online_fetches.py`) actually fetches a known structure (P05067). It's **skipped by default** via a `conftest.py` `--run-network` opt-in (so it never runs in the blocking matrix), and **wired into the non-gating nightly** (`-m network --run-network`) so an upstream API/version change shows up as a red nightly instead of slipping through.

## CONFIRM-FIRST
- **`mutation_nightly.yml`** is edited (adds the live-fetch step) — done per the explicit request that online fetches always be tested. Non-gating, never blocks PRs.

## Why it wasn't caught before
Online fetches had only mocked tests; the mocks happily returned 200 for the stale `v4` URL. This PR adds the real-endpoint guard so version/API drift can't pass silently again.