### PR TITLE
doc(workflow): push the PR before the human-review gate; skip = approve + auto-merge

### DIFF
--- a/.claude/skills/agentic-engineering/SKILL.md
+++ b/.claude/skills/agentic-engineering/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentic-engineering
-description: Drive a change through the AAanalysis agentic-engineering protocol step by step — pick/sharpen the issue, branch into an isolated worktree, implement, open a draft PR, run the automated review + quality gates, keep the branch synced, stop at the human-review gate (manual PR-review loop or skip-to-merge — the user's call), then arm GitHub-native auto-merge with a fix-forward loop on red CI. Use when the user wants to start work on an issue, "walk me through the workflow", take a change from issue to merge, or wants the auto-merge / auto-fix loop driven for them. The canonical protocol lives in docs/guides/agentic_engineering.md; this skill executes it.
+description: Drive a change through the AAanalysis agentic-engineering protocol step by step — pick/sharpen the issue, branch into an isolated worktree, implement, push and open the PR early so CI runs, run the automated review + quality gates, keep the branch synced, then hold at the human-review gate where the user picks a manual PR-review loop or skips (skip = post an approving review comment, then arm GitHub-native auto-merge), with a fix-forward loop on red CI. Use when the user wants to start work on an issue, "walk me through the workflow", take a change from issue to merge, or wants the auto-merge / auto-fix loop driven for them. The canonical protocol lives in docs/guides/agentic_engineering.md; this skill executes it.
 ---
 
 # AAanalysis agentic-engineering — drive a change to merge
@@ -66,9 +66,11 @@ Eight steps in three phases. **Full rationale + the quality-gates table live in
    the approach before commits land); plain edits for trivial diffs. Honor the auto-loaded
    `.claude/rules/` for the files you touch. A PR needs ≥1 commit: push a scaffolding commit and open
    a **draft PR** so CI + the RTD preview run while you keep pushing to refine. (Push → §0 go-ahead.)
-   **Before a substantive push, run the fast local unit gate** (`pytest tests -m "not regression" -x
-   -n auto -c tests/pytest.ini`) — far faster than a red-CI round-trip. **No change is done until you
-   walk the Ripple checklist below** — the code edit usually lands with its mirrors *in the same PR*.
+   **Push and open the PR *before* the human-review gate (step 6), not after** — that is what starts
+   CI/RTD, so the checks run *while* the user reviews or decides to skip. **Before a substantive push,
+   run the fast local unit gate** (`pytest tests -m "not regression" -x -n auto -c tests/pytest.ini`) —
+   far faster than a red-CI round-trip. **No change is done until you walk the Ripple checklist
+   below** — the code edit usually lands with its mirrors *in the same PR*.
 5. **Automated review gate.** Run `/review` (PR diff) + `/security-review` (vulnerability scan); for a
    substantial diff also `/code-review high` (or `ultra` for the deep cloud review) + `/simplify`, and
    `/docstrings` when public API or docstrings change. The canonical doc's quality gates must be green.
@@ -78,9 +80,11 @@ Eight steps in three phases. **Full rationale + the quality-gates table live in
 
 **Review, merge & clean up**
 
