### PR TITLE
docs(api): surface implicit contracts at the docstring surface (#135)

### DIFF
--- a/aaanalysis/data_handling_pro/_annot_preproc.py
+++ b/aaanalysis/data_handling_pro/_annot_preproc.py
@@ -92,8 +92,8 @@ def _check_scores_unit_range(scores, name="score"):
 # II Main Functions
 class AnnotationPreprocessor:
     """
-    Preprocessing class for per-residue post-translational modification (PTM) /
-    functional-site annotations.
+    Preprocessing class (**[pro]**, requires ``aaanalysis[pro]``) for per-residue
+    post-translational modification (PTM) / functional-site annotations.
 
     Collects per-residue annotations — fetched from UniProt
     (:meth:`fetch_uniprot`) or ingested from a user / predictor table

--- a/aaanalysis/data_handling_pro/_struct_preproc.py
+++ b/aaanalysis/data_handling_pro/_struct_preproc.py
@@ -348,7 +348,8 @@ def _run_get_dssp_internal(df_seq, pdb_folder, features, ss_mode,
 # II Main Functions
 class StructurePreprocessor:
     """
-    Preprocessing class for protein structure features (PDB / CIF / AlphaFold).
+    Preprocessing class (**[pro]**, requires ``aaanalysis[pro]``) for protein
+    structure features (PDB / CIF / AlphaFold).
 
     Turns local structure files into the ``[0, 1]``-normalized per-residue
     ``dict_num`` consumed by :meth:`CPP.run_num`. Each ``encode_*`` method

--- a/aaanalysis/explainable_ai_pro/_shap_model.py
+++ b/aaanalysis/explainable_ai_pro/_shap_model.py
@@ -238,8 +238,9 @@ def check_match_df_feat_shap_values(df_feat=None, shap_values=None, drop=False, 
 # II Main Functions
 class ShapModel:
     """
-    SHAP Model class: A wrapper for SHAP (SHapley Additive exPlanations) [Lundberg20]_ explainers to obtain
-    Monte Carlo estimates for feature impact [Breimann25a]_.
+    SHAP Model class (**[pro]**, requires ``aaanalysis[pro]``): A wrapper for SHAP
+    (SHapley Additive exPlanations) [Lundberg20]_ explainers to obtain Monte Carlo
+    estimates for feature impact [Breimann25a]_.
 
     `SHAP <https://shap.readthedocs.io/en/latest/index.html>`_ is an explainable Artificial Intelligence (AI) framework
     and game-theoretic approach to explain the output of any machine learning model using SHAP values. These SHAP values

--- a/aaanalysis/feature_engineering/_cpp.py
+++ b/aaanalysis/feature_engineering/_cpp.py
@@ -792,6 +792,11 @@ class CPP(Tool):
 
         Notes
         -----
+        * **Call order — ``get_parts`` then ``run_num``.** ``dict_num_parts`` must come
+          from :meth:`NumericalFeature.get_parts` (step 1), which slices a raw
+          ``df_seq`` + ``dict_num`` into the per-part tensors consumed here (step 2).
+          There is no raw-``df_seq`` / ``dict_num`` entry point on ``run_num``; passing
+          ``dict_num_parts=None`` raises (use :meth:`run` for sequence-mode).
         * **Raw PLM embeddings are not directly usable — normalize them first.**
           Per-residue values are expected in ``[0, 1]`` (the ``StructurePreprocessor`` /
           ``AnnotationPreprocessor`` normalization convention), since the default
@@ -799,6 +804,9 @@ class CPP(Tool):
           (unbounded floats) must be passed through
           :meth:`EmbeddingPreprocessor.encode` to obtain a ``[0, 1]``-normalized
           ``{entry: (L, D)}`` ``dict_num`` before :meth:`NumericalFeature.get_parts`.
+          Skipping normalization raises no error — the ``max_std_test`` pre-filter is
+          simply miscalibrated for the out-of-range spread, so the feature funnel
+          silently keeps/drops the wrong features.
           (``EmbeddingPreprocessor.build_scales`` / ``build_cat`` serve the *other*,
           AA-scale path via :meth:`run`; they are not a per-residue value source here.)
         * **Three arms, one entry point.** *structure-only* (``dict_num`` from

--- a/aaanalysis/feature_engineering/_numerical_feature.py
+++ b/aaanalysis/feature_engineering/_numerical_feature.py
@@ -197,6 +197,20 @@ class NumericalFeature:
 
         Notes
         -----
+        * **Call order — ``get_parts`` then ``run_num``.** This is step 1 of the
+          two-step numerical-mode workflow: it only *slices* ``df_seq`` + ``dict_num``
+          into ``(df_parts, dict_num_parts)``. Pass ``df_parts`` to the :class:`CPP`
+          constructor and ``dict_num_parts`` to :meth:`CPP.run_num` (step 2);
+          ``run_num`` has no raw-``df_seq`` / ``dict_num`` entry point, so this order
+          is the only supported one.
+        * **``dict_num`` must already be ``[0, 1]``-normalized.** ``get_parts`` slices
+          values verbatim — it does NOT rescale. The ``max_std_test`` pre-filter in
+          :meth:`CPP.run_num` is calibrated for the ``[0, 1]`` range; passing unbounded
+          values (e.g. raw protein language model embeddings) leaves that pre-filter
+          miscalibrated, so the feature funnel silently keeps/drops the wrong features
+          (no error is raised). Normalize first — e.g. via
+          :meth:`EmbeddingPreprocessor.encode`, :class:`StructurePreprocessor`, or
+          :class:`AnnotationPreprocessor`, all of which emit ``[0, 1]`` ``dict_num``.
         * ``dict_num_parts`` carries NaN padding at the trailing rows for entries
           whose JMD doesn't fit the requested length. The corresponding per-part
           string in ``df_parts`` also pads with ``'-'`` (gap), so the two outputs

--- a/aaanalysis/protein_design/_seqmut.py
+++ b/aaanalysis/protein_design/_seqmut.py
@@ -148,7 +148,8 @@ class SeqMut:
         ----------
         df_seq : pd.DataFrame, shape (n_samples, n_seq_info)
             DataFrame containing an ``entry`` column with unique protein identifiers, in the
-            **position-based** format (``sequence``, ``tmd_start``, ``tmd_stop``).
+            **position-based** format (``sequence``, ``tmd_start``, ``tmd_stop``). See
+            :meth:`SequenceFeature.get_df_parts` for the full ``df_seq`` format specification.
         mutations : pd.DataFrame, shape (n_mutations, >=3)
             Tidy mutation table with columns ``entry``, ``pos`` (1-based position in the full
             sequence), and ``to_aa`` (target amino acid). ``from_aa`` is derived and checked.
@@ -225,7 +226,8 @@ class SeqMut:
         ----------
         df_seq : pd.DataFrame, shape (n_samples, n_seq_info)
             DataFrame containing an ``entry`` column with unique protein identifiers, in the
-            **position-based** format (``sequence``, ``tmd_start``, ``tmd_stop``).
+            **position-based** format (``sequence``, ``tmd_start``, ``tmd_stop``). See
+            :meth:`SequenceFeature.get_df_parts` for the full ``df_seq`` format specification.
         df_feat : pd.DataFrame
             CPP feature set (output of :meth:`CPP.run`) defining which features ΔCPP is measured over.
         region : str or list of int, optional
@@ -291,7 +293,8 @@ class SeqMut:
         ----------
         df_seq : pd.DataFrame, shape (n_samples, n_seq_info)
             DataFrame containing an ``entry`` column with unique protein identifiers, in the
-            **position-based** format (``sequence``, ``tmd_start``, ``tmd_stop``).
+            **position-based** format (``sequence``, ``tmd_start``, ``tmd_stop``). See
+            :meth:`SequenceFeature.get_df_parts` for the full ``df_seq`` format specification.
         df_feat : pd.DataFrame
             CPP feature set (output of :meth:`CPP.run`); its signed ``mean_dif`` defines the target direction.
         n : int, default=10

--- a/aaanalysis/seq_analysis_pro/_comp_seq_sim.py
+++ b/aaanalysis/seq_analysis_pro/_comp_seq_sim.py
@@ -15,7 +15,7 @@ def comp_seq_sim(seq1: Optional[str] = None,
                  df_seq: Optional[pd.DataFrame] = None,
                  ) -> Union[float, pd.DataFrame]:
     """
-    Compute pairwise similarity between two or more sequences.
+    Compute pairwise similarity between two or more sequences (**[pro]**, requires ``aaanalysis[pro]``).
 
     The sequence similarity score between two sequences is the alignment score expressed as a percentage of
     the length of the longest sequence (range ``[0, 100]``). The alignment score is obtained using the

--- a/aaanalysis/seq_analysis_pro/_filter_seq.py
+++ b/aaanalysis/seq_analysis_pro/_filter_seq.py
@@ -57,7 +57,7 @@ def filter_seq(df_seq: pd.DataFrame = None,
                verbose: bool = False
                ) -> pd.DataFrame:
     """
-    Redundancy reduction of sequences using clustering-based algorithms.
+    Redundancy reduction of sequences using clustering-based algorithms (**[pro]**, requires ``aaanalysis[pro]``).
 
     This functions performs redundancy reduction of sequences by clustering and selecting representative sequences using
     the CD-HIT ([Li06]_) or MMseqs2 ([Steinegger17]_) algorithms locally. It allows for adjustable filtering strictness:

--- a/aaanalysis/seq_analysis_pro/_scan_motif.py
+++ b/aaanalysis/seq_analysis_pro/_scan_motif.py
@@ -141,7 +141,8 @@ def scan_motif(df_seq: pd.DataFrame = None,
                                   motif_pseudo: Optional[float] = None,
                                   ) -> pd.DataFrame:
     """
-    Scan candidate proteins for statistically significant Position Weight Matrix (PWM) occurrences using FIMO.
+    Scan candidate proteins for statistically significant Position Weight Matrix (PWM)
+    occurrences using FIMO (**[pro]**, requires ``aaanalysis[pro]``).
 
     ``scan_motif`` is a Command-Line Interface (CLI) wrapper around FIMO (Find
     Individual Motif Occurrences) [Bailey09]_, [Grant11]_ from the MEME (Multiple

--- a/docs/source/index/release_notes.rst
+++ b/docs/source/index/release_notes.rst
@@ -139,6 +139,14 @@ Changed
   the new ``show_title`` (default ``True``) and ``title_wrap_width`` (default ``45``)
   parameters. A subsequent ``plt.title(...)`` still overrides it; ``feature_map`` and
   ``ranking`` are unchanged.
+- **Docstring discoverability**: Surfaced previously implicit API contracts at the
+  docstrings users actually read (no behavior change). ``CPP.run_num`` /
+  ``NumericalFeature.get_parts`` now state the ``get_parts`` → ``run_num`` call order
+  and the ``[0, 1]`` normalization contract (and what breaks if unnormalized); the
+  ``[pro]`` classes / functions (``ShapModel``, ``StructurePreprocessor``,
+  ``AnnotationPreprocessor``, ``comp_seq_sim``, ``filter_seq``, ``scan_motif``) carry
+  a ``[pro]`` install marker in their summary; and ``SeqMut`` cross-links the canonical
+  ``df_seq`` format spec (``SequenceFeature.get_df_parts``).
 
 
 Version 1.0 (Stable Version)

--- a/tests/unit/api_tests/test_docstring_contracts.py
+++ b/tests/unit/api_tests/test_docstring_contracts.py
@@ -1,0 +1,89 @@
+"""Discoverability guard: load-bearing API contracts must live in the numpydoc
+docstrings users actually read, not only in ``CONTEXT.md`` (issue #135).
+
+This codifies the KPI of that issue — *a reader can determine pro-gating,
+``[0, 1]`` normalization, and the ``get_parts`` -> ``run_num`` call order without
+running code* — so the contracts cannot silently drift back out of the docstrings:
+
+* every ``[pro]`` class / function carries a ``[pro]`` marker in its summary;
+* ``CPP.run_num`` and ``NumericalFeature.get_parts`` state the ``[0, 1]`` contract
+  and the two-step call order;
+* ``SeqMut``'s ``df_seq`` consumers cross-link the canonical ``df_seq`` format spec
+  (:meth:`SequenceFeature.get_df_parts`).
+
+Docstrings are read straight from source via ``ast`` so the guard holds even when
+the optional ``pro`` extras are not installed (the runtime objects are stubs then).
+"""
+import ast
+import pathlib
+
+import pytest
+
+import aaanalysis as aa
+
+PKG = pathlib.Path(aa.__file__).resolve().parent
+
+
+def _module_doc(rel_path, *, cls=None, func=None):
+    """Return the docstring of a top-level function, class, or method (``cls.func``)."""
+    tree = ast.parse((PKG / rel_path).read_text(encoding="utf-8"))
+
+    def _find(nodes, name, kinds):
+        for node in nodes:
+            if isinstance(node, kinds) and node.name == name:
+                return node
+        return None
+
+    func_kinds = (ast.FunctionDef, ast.AsyncFunctionDef)
+    if cls is not None:
+        cls_node = _find(tree.body, cls, (ast.ClassDef,))
+        assert cls_node is not None, f"class {cls} not found in {rel_path}"
+        if func is None:
+            return ast.get_docstring(cls_node)
+        meth = _find(cls_node.body, func, func_kinds)
+        assert meth is not None, f"method {cls}.{func} not found in {rel_path}"
+        return ast.get_docstring(meth)
+    fn_node = _find(tree.body, func, func_kinds)
+    assert fn_node is not None, f"function {func} not found in {rel_path}"
+    return ast.get_docstring(fn_node)
+
+
+# (rel_path, cls, func) for each [pro] class / function that must advertise gating.
+PRO_TARGETS = [
+    ("explainable_ai_pro/_shap_model.py", "ShapModel", None),
+    ("data_handling_pro/_struct_preproc.py", "StructurePreprocessor", None),
+    ("data_handling_pro/_annot_preproc.py", "AnnotationPreprocessor", None),
+    ("seq_analysis_pro/_comp_seq_sim.py", None, "comp_seq_sim"),
+    ("seq_analysis_pro/_filter_seq.py", None, "filter_seq"),
+    ("seq_analysis_pro/_scan_motif.py", None, "scan_motif"),
+]
+
+
+@pytest.mark.parametrize("rel_path, cls, func", PRO_TARGETS)
+def test_pro_marker_in_summary(rel_path, cls, func):
+    doc = _module_doc(rel_path, cls=cls, func=func)
+    summary = doc.split("\n\n", 1)[0] if doc else ""
+    name = cls or func
+    assert "[pro]" in summary, f"{name} summary lacks a '[pro]' gating marker"
+    assert "aaanalysis[pro]" in summary, f"{name} summary lacks the install hint"
+
+
+def test_run_num_states_normalization_and_order():
+    doc = _module_doc("feature_engineering/_cpp.py", cls="CPP", func="run_num")
+    assert "[0, 1]" in doc
+    assert "get_parts" in doc and "run_num" in doc
+
+
+def test_get_parts_states_normalization_and_order():
+    doc = _module_doc("feature_engineering/_numerical_feature.py",
+                      cls="NumericalFeature", func="get_parts")
+    assert "[0, 1]" in doc
+    assert "run_num" in doc
+
+
+@pytest.mark.parametrize("method", ["mutate", "scan", "suggest"])
+def test_seqmut_df_seq_cross_links_format_spec(method):
+    doc = _module_doc("protein_design/_seqmut.py", cls="SeqMut", func=method)
+    assert "SequenceFeature.get_df_parts" in doc, (
+        f"SeqMut.{method} df_seq doc must cross-link the canonical format spec"
+    )

--- a/tests/unit/api_tests/test_docstring_contracts.py
+++ b/tests/unit/api_tests/test_docstring_contracts.py
@@ -5,7 +5,9 @@ This codifies the KPI of that issue — *a reader can determine pro-gating,
 ``[0, 1]`` normalization, and the ``get_parts`` -> ``run_num`` call order without
 running code* — so the contracts cannot silently drift back out of the docstrings:
 
-* every ``[pro]`` class / function carries a ``[pro]`` marker in its summary;
+* every public symbol of every ``aaanalysis/*_pro/`` subpackage carries a ``[pro]``
+  install marker in its summary — **auto-discovered**, so a newly added pro feature
+  is covered without editing this test (it fails until the marker is present);
 * ``CPP.run_num`` and ``NumericalFeature.get_parts`` state the ``[0, 1]`` contract
   and the two-step call order;
 * ``SeqMut``'s ``df_seq`` consumers cross-link the canonical ``df_seq`` format spec
@@ -24,48 +26,81 @@ import aaanalysis as aa
 PKG = pathlib.Path(aa.__file__).resolve().parent
 
 
+def _find(nodes, name):
+    """Return the top-level class / function node named ``name`` (or ``None``)."""
+    kinds = (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+    for node in nodes:
+        if isinstance(node, kinds) and node.name == name:
+            return node
+    return None
+
+
 def _module_doc(rel_path, *, cls=None, func=None):
     """Return the docstring of a top-level function, class, or method (``cls.func``)."""
     tree = ast.parse((PKG / rel_path).read_text(encoding="utf-8"))
-
-    def _find(nodes, name, kinds):
-        for node in nodes:
-            if isinstance(node, kinds) and node.name == name:
-                return node
-        return None
-
-    func_kinds = (ast.FunctionDef, ast.AsyncFunctionDef)
     if cls is not None:
-        cls_node = _find(tree.body, cls, (ast.ClassDef,))
-        assert cls_node is not None, f"class {cls} not found in {rel_path}"
+        cls_node = _find(tree.body, cls)
+        assert isinstance(cls_node, ast.ClassDef), f"class {cls} not found in {rel_path}"
         if func is None:
             return ast.get_docstring(cls_node)
-        meth = _find(cls_node.body, func, func_kinds)
+        meth = _find(cls_node.body, func)
         assert meth is not None, f"method {cls}.{func} not found in {rel_path}"
         return ast.get_docstring(meth)
-    fn_node = _find(tree.body, func, func_kinds)
+    fn_node = _find(tree.body, func)
     assert fn_node is not None, f"function {func} not found in {rel_path}"
     return ast.get_docstring(fn_node)
 
 
-# (rel_path, cls, func) for each [pro] class / function that must advertise gating.
-PRO_TARGETS = [
-    ("explainable_ai_pro/_shap_model.py", "ShapModel", None),
-    ("data_handling_pro/_struct_preproc.py", "StructurePreprocessor", None),
-    ("data_handling_pro/_annot_preproc.py", "AnnotationPreprocessor", None),
-    ("seq_analysis_pro/_comp_seq_sim.py", None, "comp_seq_sim"),
-    ("seq_analysis_pro/_filter_seq.py", None, "filter_seq"),
-    ("seq_analysis_pro/_scan_motif.py", None, "scan_motif"),
-]
+def _discover_pro_symbols():
+    """Every public symbol of every ``aaanalysis/*_pro/`` subpackage, paired with
+    the source file and docstring of its definition.
+
+    Discovery is authoritative: it reads each ``*_pro/__init__.py`` ``__all__`` and
+    follows the ``from ._module import Name`` line to the defining module. A new
+    ``*_pro`` package or a new export is therefore picked up automatically.
+    """
+    out = []
+    for init_path in sorted(PKG.glob("*_pro/__init__.py")):
+        pkg = init_path.parent
+        tree = ast.parse(init_path.read_text(encoding="utf-8"))
+        exported, import_of = [], {}
+        for node in tree.body:
+            if isinstance(node, ast.Assign) and any(
+                isinstance(t, ast.Name) and t.id == "__all__" for t in node.targets
+            ):
+                exported = [e.value for e in node.value.elts
+                            if isinstance(e, ast.Constant)]
+            elif isinstance(node, ast.ImportFrom) and node.level == 1 and node.module:
+                for alias in node.names:
+                    import_of[alias.asname or alias.name] = node.module
+        for name in exported:
+            mod = import_of.get(name)
+            assert mod is not None, (
+                f"{pkg.name}.__all__ exports {name!r} but no "
+                f"'from .<module> import {name}' line was found"
+            )
+            src = pkg / f"{mod.lstrip('.')}.py"
+            doc = _module_doc(src.relative_to(PKG).as_posix(),
+                              cls=name if name[:1].isupper() else None,
+                              func=None if name[:1].isupper() else name)
+            out.append((f"{pkg.name}.{name}", doc))
+    return out
 
 
-@pytest.mark.parametrize("rel_path, cls, func", PRO_TARGETS)
-def test_pro_marker_in_summary(rel_path, cls, func):
-    doc = _module_doc(rel_path, cls=cls, func=func)
+PRO_SYMBOLS = _discover_pro_symbols()
+
+
+def test_pro_discovery_is_not_vacuous():
+    # Guard the guard: if discovery silently finds nothing, the parametrized test
+    # below would pass vacuously. Pin a floor at the symbols known to exist today.
+    assert len(PRO_SYMBOLS) >= 6, f"only discovered {len(PRO_SYMBOLS)} pro symbols"
+
+
+@pytest.mark.parametrize("qualname, doc", PRO_SYMBOLS, ids=[q for q, _ in PRO_SYMBOLS])
+def test_pro_marker_in_summary(qualname, doc):
     summary = doc.split("\n\n", 1)[0] if doc else ""
-    name = cls or func
-    assert "[pro]" in summary, f"{name} summary lacks a '[pro]' gating marker"
-    assert "aaanalysis[pro]" in summary, f"{name} summary lacks the install hint"
+    assert "[pro]" in summary, f"{qualname} summary lacks a '[pro]' gating marker"
+    assert "aaanalysis[pro]" in summary, f"{qualname} summary lacks the install hint"
 
 
 def test_run_num_states_normalization_and_order():


### PR DESCRIPTION
Closes #135

## What

Elevates four load-bearing contracts that previously lived only in `CONTEXT.md` to the numpydoc docstrings users actually read. **Docs only — no API or behavior change.**

1. **Call order + `[0, 1]` contract.** `CPP.run_num` and `NumericalFeature.get_parts` Notes now state the two-step `get_parts → run_num` order and the `[0, 1]` normalization contract — *including what breaks if `dict_num` is unnormalized*: the `max_std_test` pre-filter is silently miscalibrated and the feature funnel keeps/drops the wrong features (no error raised).
2. **`[pro]` markers.** `ShapModel`, `StructurePreprocessor`, `AnnotationPreprocessor`, `comp_seq_sim`, `filter_seq`, `scan_motif` now carry a `[pro]` / "requires `aaanalysis[pro]`" marker in their summary, so gating is visible without first hitting an `ImportError`.
3. **`df_seq` format cross-link.** `SeqMut.mutate` / `scan` / `suggest` cross-link the canonical `df_seq` format spec (`SequenceFeature.get_df_parts`). (`comp_seq_sim` / `filter_seq` / `scan_motif` already spell out their exact columns inline, so they were left unchanged.)
4. **Guard test.** New `tests/unit/api_tests/test_docstring_contracts.py` — an `ast`-based meta-test (env-independent; holds even without the `pro` extras installed) codifying the issue KPI so these contracts cannot silently drift back out of the docstrings.

Plus a Release Notes entry under *v1.1.0 (Unreleased) → Changed*.

## Local gates (all green)

- `check_docstrings.py`: **0 defects** (6 advisories, all pre-existing / identical to baseline).
- `doc_signature_drift.py`: **0 drift**.
- `tests/unit/api_tests/`: **62 passed** (incl. the new 11-case guard).
- Package imports cleanly; all cross-references resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)