### PR TITLE
docs(usage): drop user-facing ADR-0022 citation from prediction-tasks page

### DIFF
--- a/docs/source/index/usage_principles/prediction_tasks.rst
+++ b/docs/source/index/usage_principles/prediction_tasks.rst
@@ -166,4 +166,4 @@ Where to go next
    - **Mechanics:** the per-function :ref:`tutorials <tutorials>` cover
      ``CPP``, ``SequenceFeature``, ``AAclust``, and the rest.
    - **Vocabulary:** every term used here is defined in the
-     :ref:`glossary <glossary>`. The taxonomy itself is recorded in ADR-0022.
+     :ref:`glossary <glossary>`.


### PR DESCRIPTION
Follow-up to #154 (issue #21). Removes the rendered "The taxonomy itself is recorded in ADR-0022." clause from the prediction-tasks page's Vocabulary seealso bullet — a newcomer can't act on an ADR number, and the house norm keeps ADR citations out of user-facing text. The non-rendered dev-note comment at the top of the file still records the provenance for maintainers.

Docs build verified clean locally (no page warnings; rendered page now has zero ADR-0022 mentions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)