-6. **Human review gate — STOP and let the user choose.** After the push lands and CI/Actions are
-   running (confirm with `gh pr checks <n>` / `gh run list --branch <branch>`), do **not** advance to
-   merge on your own. Surface the fork explicitly and **wait for the user's decision**:
+6. **Human review gate — the PR is already up; the user picks how to review.** You pushed and opened
+   the PR back in step 4, so by now CI/Actions + the RTD preview are **already running while the user
+   decides** (confirm with `gh pr checks <n>` / `gh run list --branch <branch>`). This gate is human
+   judgement on the *content* — **not** a decision about whether to push (that already happened). Do
+   **not** advance to merge on your own; surface the fork and **wait for the user's decision**:
    - **(a) Manual PR review (iterate).** The user reviews the PR diff on GitHub and leaves comments.
      Address **each** comment by refactoring **forward on the same branch** (honor the Ripple
      checklist + auto-loaded `.claude/rules/`), re-run the fast local gate, push (*each re-push → §0
@@ -88,12 +92,16 @@ Eight steps in three phases. **Full rationale + the quality-gates table live in
      comments and repeat the *review → refactor → push* cycle. Stay in this loop until the user
      explicitly says the review is done (e.g. "merge it" / "looks good" / "skip further review"); only
      then go to step 7. Re-pushes re-trigger CI, and any armed auto-merge waits for the new green.
-   - **(b) Skip review → merge + clean up.** The user opts out of manual review; go straight to step 7.
+   - **(b) Skip review → approve + auto-merge.** The user opts out of a manual pass: post a short
+     **approving review comment** (e.g. "Skipping manual review — automated gates green, all good") so
+     the skip is recorded on the PR, then go to step 7 to arm auto-merge. The PR merges and closes
+     itself once CI is green.
    Recommend (a) for substantial or architectural diffs and (b) for trivial ones, but **never assume —
    the user picks.** This gate is about human judgement on the *content*; the automated gates (step 5)
    and CI still independently enforce *never merge red*.
-7. **Arm auto-merge; fix-forward on red.** Once the user has cleared step 6, and you've read the RTD
-   preview + PR diff: `gh pr merge --auto --squash` (*a publish action → §0 go-ahead*). GitHub merges
+7. **Arm auto-merge; fix-forward on red.** Once the user has cleared step 6 (on the skip path, after
+   you've posted the approving review comment), and you've read the RTD preview + PR diff:
+   `gh pr merge --auto --squash` (*a publish action → §0 go-ahead*). GitHub merges
    only on all-green + conflict-free, so *never merge red* holds. On red CI: `gh run watch` /
    `gh run view --log-failed` → **reproduce locally** (see *Local gate commands*) → fix **forward on
    the same branch** and push; armed auto-merge re-arms and completes on the green re-run.

--- a/docs/guides/agentic_engineering.md
+++ b/docs/guides/agentic_engineering.md
@@ -31,11 +31,14 @@ order there is natural rather than rigid. The full rationale lives in this secti
    (approve the approach before commits land); drop to plain edits for trivial diffs. Honor the
    path-scoped rules in `.claude/rules/` that auto-load for the files you touch. A PR needs ≥1
    commit, so push a scaffolding commit and open a **draft PR** early — CI and the Read the Docs
-   (RTD) preview then run while you keep pushing to refine. **Before a substantive push, run the
-   fast local unit gate** (`pytest tests -m "not regression" -x -n auto -c tests/pytest.ini`) — a
-   local run catches the obvious break far faster than a red-CI round-trip. **No change is done
-   until you have walked the ripple checklist below** — a code edit almost always has to land
-   alongside its docstring, example, test, and other mirrors *in the same PR*.
+   (RTD) preview then run while you keep pushing to refine. **Push and open the PR *before* the
+   human-review gate (step 6), not after** — opening the PR is what starts CI/RTD, so the checks run
+   *while* the user reviews or decides to skip, instead of the user waiting on a cold start.
+   **Before a substantive push, run the fast local unit gate**
+   (`pytest tests -m "not regression" -x -n auto -c tests/pytest.ini`) — a local run catches the
+   obvious break far faster than a red-CI round-trip. **No change is done until you have walked the
+   ripple checklist below** — a code edit almost always has to land alongside its docstring, example,
+   test, and other mirrors *in the same PR*.
 5. **Automated review gate (machine-enforced, not eyeballed).** Run `/review` (reviews the PR
    diff) and `/security-review` (scans the pending diff for vulnerabilities); for a substantial
    diff reach for `/code-review high` (or `ultra` for the deep cloud review) and `/simplify`, and
@@ -48,12 +51,13 @@ order there is natural rather than rigid. The full rationale lives in this secti
 
 ### Review, merge & clean up
 
-6. **Human review gate — stop and let the user choose.** After the push lands and the GitHub
-   Actions are running (confirm with `gh pr checks <n>` / `gh run list --branch <branch>`), do
-   **not** advance to merge on your own. This is a deliberate checkpoint for human judgement on the
-   *content* of the change — distinct from, and on top of, the automated gates in step 5 and CI,
-   which independently enforce *never merge red*. Surface the fork explicitly and **wait for the
-   user's decision**:
+6. **Human review gate — the PR is already up; the user picks how to review.** You pushed and opened
+   the PR back in step 4, so the GitHub Actions + RTD preview are **already running while the user
+   decides** (confirm with `gh pr checks <n>` / `gh run list --branch <branch>`). This is a deliberate
+   checkpoint for human judgement on the *content* of the change — **not** a decision about whether to
+   push (that already happened), and distinct from / on top of the automated gates in step 5 and CI,
+   which independently enforce *never merge red*. Do **not** advance to merge on your own; surface the
+   fork explicitly and **wait for the user's decision**:
 
    - **(a) Manual PR review — iterate.** The user reviews the PR diff on GitHub and leaves comments.
      Address **each** comment by refactoring **forward on the same branch** (honor the *Propagate
@@ -64,15 +68,17 @@ order there is natural rather than rigid. The full rationale lives in this secti
      "merge it" / "looks good" / "skip further review") — only then proceed to step 7. Each re-push
      re-triggers CI, and any armed auto-merge simply waits for the new green, so iterating never
      races the merge.
-   - **(b) Skip review — merge + clean up.** The user opts out of a manual pass; proceed straight to
-     step 7.
+   - **(b) Skip review — approve + auto-merge.** The user opts out of a manual pass: post a short
+     **approving review comment** (e.g. "Skipping manual review — automated gates green, all good") so
+     the skip is recorded on the PR, then proceed to step 7 to arm auto-merge. The PR merges and
+     closes itself once CI is green.
 
    Recommend (a) for substantial or architectural diffs and (b) for trivial ones, but **never
    assume the answer — the user picks.** Holding here is also why the draft PR + CI run early
    (step 4): the user can review against a green, RTD-previewed PR rather than a moving target.
-7. **Arm auto-merge; fix-forward on red.** Once the user has cleared the review gate (step 6) and
-   you've read the RTD preview + PR diff, enable GitHub-native auto-merge: `gh pr merge --auto
-   --squash`. GitHub merges the moment every required check passes and the branch is conflict-free,
+7. **Arm auto-merge; fix-forward on red.** Once the user has cleared the review gate (step 6) — on the
+   skip path, after you've posted the approving review comment — and you've read the RTD preview + PR
+   diff, enable GitHub-native auto-merge: `gh pr merge --auto --squash`. GitHub merges the moment every required check passes and the branch is conflict-free,
    so **"never merge red" still holds** — a red check blocks the merge instead of completing it. If
    CI goes red, pull the failing logs (`gh run view --log-failed`, or `gh run watch` to follow
    live), reproduce locally, and fix **forward on the same branch**; armed auto-merge re-arms itself

--- a/docs/source/index/CONTRIBUTING_COPY.rst
+++ b/docs/source/index/CONTRIBUTING_COPY.rst
@@ -390,7 +390,7 @@ committed. The canonical version of this protocol lives in
 
 Workflow (step by step)
 -----------------------
-Seven steps in three phases. Phases group the work; within the Build phase you iterate, so the
+Eight steps in three phases. Phases group the work; within the Build phase you iterate, so the
 order there is natural rather than rigid.
 
 **Prepare**
@@ -412,11 +412,13 @@ order there is natural rather than rigid.
    (approve the approach before commits land); drop to plain edits for trivial diffs. Honor the
    path-scoped rules in ``.claude/rules/`` that auto-load for the files you touch. A PR needs ≥1
    commit, so push a scaffolding commit and open a **draft PR** early — CI and the Read the Docs
-   (RTD) preview then run while you keep pushing to refine. **Before a substantive push, run the
-   fast local unit gate** (``pytest tests -m "not regression" -x -n auto -c tests/pytest.ini``) — a
-   local run catches the obvious break far faster than a red-CI round-trip. **No change is done
-   until you have walked the ripple checklist below** — a code edit almost always lands alongside
-   its docstring, example, test, and other mirrors *in the same PR*.
+   (RTD) preview then run while you keep pushing to refine. **Push and open the PR *before* the
+   human-review gate (step 6), not after** — opening the PR is what starts CI/RTD, so the checks run
+   *while* the user reviews or decides to skip. **Before a substantive push, run the fast local unit
+   gate** (``pytest tests -m "not regression" -x -n auto -c tests/pytest.ini``) — a local run catches
+   the obvious break far faster than a red-CI round-trip. **No change is done until you have walked
+   the ripple checklist below** — a code edit almost always lands alongside its docstring, example,
+   test, and other mirrors *in the same PR*.
 5. **Automated review gate (machine-enforced, not eyeballed).** Run ``/review`` (reviews the PR
    diff) and ``/security-review`` (scans the pending diff for vulnerabilities); for a substantial
    diff reach for ``/code-review high`` (or ``ultra`` for the deep cloud review) and ``/simplify``,
@@ -427,17 +429,40 @@ order there is natural rather than rigid.
    a synced branch or an early conflict warning). **A scheduled job syncs only — it must never
    resolve conflicts or merge a branch to** ``master`` **unattended; it just flags you.**
 
-**Merge & clean up**
+**Review, merge & clean up**
 
-6. **Arm auto-merge; fix-forward on red.** Once the review is green and you've read the RTD
-   preview + PR diff, enable GitHub-native auto-merge: ``gh pr merge --auto --squash``. GitHub
+6. **Human review gate — the PR is already up; the user picks how to review.** Because the PR was
+   pushed and opened in step 4, the GitHub Actions + RTD preview are **already running while the user
+   decides** (confirm with ``gh pr checks <n>`` / ``gh run list --branch <branch>``). This is a
+   deliberate checkpoint for human judgement on the *content* of the change — **not** a decision about
+   whether to push (that already happened) — distinct from and on top of the automated gates in step 5
+   and CI. Do **not** advance to merge on your own; surface the fork and **wait for the user's
+   decision**:
+
+   - **(a) Manual PR review — iterate.** The user reviews the PR diff on GitHub and leaves comments.
+     Address **each** comment by refactoring **forward on the same branch** (honor the ripple
+     checklist and the auto-loaded ``.claude/rules/``), re-run the fast local gate, push, and report
+     back per comment. Then **loop**: wait for the next round and repeat the *review → refactor →
+     push* cycle until the user signals the review is complete (e.g. "merge it" / "looks good") —
+     only then proceed to step 7. Each re-push re-triggers CI, and any armed auto-merge waits for the
+     new green.
+   - **(b) Skip review — approve + auto-merge.** The user opts out of a manual pass: post a short
+     **approving review comment** (e.g. "Skipping manual review — automated gates green, all good") so
+     the skip is recorded on the PR, then proceed to step 7. The PR merges and closes itself once CI
+     is green.
+
+   Recommend (a) for substantial or architectural diffs and (b) for trivial ones, but **never assume
+   the answer — the user picks.**
+7. **Arm auto-merge; fix-forward on red.** Once the user has cleared the review gate (step 6) — on the
+   skip path, after the approving review comment — and you've read the RTD preview + PR diff, enable
+   GitHub-native auto-merge: ``gh pr merge --auto --squash``. GitHub
    merges the moment every required check passes and the branch is conflict-free, so **"never
    merge red" still holds** — a red check blocks the merge instead of completing it. If CI goes
    red, pull the failing logs (``gh run view --log-failed``, or ``gh run watch`` to follow live),
    reproduce locally, and fix **forward on the same branch**; armed auto-merge re-arms itself and
    completes on the green re-run. Disarm with ``gh pr merge --disable-auto`` to hold the PR, or
    skip ``--auto`` for a hard human gate.
-7. **Clean up — gated on merge + a green** ``master``. Key cleanup off the **merge state, never a
+8. **Clean up — gated on merge + a green** ``master``. Key cleanup off the **merge state, never a
    single CI run**: once ``gh pr view <n> --json state,mergedAt`` shows ``MERGED``, let the
    push-triggered workflows on ``master`` run and **wait for them to pass** — that confirms the
    squash didn't break anything the branch CI couldn't see (master may have moved under it). An


### PR DESCRIPTION
Clarifies the agentic-engineering protocol so the **PR is pushed/opened in the Build phase (step 4), *before* the human-review gate (step 6)** — opening the PR is what starts CI + the RTD preview, so the checks run *while* the user reviews or decides to skip, instead of the user waiting on a cold start. The human gate is now explicitly about reviewing **content**, not about whether to push (that already happened).

## What changed

- **Step 4** — push and open the (draft) PR before the human-review gate; that's what starts CI/RTD.
- **Step 6 (human-review gate)** — the PR is already up and CI already running; the user picks:
  - **(a) Manual review** — comment → fix-forward → re-push → loop until "looks good".
  - **(b) Skip** — post a short **approving review comment** ("automated gates green — all good"), then arm auto-merge; the PR merges and closes itself on green.
- **Step 7** — on the skip path, the approving comment is posted before arming auto-merge.

Updated in all three places the protocol lives:
- `docs/guides/agentic_engineering.md` (canonical source of truth)
- `.claude/skills/agentic-engineering/SKILL.md` (the executor)
- `docs/source/index/CONTRIBUTING_COPY.rst` (RTD port) — also **re-synced**: it had drifted to a 7-step version missing the explicit human-review gate; now 8 steps, matching the guide.

## Gate

Docs build passes locally (`make html`, exit 0; no errors on the changed RST). Process-doc only — no code, no issue to close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)