### PR TITLE
feat(versioning): add CHANGELOG.md + strict-semver deprecation policy (#74)

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -6,8 +6,8 @@ paths:
 
 # CHANGELOG
 
-> **Status:** aspirational — `CHANGELOG.md` does not exist at the repo root yet.
-> Once created, the rules below kick in.
+> **Status:** active — `CHANGELOG.md` exists at the repo root (added with the
+> strict-semver deprecation policy, ADR-0030).
 
 - `CHANGELOG.md` lives at repo root, in
   [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
@@ -17,4 +17,13 @@ paths:
   user-visible change (new public symbol, signature change, behavior change,
   deprecation, important bug fix), Claude appends a one-line entry under the
   appropriate subsection in the same PR.
+- `CHANGELOG.md` is the **terse** index; the narrative, RTD-rendered notes live
+  in `docs/source/index/release_notes.rst`. Update **both** in the same PR — the
+  terse one-liner here, the prose entry there — and keep their `Unreleased`
+  sections in sync. Each file cross-links the other.
+- **Deprecation policy (semver-strict, ADR-0030).** Renaming/removing a public
+  symbol (one in `aaanalysis.__all__`) ships ≥1 minor release decorated with
+  `ut.deprecated(reason=..., version_removed=...)` (a `DeprecationWarning` +
+  a docstring deprecation note) before removal. Record the eventual removal
+  under `Removed`. The decorator is internal (`ut.deprecated`), not public API.
 - No `SECURITY.md` for now (documented gap).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,141 @@
+# Changelog
+
+All notable changes to **AAanalysis** are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html):
+from v1.x onward, any rename or removal of a public symbol (one re-exported by
+`aaanalysis/__init__.py`) ships at least one **minor** release carrying a
+`DeprecationWarning` (via `aaanalysis.utils.deprecated`) before the symbol is
+removed. See the *Versioning and Deprecation Policy* in `CONTRIBUTING.rst`.
+
+This is the terse, developer-facing index. The narrative, RTD-rendered release
+notes — with cross-references and examples — live in
+[`docs/source/index/release_notes.rst`](docs/source/index/release_notes.rst).
+
+## [Unreleased]
+
+This release substantially expands the feature-engineering surface: a unified
+feature-preprocessor family (embedding / structure / annotation sources), a
+numerical mode for CPP, a configuration-sweep wrapper, sequence-window sampling,
+and a suite of site-localization metrics and plotting helpers.
+
+### Added
+- `EmbeddingPreprocessor`, `StructurePreprocessor` (`[pro]`),
+  `AnnotationPreprocessor` (`[pro]`), and `combine_dict_nums` for building
+  per-residue numerical tensors as `CPP.run_num` input. New `[embed]` extra
+  isolates the heavy `torch` / `transformers` dependencies.
+- `CPPGrid` configuration-sweep wrapper and `CPP.run_num` numerical mode.
+- `SequenceFeature` label helpers (`get_labels_ovr` / `get_labels_ovo` /
+  `get_labels_quantile` / `get_labels_tiered`), `get_df_parts_from_windows`,
+  and `get_feature_descriptions`.
+- `AAclust.select_scales` and `AAclust.select_proteins`.
+- `AAWindowSampler` sequence-window sampler and `scan_motif` (`[pro]`, MEME/FIMO).
+- `aa.metrics` site-localization helpers: `comp_per_protein_ap`,
+  `comp_detection_metrics`, `comp_bootstrap_ci`, `comp_smooth_scores`.
+- `plot_rank` per-protein max-score-vs-rank scatter.
+- `aa.__version__` top-level attribute.
+- `aaanalysis.utils.deprecated(reason, version_removed)` decorator helper for
+  marking public symbols deprecated under the strict-semver policy (internal
+  helper; not part of the public API).
+- This `CHANGELOG.md`.
+
+### Changed
+- **CPP performance work lands in this release.** The Cython feature-matrix
+  kernel, macOS-safe threaded `n_jobs`, scale / AA-index caching, and scale /
+  sample batching together replace the hour-long, low-CPU runs seen on `1.0.3`
+  and earlier. **Users on `≤1.0.3` should upgrade** rather than debug a
+  performance pathology that is already fixed on `master`.
+- The Cython-fallback notice (shown when the compiled extension is missing and
+  CPP falls back to the ~2× slower pure-Python kernel) is now a one-time
+  `UserWarning` instead of an easily-missed INFO print, so it surfaces even with
+  `aa.options['verbose'] = False`.
+- `SequenceFeature.feature_matrix` accepts a `batch=` list of `df_parts` for a
+  single Cython pass.
+- `SequenceFeature.get_df_parts` / `NumericalFeature.get_parts` gain a
+  `pos`-anchor input mode (`tmd_len=`).
+- Unified `n_jobs` parallelism convention across `CPP` / `CPPGrid`, with an
+  `options['n_jobs']` global override.
+- `CPPPlot.feature` titles the plot with the feature's human-readable
+  description, controlled by new `show_title` / `title_wrap_width` parameters.
+
+### Deprecated
+- None. The strict-semver deprecation policy and the `deprecated` decorator are
+  now in force for all future public-API renames and removals.
+
+## [1.0.3] - 2026-04-06
+### Added
+- `AAlogo` and `AAlogoPlot` for amino acid logo visualization.
+
+### Changed
+- Dropped end-of-life Python 3.9; added 3.13 and 3.14 (now 3.10–3.14).
+- Migrated dependency management to a single `pyproject.toml` with `[pro]` /
+  `[docs]` / `[dev]` extras; added full `uv` support.
+
+> Note: `1.0.3` and earlier **predate the CPP performance work** (see the
+> Unreleased *Changed* section). Installs pinned to these versions can see
+> hour-long, low-CPU CPP runs; upgrading resolves it.
+
+## 1.0.2 - 2025-06-17
+### Changed
+- Faster CPP pipeline: 3–5× faster `CPP.run()` via optimized part-split-scale
+  generation and filtering.
+- `CPP.feature_map()` adds a cumulative per-residue importance bar plot.
+
+### Fixed
+- Minor dependency-resolution and edge-case fixes.
+
+## 1.0.1 - 2025-01-29
+### Changed
+- Better `[pro]` IDE integration (jump to implementation, not `__init__.py`).
+- Preserve original import-error messages for missing `[pro]` dependencies.
+
+### Fixed
+- Consistent subcategory ordering between heatmap and bar plot in the feature map.
+- `numpy>=2.0.0` compatibility.
+
+## [1.0.0] - 2024-07-01
+### Added
+- `SequencePreprocessor`, `comp_seq_sim`, `filter_seq`, and global `jmd_n/c_len`
+  options.
+
+### Changed
+- Renamed `ShapExplainer` → `ShapModel`; renamed the *Perturbation* module to
+  *Protein Design*. Biopython is now `[pro]`-only.
+
+### Fixed
+- Script-level multiprocessing support outside functions/classes.
+
+## 0.1.5 - 2024-04-18
+### Changed
+- Relicensed MIT → BSD-3-Clause; added a Code of Conduct.
+
+### Fixed
+- Replaced native `multiprocessing` with `joblib` for CPP / feature-matrix
+  construction.
+
+## 0.1.4 - 2024-04-09
+### Added
+- Split core vs `[pro]` install profiles.
+
+### Changed
+- General API consistency improvements; Python support extended to 3.12.
+
+## 0.1.3 - 2024-02-09
+### Added
+- `TreeModel`, `ShapExplainer`, `NumericalFeature`, and `load_features`.
+
+## 0.1.2 - 2023-11-06
+### Added
+- `CPPPlot`, `dPULearnPlot`, `AAclustPlot`, and the `options` interface.
+
+## [0.1.1] - 2023-09-11
+- Test release of the first beta version (`CPP`, `dPULearn`, `AAclust`,
+  `SequenceFeature`, `load_dataset`, `load_scales`).
+
+<!-- Only tags 0.1.1, v1.0.0, v1.0.3 exist; intermediate versions (1.0.1/1.0.2,
+     0.1.2–0.1.5) were never tagged, so only the real tags are linked here. -->
+[Unreleased]: https://github.com/breimanntools/aaanalysis/compare/v1.0.3...HEAD
+[1.0.3]: https://github.com/breimanntools/aaanalysis/compare/v1.0.0...v1.0.3
+[1.0.0]: https://github.com/breimanntools/aaanalysis/compare/0.1.1...v1.0.0
+[0.1.1]: https://github.com/breimanntools/aaanalysis/releases/tag/0.1.1

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -319,6 +319,60 @@ To generate the documentation locally:
 
 - Open `_build/html/index.html` in a browser.
 
+Versioning and Deprecation Policy
+=================================
+
+AAanalysis follows `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_
+(**MAJOR.MINOR.PATCH**) and is **semver-strict from v1.x onward**. The public API
+is exactly the set of symbols re-exported by ``aaanalysis/__init__.py`` (anything
+starting with ``_`` is private and may change without notice).
+
+Deprecation policy
+------------------
+
+Renaming or removing a public symbol is a breaking change. To give users a
+migration window, such a change is staged across releases:
+
+1. **Deprecate, don't remove.** Keep the symbol working and decorate it with
+   ``aaanalysis.utils.deprecated(reason=..., version_removed=...)``. Calling it
+   (or, for a class, instantiating it) then emits a ``DeprecationWarning`` naming
+   the replacement and the planned removal version, and the docstring gains a
+   deprecation note rendered in the API docs.
+
+   .. code-block:: python
+
+       import aaanalysis.utils as ut
+
+       @ut.deprecated(reason="Use 'new_name' instead.", version_removed="1.2.0")
+       def old_name(...):
+           ...
+
+2. **Ship at least one minor release** carrying the ``DeprecationWarning`` before
+   the symbol is removed.
+3. **Remove** the symbol only in a subsequent **minor** (or major) release, and
+   record it under ``Removed`` in the changelog.
+
+PATCH releases never rename or remove public symbols; MINOR releases add
+backward-compatible functionality (and may *introduce* deprecations); MAJOR
+releases may complete removals.
+
+Changelog
+---------
+
+Every user-visible change (new public symbol, signature change, behavior change,
+deprecation, or important bug fix) is recorded **in the same pull request** in two
+places:
+
+- ``CHANGELOG.md`` (repo root, `Keep a Changelog
+  <https://keepachangelog.com/en/1.1.0/>`_ format) — a terse, one-line-per-change
+  index under the top ``Unreleased`` section
+  (``Added`` / ``Changed`` / ``Deprecated`` / ``Removed`` / ``Fixed``).
+- ``docs/source/index/release_notes.rst`` — the narrative, RTD-rendered notes
+  under the current ``Unreleased`` version, with cross-references and examples.
+
+At release time, the ``Unreleased`` heading in both files is renamed to the new
+version with its date.
+
 Building New PyPi package version
 ---------------------------------
 

--- a/aaanalysis/_utils/decorators.py
+++ b/aaanalysis/_utils/decorators.py
@@ -8,8 +8,98 @@ import traceback
 from sklearn.exceptions import ConvergenceWarning, UndefinedMetricWarning
 import functools
 import re
+import textwrap
 
 # Helper functions
+def _build_deprecation_message(name=None, reason=None, version_removed=None):
+    """Assemble the user-facing DeprecationWarning text for a deprecated symbol."""
+    msg = f"'{name}' is deprecated"
+    if version_removed is not None:
+        msg += f" and will be removed in version {version_removed}"
+    msg += "."
+    if reason is not None:
+        msg += f" {reason}"
+    return msg
+
+
+def _prepend_deprecation_note(doc=None, reason=None, version_removed=None):
+    """Prepend a ``.. admonition:: Deprecated`` block to an existing docstring.
+
+    Sphinx renders it as a highlighted box in the API docs, so the deprecation is
+    visible both at call time (the warning) and in the rendered documentation. An
+    ``admonition`` (rather than the ``.. deprecated::`` directive) is used on
+    purpose: the latter requires a "deprecated since" version argument, whereas we
+    track the *removal* target — and an argument-less ``.. deprecated::`` is a
+    Sphinx build error. The body is always non-empty so the directive is valid.
+    """
+    body = []
+    if reason is not None:
+        body.append(reason)
+    if version_removed is not None:
+        body.append(f"Scheduled for removal in version {version_removed}.")
+    if not body:
+        body.append("This API is deprecated and will be removed in a future release.")
+    # Indent every physical line (a multi-line ``reason`` must stay inside the
+    # directive body, or Sphinx drops the continuation lines). textwrap.indent
+    # leaves blank lines un-prefixed, so no trailing whitespace creeps in.
+    indented = textwrap.indent("\n".join(body), "   ")
+    block = f".. admonition:: Deprecated\n\n{indented}"
+    if not doc:
+        return block + "\n"
+    return f"{block}\n\n{doc}"
+
+
+# Deprecation
+def deprecated(reason=None, version_removed=None):
+    """Mark a public function, method, or class as deprecated (semver policy).
+
+    Emits a :class:`DeprecationWarning` whenever the wrapped callable is invoked
+    (for a class, on instantiation) and prepends a ``.. admonition:: Deprecated``
+    note to its docstring. Per the project's strict-semver policy, a symbol in
+    ``aaanalysis.__all__`` must ship at least one minor release carrying this
+    decorator before it is renamed or removed.
+
+    Parameters
+    ----------
+    reason
+        Human-readable explanation and migration hint (e.g. the replacement
+        symbol). Appended to the warning message and the docstring note.
+    version_removed
+        The version in which the symbol is scheduled to be removed (e.g.
+        ``"1.2.0"``). Surfaced in both the warning and the docstring note.
+
+    Returns
+    -------
+    decorator
+        A decorator that wraps the target callable/class with the deprecation
+        warning while preserving its signature and metadata.
+    """
+    def decorator(obj):
+        msg = _build_deprecation_message(name=obj.__name__, reason=reason,
+                                         version_removed=version_removed)
+        doc = _prepend_deprecation_note(doc=obj.__doc__, reason=reason,
+                                        version_removed=version_removed)
+        if isinstance(obj, type):
+            orig_init = obj.__init__
+
+            @functools.wraps(orig_init)
+            def new_init(self, *args, **kwargs):
+                warnings.warn(msg, DeprecationWarning, stacklevel=2)
+                orig_init(self, *args, **kwargs)
+
+            obj.__init__ = new_init
+            obj.__doc__ = doc
+            return obj
+
+        @functools.wraps(obj)
+        def wrapper(*args, **kwargs):
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
+            return obj(*args, **kwargs)
+
+        wrapper.__doc__ = doc
+        return wrapper
+
+    return decorator
 
 
 # Catch backend errors

--- a/aaanalysis/feature_engineering/_backend/cpp_run.py
+++ b/aaanalysis/feature_engineering/_backend/cpp_run.py
@@ -130,19 +130,23 @@ def _pick_feature_matrix_builder():
 
     Public ``CPP.run`` and ``CPP.run_num`` both call this — neither exposes a
     user-facing backend switch (the choice is determined entirely by wheel
-    state at import time). One-time INFO notice on first fallback use so a
+    state at import time). One-time ``UserWarning`` on first fallback use so a
     pure-Python install isn't silent.
     """
     global _PYTHON_FALLBACK_NOTIFIED
     if _HAS_CYTHON_INNER:
         return get_feature_matrix_c_
     if not _PYTHON_FALLBACK_NOTIFIED:
-        ut.print_out(
-            "CPP using the Python kernel fallback — the compiled Cython "
+        # A real warning (not an INFO print) so it surfaces even with
+        # ``aa.options['verbose'] = False`` — a silent INFO let users blame the
+        # algorithm for ~2x-slower runs instead of reinstalling for the wheel.
+        warnings.warn(
+            "CPP is using the Python kernel fallback — the compiled Cython "
             "extension is not available in this install. Output is bit-exact "
             "with the Cython path but ~2x slower. Reinstall via "
             "`pip install --force-reinstall aaanalysis` to fetch a prebuilt "
-            "wheel."
+            "wheel.",
+            UserWarning,
         )
         _PYTHON_FALLBACK_NOTIFIED = True
     return get_feature_matrix_fast_

--- a/aaanalysis/utils.py
+++ b/aaanalysis/utils.py
@@ -30,7 +30,8 @@ from ._utils.utils_types import (ArrayLike1D,
                                  VALID_INT_FLOAT_TYPES)
 
 # Decorators
-from ._utils.decorators import (catch_backend_processing_error,
+from ._utils.decorators import (deprecated,
+                                catch_backend_processing_error,
                                 BackendProcessingError,
                                 catch_runtime_warnings,
                                 CatchRuntimeWarnings,

--- a/docs/adr/0030-changelog-and-deprecation-policy.md
+++ b/docs/adr/0030-changelog-and-deprecation-policy.md
@@ -1,0 +1,70 @@
+# ADR-0030 — Strict-semver deprecation policy, `deprecated` decorator, and a two-file changelog
+
+Status: Accepted — 2026-06-13
+
+Relates to: the `api-stability.md` and `changelog.md` path-scoped rules; the
+`Versioning and Deprecation Policy` section of `CONTRIBUTING.rst`.
+
+## Context
+
+AAanalysis is Production/Stable on PyPI and declares itself semver-strict from
+v1.x onward, but had no mechanism to honor that promise: nothing marked a public
+symbol as deprecated, and there was no root `CHANGELOG.md` (the format
+`.claude/rules/changelog.md` already anticipated). A narrative changelog existed
+only as `docs/source/index/release_notes.rst`, which is RTD-rendered prose — not
+the terse, machine-greppable file developers and tooling expect at the repo root.
+Separately, an external user (the antibody/nanobody project) ran `1.0.3`, which
+predates the CPP performance work, hit hour-long low-CPU runs, and blamed the
+algorithm — there was no changelog line telling them a newer release fixes it.
+
+The Python floor is 3.11, so `typing.deprecated` / `warnings.deprecated`
+(PEP 702, 3.13+) is unavailable.
+
+## Decision
+
+- **D1 — Strict-semver deprecation window.** Any rename/removal of a symbol in
+  `aaanalysis.__all__` ships at least one **minor** release carrying a
+  `DeprecationWarning` before the symbol is removed. PATCH never breaks the public
+  API; MINOR may introduce deprecations; MAJOR may complete removals.
+- **D2 — Hand-rolled `deprecated(reason, version_removed)` decorator** in
+  `aaanalysis/_utils/decorators.py`, exposed through the `ut` barrel as
+  `ut.deprecated`. It wraps a function/method (warn on call) or class (warn on
+  instantiation) with a `DeprecationWarning`, preserves the signature via
+  `functools.wraps`, and prepends a `.. admonition:: Deprecated` note so the
+  deprecation shows both at call time and in the rendered API docs. (An
+  `.. admonition::`, not the `.. deprecated::` directive: the latter requires a
+  "deprecated since" version argument we do not track, and an argument-less
+  `.. deprecated::` is a Sphinx build error.)
+- **D3 — `deprecated` is an internal helper, not public API.** It is reachable as
+  `ut.deprecated` for maintainers but is not added to `aaanalysis.__all__`.
+- **D4 — Two-file changelog, terse + narrative.** A root `CHANGELOG.md`
+  (Keep a Changelog) is the terse, one-line-per-change developer index;
+  `release_notes.rst` stays as the narrative RTD release notes. A user-visible
+  change updates **both** in the same PR, and each file cross-links the other.
+- **D5 — Record the CPP-performance release line.** The changelog explicitly
+  notes that the Cython feature-matrix kernel, threaded `n_jobs`, caching, and
+  batching land post-`1.0.3`, and that `≤1.0.3` users should upgrade.
+
+## Rejected alternatives
+
+- **`typing.deprecated` / `warnings.deprecated` (PEP 702).** Cleaner and
+  type-checker-aware, but requires Python 3.13; the floor is 3.11. Revisit when
+  the floor rises.
+- **Single changelog only.** Either keep just `release_notes.rst` (no root file
+  that tooling/users expect, and the rule already anticipates one) or replace it
+  with `CHANGELOG.md` (discards the RTD-rendered narrative and its cross-links).
+  Keeping both, with terse one-liners in the root file, makes the ongoing
+  maintenance cost of the second file negligible while satisfying both audiences.
+- **Making `deprecated` public API.** It is a release-engineering tool, not part
+  of the analysis surface; exposing it would enlarge the stability contract for no
+  user benefit.
+- **Auto-generating one changelog from the other.** No generator exists and the
+  two serve different audiences (terse vs narrative); a generator would couple
+  their formats and add build machinery for little gain.
+
+## Consequences
+
+- Future public-API renames/removals must go through `ut.deprecated` for ≥1 minor
+  release; the `Removed` changelog subsection records the eventual removal.
+- Contributors update `CHANGELOG.md` + `release_notes.rst` in the same PR
+  (now stated in `CONTRIBUTING.rst` and its RTD copy).

--- a/docs/source/index/CONTRIBUTING_COPY.rst
+++ b/docs/source/index/CONTRIBUTING_COPY.rst
@@ -322,6 +322,60 @@ To generate the documentation locally:
 
 - Open `_build/html/index.html` in a browser.
 
+Versioning and Deprecation Policy
+=================================
+
+AAanalysis follows `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_
+(**MAJOR.MINOR.PATCH**) and is **semver-strict from v1.x onward**. The public API
+is exactly the set of symbols re-exported by ``aaanalysis/__init__.py`` (anything
+starting with ``_`` is private and may change without notice).
+
+Deprecation policy
+------------------
+
+Renaming or removing a public symbol is a breaking change. To give users a
+migration window, such a change is staged across releases:
+
+1. **Deprecate, don't remove.** Keep the symbol working and decorate it with
+   ``aaanalysis.utils.deprecated(reason=..., version_removed=...)``. Calling it
+   (or, for a class, instantiating it) then emits a ``DeprecationWarning`` naming
+   the replacement and the planned removal version, and the docstring gains a
+   deprecation note rendered in the API docs.
+
+   .. code-block:: python
+
+       import aaanalysis.utils as ut
+
+       @ut.deprecated(reason="Use 'new_name' instead.", version_removed="1.2.0")
+       def old_name(...):
+           ...
+
+2. **Ship at least one minor release** carrying the ``DeprecationWarning`` before
+   the symbol is removed.
+3. **Remove** the symbol only in a subsequent **minor** (or major) release, and
+   record it under ``Removed`` in the changelog.
+
+PATCH releases never rename or remove public symbols; MINOR releases add
+backward-compatible functionality (and may *introduce* deprecations); MAJOR
+releases may complete removals.
+
+Changelog
+---------
+
+Every user-visible change (new public symbol, signature change, behavior change,
+deprecation, or important bug fix) is recorded **in the same pull request** in two
+places:
+
+- ``CHANGELOG.md`` (repo root, `Keep a Changelog
+  <https://keepachangelog.com/en/1.1.0/>`_ format) — a terse, one-line-per-change
+  index under the top ``Unreleased`` section
+  (``Added`` / ``Changed`` / ``Deprecated`` / ``Removed`` / ``Fixed``).
+- ``docs/source/index/release_notes.rst`` — the narrative, RTD-rendered notes
+  under the current ``Unreleased`` version, with cross-references and examples.
+
+At release time, the ``Unreleased`` heading in both files is renamed to the new
+version with its date.
+
 Building New PyPi package version
 ---------------------------------
 

--- a/docs/source/index/release_notes.rst
+++ b/docs/source/index/release_notes.rst
@@ -120,10 +120,28 @@ Added
 
 - **aa.__version__**: The installed package version is now exposed as a
   top-level attribute via ``importlib.metadata``.
+- **CHANGELOG.md + deprecation policy**: A root ``CHANGELOG.md``
+  (`Keep a Changelog <https://keepachangelog.com/en/1.1.0/>`_ format) now gives a
+  terse, developer-facing index alongside these narrative notes. The project
+  adopts strict semantic versioning: from v1.x onward, any rename or removal of a
+  public symbol ships at least one minor release carrying a ``DeprecationWarning``
+  first. A ``deprecated(reason, version_removed)`` decorator helper (internal,
+  ``aaanalysis.utils``) marks such symbols and prepends a deprecation note
+  to their docstring. See the *Versioning and Deprecation Policy* in
+  ``CONTRIBUTING.rst``.
 
 Changed
 ~~~~~~~
 
+- **CPP performance work**: The Cython feature-matrix kernel, macOS-safe threaded
+  ``n_jobs``, scale / AA-index caching, and scale / sample batching land in this
+  release, replacing the hour-long, low-CPU CPP runs seen on ``1.0.3`` and
+  earlier. **Users on** ``≤1.0.3`` **should upgrade** rather than debug a
+  performance pathology that is already fixed.
+- **CPP Cython-fallback notice**: When the compiled extension is missing and CPP
+  falls back to the ~2× slower pure-Python kernel, the one-time notice is now a
+  ``UserWarning`` instead of an easily-missed INFO print, so it surfaces even with
+  ``aa.options['verbose'] = False``.
 - **SequenceFeature.feature_matrix**: New ``batch=`` parameter accepts a list of
   ``df_parts`` and builds them in a single Cython pass, returning a list of
   feature matrices — faster than per-call construction for many small part tables.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,3 +60,23 @@ def _restore_global_state():
         plt.close("all")
         mpl.rcParams.update(saved_rc)
         aa.options._settings.update(_dict_options)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _prime_cpp_fallback_notice():
+    """Mark the one-time CPP Python-kernel fallback notice as already shown.
+
+    On an install without the compiled Cython extension,
+    ``_pick_feature_matrix_builder`` emits a one-time ``UserWarning`` on its
+    first call (issue #74). Several CPP tests run ``cpp.run(...)`` inside
+    ``warnings.simplefilter("error", UserWarning)`` to assert their *own* code
+    path is warning-free; whichever of them happened to trigger the very first
+    feature-matrix build would otherwise turn that orthogonal install-state
+    notice into an error (flaky, ordering-dependent, non-Cython only). Priming
+    the guard once per session keeps those assertions about the intended
+    warnings only. The dedicated test in ``test_cpp_run_fallback_notice.py``
+    flips the guard back off to exercise the firing path explicitly.
+    """
+    import aaanalysis.feature_engineering._backend.cpp_run as _cpp_run
+    _cpp_run._PYTHON_FALLBACK_NOTIFIED = True
+    yield

--- a/tests/unit/cpp_tests/test_cpp_run_fallback_notice.py
+++ b/tests/unit/cpp_tests/test_cpp_run_fallback_notice.py
@@ -1,0 +1,54 @@
+"""This is a script to test the CPP Python-kernel fallback notice in
+aaanalysis.feature_engineering._backend.cpp_run._pick_feature_matrix_builder.
+
+The notice was promoted from an INFO ``print_out`` to a one-time ``UserWarning``
+so it surfaces even with ``aa.options['verbose'] = False`` (issue #74).
+"""
+import warnings
+
+import pytest
+
+import aaanalysis.feature_engineering._backend.cpp_run as cpp_run
+
+
+@pytest.fixture
+def reset_fallback_guard():
+    """Restore the module-level cython flag + one-time guard after each test."""
+    orig_has = cpp_run._HAS_CYTHON_INNER
+    orig_notified = cpp_run._PYTHON_FALLBACK_NOTIFIED
+    yield
+    cpp_run._HAS_CYTHON_INNER = orig_has
+    cpp_run._PYTHON_FALLBACK_NOTIFIED = orig_notified
+
+
+class TestFallbackNotice:
+    """The fallback notice is a one-time UserWarning, not an INFO print."""
+
+    def test_warns_userwarning_when_no_cython(self, reset_fallback_guard):
+        cpp_run._HAS_CYTHON_INNER = False
+        cpp_run._PYTHON_FALLBACK_NOTIFIED = False
+        with pytest.warns(UserWarning, match="Python kernel fallback"):
+            builder = cpp_run._pick_feature_matrix_builder()
+        # Falls back to the pure-Python builder.
+        assert builder is cpp_run.get_feature_matrix_fast_
+
+    def test_warns_only_once(self, reset_fallback_guard):
+        cpp_run._HAS_CYTHON_INNER = False
+        cpp_run._PYTHON_FALLBACK_NOTIFIED = False
+        with pytest.warns(UserWarning, match="Python kernel fallback"):
+            cpp_run._pick_feature_matrix_builder()
+        # Guard is set; a second call must be silent.
+        assert cpp_run._PYTHON_FALLBACK_NOTIFIED is True
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            cpp_run._pick_feature_matrix_builder()
+
+    def test_no_warning_when_cython_available(self, reset_fallback_guard):
+        if cpp_run.get_feature_matrix_c_ is None:
+            pytest.skip("compiled Cython extension not built in this environment")
+        cpp_run._HAS_CYTHON_INNER = True
+        cpp_run._PYTHON_FALLBACK_NOTIFIED = False
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            builder = cpp_run._pick_feature_matrix_builder()
+        assert builder is cpp_run.get_feature_matrix_c_

--- a/tests/unit/utils_tests/test_decorators.py
+++ b/tests/unit/utils_tests/test_decorators.py
@@ -1,8 +1,9 @@
 """This is a script to test the warning/exception decorators in
 aaanalysis._utils.decorators (exposed via aaanalysis.utils): the backend-error
-wrapper, the RuntimeWarning catcher, the invalid-division catcher, and the
-UndefinedMetricWarning catcher.
+wrapper, the RuntimeWarning catcher, the invalid-division catcher, the
+UndefinedMetricWarning catcher, and the ``deprecated`` decorator.
 """
+import inspect
 import warnings
 
 import pytest
@@ -119,3 +120,79 @@ class TestCatchUndefinedMetricWarning:
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             assert quiet() == 5
+
+
+class TestDeprecated:
+    """deprecated() emits a DeprecationWarning and annotates the docstring."""
+
+    def test_function_warns_on_call(self):
+        @ut.deprecated(reason="Use 'new_fn' instead.", version_removed="1.2.0")
+        def old_fn():
+            return 42
+        with pytest.warns(DeprecationWarning) as record:
+            assert old_fn() == 42
+        msg = str(record[0].message)
+        assert "'old_fn' is deprecated" in msg
+        assert "1.2.0" in msg
+        assert "Use 'new_fn' instead." in msg
+
+    def test_function_return_value_and_args_pass_through(self):
+        @ut.deprecated()
+        def add(a, b=1):
+            return a + b
+        with pytest.warns(DeprecationWarning):
+            assert add(2, b=3) == 5
+
+    def test_signature_and_metadata_preserved(self):
+        @ut.deprecated(reason="gone soon")
+        def f(a, b=2):
+            """Original summary."""
+            return a
+        assert f.__name__ == "f"
+        assert list(inspect.signature(f).parameters) == ["a", "b"]
+        # The original docstring is kept below the deprecation note.
+        assert "Original summary." in f.__doc__
+        assert ".. admonition:: Deprecated" in f.__doc__
+        assert "gone soon" in f.__doc__
+
+    def test_no_args_warns_without_reason_or_version(self):
+        @ut.deprecated()
+        def g():
+            return None
+        with pytest.warns(DeprecationWarning, match="'g' is deprecated"):
+            g()
+
+    def test_class_warns_on_instantiation(self):
+        @ut.deprecated(reason="Use NewCls.", version_removed="2.0.0")
+        class OldCls:
+            """A class on its way out."""
+            def __init__(self, x):
+                self.x = x
+        with pytest.warns(DeprecationWarning, match="'OldCls' is deprecated"):
+            obj = OldCls(7)
+        # Instance is constructed correctly despite the warning.
+        assert obj.x == 7
+        assert ".. admonition:: Deprecated" in OldCls.__doc__
+
+    def test_class_keeps_type_identity(self):
+        @ut.deprecated()
+        class C:
+            def __init__(self):
+                pass
+        assert isinstance(C, type)
+        with pytest.warns(DeprecationWarning):
+            assert isinstance(C(), C)
+
+    def test_multiline_reason_stays_indented_in_admonition(self):
+        # A multi-line reason must keep every continuation line inside the
+        # admonition body (3-space indent), or Sphinx drops the later lines.
+        @ut.deprecated(reason="First line.\nSecond line.")
+        def h():
+            """Summary."""
+            return None
+        body = h.__doc__.split("Summary.")[0]
+        content = [ln for ln in body.splitlines()
+                   if ln and not ln.startswith(".. admonition")]
+        assert content, "expected an indented admonition body"
+        assert all(ln.startswith("   ") for ln in content)
+        assert "   Second line." in h.__doc__


### PR DESCRIPTION
Closes #74

Adopt a strict-semver deprecation policy and the supporting machinery.

## What changed

- **`deprecated(reason, version_removed)` decorator** (`aaanalysis/_utils/decorators.py`, exposed as `ut.deprecated`; **internal helper, not in `__all__`**). Wraps functions/methods (warn on call) and classes (warn on instantiation) with a `DeprecationWarning`, preserves the signature via `functools.wraps`, and prepends a `.. admonition:: Deprecated` note to the docstring. Hand-rolled because the 3.11 floor rules out `typing.deprecated` (PEP 702).
- **Root `CHANGELOG.md`** ([Keep a Changelog](https://keepachangelog.com/en/1.1.0/)) as the terse, developer-facing index; `docs/source/index/release_notes.rst` stays the narrative RTD notes. Each cross-links the other.
- **CPP-performance release line recorded** (per the issue's external-feedback comment): the Cython feature-matrix kernel, threaded `n_jobs`, caching, and batching land post-`1.0.3`, with an explicit "users on ≤1.0.3 should upgrade" note.
- **Cython-fallback notice promoted** from an INFO `print_out` to a one-time `UserWarning` so it surfaces with `aa.options['verbose'] = False`.
- **Policy documented**: a *Versioning and Deprecation Policy* section in `CONTRIBUTING.rst` + its RTD copy; ADR-0030; `.claude/rules/changelog.md` flipped from aspirational to active.
- **Tests** for the decorator and the fallback warning.

## Design note

Kept **both** `CHANGELOG.md` (terse) and `release_notes.rst` (narrative), cross-linked, rather than collapsing to one — rationale in ADR-0030 (D4).

A session-autouse conftest fixture primes the one-time fallback guard so the new `UserWarning` can't turn unrelated `simplefilter("error", UserWarning)` CPP tests into errors on non-Cython systems.

## Local gates (all green)

- Full fast unit suite: **4120 passed, 8 skipped**
- Param-coverage meta-test: passed · docstring checkers: 0 defects · docs build: exit 0 (no new errors) · `CONTRIBUTING` vs `CONTRIBUTING_COPY` section identical
- Reviewed via `/code-review high`, `/security-review` (no findings), `/simplify` — all findings fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)