### PR TITLE
perf: vectorize AAWindowSampler candidate-center filter + motif PWM scan (same output)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,9 @@ and a suite of site-localization metrics and plotting helpers.
   `AAWindowSampler` redundancy/similarity filtering (vectorized, ~30x at scale),
   `AAclust` sample-to-medoid correlation distances (single pass), and per-feature
   Kullback-Leibler divergence used by `dPULearn.eval(comp_kld=True)`
-  (parallelized, honors `options['n_jobs']`).
+  (parallelized, honors `options['n_jobs']`). Plus `AAWindowSampler`
+  candidate-center band filtering (~40x) and `sample_motif_matched` PWM scoring
+  (~12x), vectorized with identical output.
 
 ### Deprecated
 - None. The strict-semver deprecation policy and the `deprecated` decorator are

--- a/aaanalysis/seq_analysis/_backend/aa_window_sampler/_utils.py
+++ b/aaanalysis/seq_analysis/_backend/aa_window_sampler/_utils.py
@@ -11,6 +11,10 @@ import aaanalysis.utils as ut
 
 
 # I Helper Functions
+# Canonical amino-acid -> column index (built once; identical to rebuilding it per call).
+_AA_INDEX = {a: i for i, a in enumerate(ut.LIST_CANONICAL_AA)}
+
+
 def _is_missing(val):
     """Treat ``None`` / ``NaN`` / empty string as 'no positive positions'."""
     return (val is None
@@ -93,16 +97,17 @@ def candidate_centers_(seq_len, window_size, exclude_positions=None,
         return centers
     if min_distance is None and max_distance is None:
         return centers
-    excl_0based = [p - 1 for p in exclude_positions]
-    result = []
-    for c in centers:
-        d = min(abs(c - p) for p in excl_0based)
-        if min_distance is not None and d < min_distance:
-            continue
-        if max_distance is not None and d > max_distance:
-            continue
-        result.append(c)
-    return result
+    # Nearest-excluded L1 distance per center, vectorized. Distances are integers, so the
+    # band comparisons reproduce the scalar keep/drop decisions exactly.
+    centers_arr = np.asarray(centers)
+    excl = np.asarray([p - 1 for p in exclude_positions])
+    d = np.abs(centers_arr[:, None] - excl[None, :]).min(axis=1)
+    keep = np.ones(len(centers_arr), dtype=bool)
+    if min_distance is not None:
+        keep &= d >= min_distance
+    if max_distance is not None:
+        keep &= d <= max_distance
+    return centers_arr[keep].tolist()
 
 
 def collect_test_windows(df_seq, pos_col, window_size):
@@ -242,10 +247,9 @@ def score_window_pwm_(window, pwm):
     ordered by ``ut.LIST_CANONICAL_AA``. The score is the sum over positions of
     ``pwm[i, aa_index[w[i]]]``; non-canonical residues contribute zero.
     """
-    aa_index = {a: i for i, a in enumerate(ut.LIST_CANONICAL_AA)}
     score = 0.0
     for i, aa in enumerate(window):
-        j = aa_index.get(aa)
+        j = _AA_INDEX.get(aa)
         if j is not None:
             score += float(pwm[i, j])
     return score

--- a/aaanalysis/seq_analysis/_backend/aa_window_sampler/sample_motif_matched.py
+++ b/aaanalysis/seq_analysis/_backend/aa_window_sampler/sample_motif_matched.py
@@ -27,20 +27,24 @@ def _scan_protein_(seq, pwm, window_size, aa_index, threshold,
         return []
     # Per-position residue index (-1 for non-canonical).
     aa_idx_arr = np.array([aa_index.get(c, -1) for c in seq], dtype=np.int64)
-    hits = []
     lo, hi = half_left, n - half_right + 1
-    for c in range(lo, hi):
-        if allowed_centers is not None and c not in allowed_centers:
-            continue
-        score = 0.0
-        start = c - half_left
-        for i in range(window_size):
-            j = aa_idx_arr[start + i]
-            if j >= 0:
-                score += float(pwm[i, j])
-        if score >= threshold:
-            hits.append((score, c))
-    return hits
+    centers = range(lo, hi)
+    if allowed_centers is not None:
+        centers = [c for c in centers if c in allowed_centers]
+    centers = np.fromiter(centers, dtype=np.int64)
+    if centers.size == 0:
+        return []
+    # (n_centers, window_size) matrix of residue indices, one row per candidate window.
+    idx_mat = aa_idx_arr[(centers - half_left)[:, None] + np.arange(window_size)[None, :]]
+    # Sum pwm[i, idx] over positions i left-to-right (same order as the scalar loop); a
+    # non-canonical residue (idx < 0) adds 0.0, which is bit-identical to skipping it.
+    scores = np.zeros(centers.size, dtype=float)
+    for i in range(window_size):
+        col = idx_mat[:, i]
+        valid = col >= 0
+        scores += np.where(valid, pwm[i, np.where(valid, col, 0)], 0.0)
+    keep = scores >= threshold
+    return list(zip(scores[keep].tolist(), centers[keep].tolist()))
 
 
 def _slice_window_(seq, center, half_left, window_size):

--- a/docs/source/index/release_notes.rst
+++ b/docs/source/index/release_notes.rst
@@ -189,6 +189,9 @@ Changed
   per-feature Kullback-Leibler divergence (used by ``dPULearn.eval`` with
   ``comp_kld=True``) is parallelized over features and honors
   ``options['n_jobs']``. Public APIs and outputs are unchanged.
+  A further pass vectorizes ``AAWindowSampler`` window-sampling internals:
+  candidate-center band filtering (~40x faster at scale) and per-window PWM
+  scoring in ``sample_motif_matched`` (~12x), again with identical results.
 
 
 Version 1.0 (Stable Version)

--- a/tests/unit/aa_window_sampler_tests/test_batch3_vectorization_equiv.py
+++ b/tests/unit/aa_window_sampler_tests/test_batch3_vectorization_equiv.py
@@ -1,0 +1,118 @@
+"""Equivalence tests for the Batch-3 window-sampler vectorizations.
+
+`candidate_centers_` (integer L1 distances), `_scan_protein_` (left-to-right PWM
+sums), and `score_window_pwm_` (hoisted aa-index) are all bit-identical to their
+original scalar forms; these tests pin that against reference implementations."""
+import numpy as np
+import pytest
+
+import aaanalysis as aa
+import aaanalysis.utils as ut
+from aaanalysis.seq_analysis._backend.aa_window_sampler._utils import (
+    candidate_centers_, score_window_pwm_, window_offsets)
+from aaanalysis.seq_analysis._backend.aa_window_sampler.sample_motif_matched import _scan_protein_
+
+aa.options["verbose"] = False
+AA = "ACDEFGHIKLMNPQRSTVWY"
+AA_INDEX = {a: i for i, a in enumerate(ut.LIST_CANONICAL_AA)}
+
+
+# ---------------- reference (original) implementations ----------------
+def _ref_candidate_centers(seq_len, window_size, exclude_positions=None, min_distance=None, max_distance=None):
+    half_left, half_right = window_offsets(window_size)
+    lo, hi = half_left, seq_len - half_right + 1
+    if hi <= lo:
+        return []
+    centers = list(range(lo, hi))
+    if not exclude_positions or (min_distance is None and max_distance is None):
+        return centers
+    excl = [p - 1 for p in exclude_positions]
+    result = []
+    for c in centers:
+        d = min(abs(c - p) for p in excl)
+        if min_distance is not None and d < min_distance:
+            continue
+        if max_distance is not None and d > max_distance:
+            continue
+        result.append(c)
+    return result
+
+
+def _ref_scan_protein(seq, pwm, window_size, aa_index, threshold, allowed_centers=None):
+    half_left, half_right = window_offsets(window_size)
+    n = len(seq)
+    if n < window_size:
+        return []
+    aa_idx_arr = np.array([aa_index.get(c, -1) for c in seq], dtype=np.int64)
+    hits = []
+    for c in range(half_left, n - half_right + 1):
+        if allowed_centers is not None and c not in allowed_centers:
+            continue
+        score = 0.0
+        start = c - half_left
+        for i in range(window_size):
+            j = aa_idx_arr[start + i]
+            if j >= 0:
+                score += float(pwm[i, j])
+        if score >= threshold:
+            hits.append((score, c))
+    return hits
+
+
+def _ref_score_window_pwm(window, pwm):
+    score = 0.0
+    for i, aa_ in enumerate(window):
+        j = AA_INDEX.get(aa_)
+        if j is not None:
+            score += float(pwm[i, j])
+    return score
+
+
+# ---------------- tests ----------------
+class TestCandidateCentersEquivalence:
+    @pytest.mark.parametrize("min_d,max_d", [(5, 50), (3, None), (None, 20), (None, None), (0, 0)])
+    @pytest.mark.parametrize("seq_len,ws", [(2000, 15), (500, 9), (60, 7)])
+    def test_matches_reference(self, min_d, max_d, seq_len, ws):
+        excl = list(range(1, 200, 3)) + [seq_len - 5]
+        excl = [p for p in excl if 1 <= p <= seq_len]
+        kw = dict(seq_len=seq_len, window_size=ws, exclude_positions=excl,
+                  min_distance=min_d, max_distance=max_d)
+        assert candidate_centers_(**kw) == _ref_candidate_centers(**kw)
+
+    def test_edge_cases(self):
+        assert candidate_centers_(8, 15) == _ref_candidate_centers(8, 15)            # hi<=lo
+        assert candidate_centers_(100, 9, [], 5, 10) == _ref_candidate_centers(100, 9, [], 5, 10)
+        assert candidate_centers_(100, 9, [5]) == _ref_candidate_centers(100, 9, [5])  # both bounds None
+
+
+class TestScanProteinEquivalence:
+    @pytest.mark.parametrize("seed", [0, 1, 7])
+    @pytest.mark.parametrize("threshold", [-1e9, 0.0, 5.0])
+    def test_matches_reference(self, seed, threshold):
+        rng = np.random.default_rng(seed)
+        ws = 15
+        pwm = rng.standard_normal((ws, 20))
+        seq = "".join(rng.choice(list(AA + "XBZ"), 800))  # include non-canonical residues
+        assert _scan_protein_(seq, pwm, ws, AA_INDEX, threshold) == \
+               _ref_scan_protein(seq, pwm, ws, AA_INDEX, threshold)
+
+    def test_allowed_centers_and_short_seq(self):
+        rng = np.random.default_rng(3)
+        ws = 9
+        pwm = rng.standard_normal((ws, 20))
+        seq = "".join(rng.choice(list(AA), 200))
+        allowed = set(range(40, 160))
+        assert _scan_protein_(seq, pwm, ws, AA_INDEX, 1.0, allowed) == \
+               _ref_scan_protein(seq, pwm, ws, AA_INDEX, 1.0, allowed)
+        assert _scan_protein_("ACDEF", pwm, ws, AA_INDEX, 0.0) == []  # n < window_size
+
+
+class TestScoreWindowPwmEquivalence:
+    @pytest.mark.parametrize("seed", [0, 1, 2])
+    def test_matches_reference(self, seed):
+        rng = np.random.default_rng(seed)
+        ws = 15
+        pwm = rng.standard_normal((ws, 20))
+        for _ in range(50):
+            w = "".join(rng.choice(list(AA + "X"), ws))
+            assert score_window_pwm_(w, pwm) == _ref_score_window_pwm(w, pwm)


### PR DESCRIPTION
## Summary

Batch 3 of the performance effort — **same-output** vectorization of hot `AAWindowSampler` loops. Each change is verified against a verbatim copy of the original (exact equality) and benchmarked in isolation. **No public API change.**

| Hotspot | Output | Speedup (isolated) |
|---|---|---|
| `candidate_centers_` band filter | identical (integer L1 distances) | **~44x** (2.2s→0.05s, 200 calls × 200 excludes) |
| `_scan_protein_` PWM scoring (`sample_motif_matched`) | identical hits + scores (left-to-right sum) | **~12x** |
| `score_window_pwm_` aa-index hoist | identical scores | ~1.5x |

## Method (per the batch-1 discipline)

Benchmarked candidates first: `candidate_centers_` (2.2s/200 calls) and `_scan_protein_` were genuinely hot; `_compute_centers` / `_position_aa_freq` were *not* (one-time, not in any hot path) and were left alone. Each shipped change is bit-identical:
- `candidate_centers_`: nearest-excluded distance via `np.abs(centers[:,None]-excl).min(axis=1)`; integer distances → identical band keep/drop.
- `_scan_protein_`: per-window score summed over positions left-to-right via an index matrix; non-canonical residues add `0.0` (bit-identical to skipping). Hit order and float scores match.
- `score_window_pwm_`: hoist the per-call aa-index dict to a module constant.

Equivalence tests (`test_batch3_vectorization_equiv.py`) cover non-canonical residues, `allowed_centers`, band-filter edges, and early returns. Full fast unit suite green (4235 passed).

Note: in-process back-to-back timing is unreliable here (a heavy Python loop contaminates the next measurement), so the speedups above are from isolated runs; correctness is pinned by exact-equality tests regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)