### PR TITLE
perf(cpp): vectorize get_df_parts_ row driver

### DIFF
--- a/aaanalysis/feature_engineering/_backend/cpp/utils_feature.py
+++ b/aaanalysis/feature_engineering/_backend/cpp/utils_feature.py
@@ -121,13 +121,9 @@ def _get_df_pos_long(df=None, col_cat="category", col_val=None):
 
 
 # Get df parts
-def _extract_parts(row, jmd_n_len, jmd_c_len, pos_based, list_parts):
-    """Helper function to extract parts from a single row."""
-    if jmd_c_len is not None and jmd_n_len is not None and pos_based:
-        seq, tmd_start, tmd_stop = row[ut.COLS_SEQ_POS]
-        jmd_n, tmd, jmd_c = create_parts(seq, tmd_start, tmd_stop, jmd_n_len, jmd_c_len)
-    else:
-        jmd_n, tmd, jmd_c = row[ut.COLS_SEQ_PARTS]
+def _extract_parts(parts, list_parts):
+    """Build the {part: seq} dict for one sequence from its (jmd_n, tmd, jmd_c) base parts."""
+    jmd_n, tmd, jmd_c = parts
     # Get dictionary of parts and filter by list_parts
     dict_part_seq = ut.get_dict_part_seq(tmd=tmd, jmd_n=jmd_n, jmd_c=jmd_c)
     return {part: dict_part_seq[part] for part in list_parts}
@@ -192,15 +188,25 @@ def get_list_parts(features=None):
 
 def get_df_parts_(df_seq=None, list_parts=None, jmd_n_len=None, jmd_c_len=None):
     """Create DataFrame with sequence parts"""
+    # Iterate over the raw column arrays instead of df.apply(axis=1): the per-row
+    # Series materialization of apply() is the bottleneck, while the per-row work
+    # (create_parts + get_dict_part_seq) is unchanged, so the output is identical.
     pos_based = set(ut.COLS_SEQ_POS).issubset(set(df_seq))
-    _df_seq = df_seq.copy()
-    _df_seq['parts'] = df_seq.apply(lambda row:
-                                    _extract_parts(row, jmd_n_len, jmd_c_len, pos_based, list_parts), axis=1)
+    if jmd_n_len is not None and jmd_c_len is not None and pos_based:
+        cols = zip(df_seq[ut.COL_SEQ].to_numpy(),
+                   df_seq[ut.COL_TMD_START].to_numpy(),
+                   df_seq[ut.COL_TMD_STOP].to_numpy())
+        records = [_extract_parts(create_parts(seq, tmd_start, tmd_stop, jmd_n_len, jmd_c_len),
+                                  list_parts)
+                   for seq, tmd_start, tmd_stop in cols]
+    else:
+        cols = zip(df_seq[ut.COL_JMD_N].to_numpy(),
+                   df_seq[ut.COL_TMD].to_numpy(),
+                   df_seq[ut.COL_JMD_C].to_numpy())
+        records = [_extract_parts((jmd_n, tmd, jmd_c), list_parts)
+                   for jmd_n, tmd, jmd_c in cols]
     # Convert the extracted parts into a DataFrame
-    df_parts = pd.DataFrame(_df_seq['parts'].to_list(),
-                            index=df_seq[ut.COL_ENTRY])
-    # DEV: the following line sorts index if list_parts contains just one element
-    # df_parts = pd.DataFrame.from_dict(dict_parts, orient="index")
+    df_parts = pd.DataFrame(records, index=df_seq[ut.COL_ENTRY])
     return df_parts
 
 

--- a/docs/source/index/release_notes.rst
+++ b/docs/source/index/release_notes.rst
@@ -131,6 +131,10 @@ Changed
   input mode (``tmd_len=``) explodes each 1-based anchor in the ``pos`` column
   into one three-part (``jmd_n`` / ``tmd`` / ``jmd_c``) row, identified by
   ``entry_win``.
+- **SequenceFeature.get_df_parts**: Several-fold faster on large inputs — the
+  per-row ``DataFrame.apply`` driver was replaced with a vectorized iteration over
+  the raw column arrays. The output (parts, column order, index, values) is
+  unchanged.
 - **n_jobs**: Unified parallelism convention across ``CPP`` / ``CPPGrid``
   (``1`` serial, ``-1`` all cores, ``N>1`` exactly N, ``None`` optimized), with an
   ``options['n_jobs']`` global override.

--- a/tests/unit/sequence_feature_tests/test_sf_get_df_parts.py
+++ b/tests/unit/sequence_feature_tests/test_sf_get_df_parts.py
@@ -373,6 +373,31 @@ class TestGetDfPartsGoldenValues:
                     "jmd_n_tmd_n": "-MKLPQ", "tmd_c_jmd_c": "RST--"}
         assert {p: out[p].iloc[0] for p in list_parts} == expected
 
