### PR TITLE
docs(cheatsheet): simplify dPULearn / AAclust / ShapModel recipes (blocked by API ergonomics)

### DIFF
--- a/docs/_cheatsheet/README.md
+++ b/docs/_cheatsheet/README.md
@@ -56,3 +56,18 @@ Then commit the regenerated `docs/source/_static/cheat_sheet.{html,pdf}`.
   TTFs, which also make the PDF reproducible on any machine (incl. Linux CI).
 - **Not packaged:** this directory is docs tooling; it is not part of the
   installed `aaanalysis` wheel.
+
+## Planned (deferred — blocked by API ergonomics)
+
+The dPULearn / AAclust / ShapModel worked-example recipes in `content.py` still
+carry API plumbing that a few API improvements would remove. Once these land,
+simplify the corresponding recipes to the one-call forms:
+
+- [ ] **dPULearn** → `aa.dPULearn().fit(X, labels, label_unl=0, n_neg=10)` —
+  drop the manual `1/0 → 1/2` `labels_pu` encoding. Blocked by #157.
+- [ ] **AAclust** → `aa.AAclustPlot().centers(aac)` — drop the
+  `np.array(df_scales).T, labels=aac.labels_` plumbing. Blocked by #158.
+- [ ] **ShapModel** → `aa.ShapModel().fit(X, labels, fuzzy={'P05067': 0.6})` —
+  drop the manual entry-index lookup + float-label construction. Blocked by #129.
+
+Part of #81 (cheat sheet).


### PR DESCRIPTION
Tracking / draft PR — **do not merge yet**. Holds the deferred cheat-sheet work: simplifying the dPULearn / AAclust / ShapModel worked-example recipes to clean one-call forms. These currently carry API plumbing the cheat sheet has to spell out; the simplifications depend on the corresponding API-ergonomics improvements.

Blocked by:
- #157 — dPULearn.fit: accept 1/0 labels + `n_neg` alias
- #158 — AAclustPlot.centers from a fitted AAclust
- #129 — ShapModel.fit: entry-keyed soft (fuzzy) labels

When each lands, update the matching recipe in `docs/_cheatsheet/content.py` and regenerate `cheat_sheet.{html,pdf}` (see the checklist in `docs/_cheatsheet/README.md`).

Part of #81 (cheat sheet — stays open until these recipe sections are simplified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)