+    def test_backend_part_based_branch(self):
+        """``get_df_parts_`` reads parts directly from a part-based ``df_seq``.
+
+        The public ``get_df_parts`` normalizes every input format to the
+        position-based schema before calling the backend, so the part-based arm of
+        the backend driver is reached only by internal callers that pass
+        ``jmd_n`` / ``tmd`` / ``jmd_c`` columns through without position columns
+        (e.g. ``CPP.run_num``'s df_seq↔df_parts parity guard,
+        ``CPPPlot.feature``). Exercise it directly so the branch stays covered and
+        correct (parts are taken verbatim; ``jmd_n_len`` / ``jmd_c_len`` are unused
+        here).
+        """
+        from aaanalysis.feature_engineering._backend.cpp.utils_feature import get_df_parts_
+        import aaanalysis.utils as ut
+        df_seq = pd.DataFrame({ut.COL_ENTRY: ["P1", "P2"],
+                               ut.COL_JMD_N: ["AAAA", "DDDD"],
+                               ut.COL_TMD: ["LMVF", "GHIK"],
+                               ut.COL_JMD_C: ["CCCC", "EEEE"]})
+        out = get_df_parts_(df_seq=df_seq, list_parts=["jmd_n", "tmd", "jmd_c", "tmd_jmd"],
+                            jmd_n_len=4, jmd_c_len=4)
+        assert list(out.index) == ["P1", "P2"]
+        assert out.loc["P1", "tmd_jmd"] == "AAAALMVFCCCC"
+        assert out.loc["P2", "jmd_n"] == "DDDD"
+        assert out.loc["P2", "tmd"] == "GHIK"
+
 
 # Complex Cases
 class TestGetDfPartsComplex:

--- a/tests/unit/sequence_feature_tests/test_sf_get_df_parts.py
+++ b/tests/unit/sequence_feature_tests/test_sf_get_df_parts.py
@@ -351,6 +351,28 @@ class TestGetDfPartsGoldenValues:
         assert (out_pos[list_parts] == out_part[list_parts]).all().all()
         assert (out_pos[list_parts] == out_seq_tmd[list_parts]).all().all()
 
+    def test_gap_padding_golden(self):
+        """Pin the '-'-padded parts when the TMD sits too close to both termini.
+
+        seq 'MKLPQRST' (len 8), TMD 'PQR' at 1-based 4..6, jmd_n_len==jmd_c_len==4:
+        only 3 N-terminal and 2 C-terminal residues are available, so both JMDs are
+        gap-padded ('-MKL', 'ST--'). Composite parts must concatenate the *padded*
+        base parts, not the raw sequence — this is the exact invariant the vectorized
+        ``get_df_parts_`` driver has to preserve.
+        """
+        sf = aa.SequenceFeature()
+        df_seq = pd.DataFrame({"entry": ["P1"], "sequence": ["MKLPQRST"],
+                               "tmd_start": [4], "tmd_stop": [6]})
+        list_parts = ["jmd_n", "tmd", "jmd_c", "tmd_n", "tmd_c",
+                      "tmd_jmd", "jmd_n_tmd_n", "tmd_c_jmd_c"]
+        out = sf.get_df_parts(df_seq=df_seq, list_parts=list_parts,
+                              jmd_n_len=4, jmd_c_len=4)
+        expected = {"jmd_n": "-MKL", "tmd": "PQR", "jmd_c": "ST--",
+                    "tmd_n": "PQ", "tmd_c": "R",
+                    "tmd_jmd": "-MKLPQRST--",
+                    "jmd_n_tmd_n": "-MKLPQ", "tmd_c_jmd_c": "RST--"}
+        assert {p: out[p].iloc[0] for p in list_parts} == expected
+
 
 # Complex Cases
 class TestGetDfPartsComplex:


### PR DESCRIPTION
## Summary

`SequenceFeature.get_df_parts` was bottlenecked by a per-row
`DataFrame.apply(axis=1)` in the backend `get_df_parts_`. Each row paid for a
pandas `Series` materialization, while the actual per-row work (`create_parts` +
`get_dict_part_seq`) is cheap.

This replaces the `apply` driver with a list comprehension over the raw column
arrays (`zip` of `.to_numpy()` columns), branching once on `pos_based` instead of
per row. The per-row primitives are **unchanged**, so the output `df_parts` is
**byte-identical** (parts, column order, index, dtypes, values).

Closes #19.

## Performance

10k-row position-based `df_seq` (local, macOS):

| call | before | after | speedup |
|---|---|---|---|
| `all_parts=True` | ~669 ms | ~140 ms | ~4.8× |
| `list_parts="tmd"` | ~678 ms | ~134 ms | ~5.1× |

Per row: 67 µs → 14 µs. (The cost was independent of the number of parts
requested, confirming the `apply` driver — not part-building — was the
bottleneck.) Also drops the now-unneeded `df_seq.copy()` + temporary `'parts'`
column.

### Why not Cython?
The repo already ships a Cython kernel for the *feature matrix* (the numeric
inner loop). `df_parts` is string-slicing assembled into a DataFrame of Python
`str` objects — that object allocation is irreducible, so Cython's ceiling here
is low, and after this fix `df_parts` is no longer the pipeline bottleneck. The
pure-Python change captures the real win (removing per-row `Series`
materialization) with zero new infrastructure.

## Parity verification
Captured `get_df_parts` output on unmodified `master` across all input formats
(position-based, part-based, seq-TMD, anchor, gapped/short-terminus, custom jmd
lengths, single + `all_parts`) and asserted `old.equals(new)` post-change:
**10/10 byte-identical** (values, index, dtypes).

## Tests / gates (local)
- Full fast unit suite (`-m "not regression"`): **4112 passed, 7 skipped** (py3.13 + py3.14).
- `sequence_feature_tests` + `cpp_tests` (not regression): **760 passed**.
- Param-coverage meta-test: 5/5.
- Exact-value CPP regression anchor: self-skips off the canonical cell
  (ADR-0015; runs nightly on Linux/py3.11).
- New golden test `test_gap_padding_golden` pins the `-`-padded composite parts
  on a short sequence — the trickiest path the vectorized driver must preserve.

## Ripple
No public-API/signature change, so no docstring/example/cheat-sheet/tables/API-ref
churn. Touches only: the backend driver, one new golden test, and a release-notes
bullet under `v1.1.0 (Unreleased)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)