### PR TITLE
test(tiers): integration + e2e test tiers (seams + protocol workflows)

### DIFF
--- a/.claude/rules/sharp-edges.md
+++ b/.claude/rules/sharp-edges.md
@@ -7,8 +7,6 @@ limitations — do not "fix" them opportunistically.
   to the appropriate topical block (search for the nearest `# `-style
   section header). Splitting into `_constants.py`, `_checks/`,
   `_plotting_glue.py`, `_data_io.py` is a v2 refactor.
-- **`tests/integration/` and `tests/e2e/`** are nearly empty. Deferred to
-  v2.
 - **`config.py` is documented as untested.** Adding unit tests when
   touching it is welcomed.
 - **No type checker, no pre-commit, no ruff.** Out of scope until v2.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -9,11 +9,13 @@ paths:
 - `pytest` + `hypothesis`. Coverage via `pytest-cov`.
 - Layout: `tests/unit/<class_or_topic>_tests/test_<class_or_method>.py`. One
   file per public method.
-- **Three tiers** (ADR-0031): `tests/unit/` (per-method, the bulk),
-  `tests/integration/` (cross-component *seams*), `tests/e2e/`
-  (full protocol-mirroring *workflows*). All three are default-selected and
-  **gate merges** (the blocking job runs `-m "not regression"`). See the
-  per-tier taxonomy below before adding to integration/e2e.
+- **Three tiers** (ADR-0031): `tests/unit/` (per-method, the bulk; `Unit Tests`
+  workflow `main.yml`), `tests/integration/` (cross-component *seams*) and
+  `tests/e2e/` (full protocol-mirroring *workflows*) — the latter two run in
+  their **own `Integration & E2E Tests` workflow** (`integration_e2e.yml`) and
+  are excluded from the unit matrix (`main.yml` runs
+  `-m "not regression and not integration and not e2e"`). All three **gate
+  merges**. See the per-tier taxonomy below before adding to integration/e2e.
 
 ## Tier taxonomy (what each tier tests — ADR-0031)
 Count is bounded by distinct *seams* and *workflows*, **not** by unit-test
@@ -132,11 +134,11 @@ actually in use — **do not** create empty `benchmark` tiers.
 
 - `regression` — a frozen-value anchor (see below).
 - `slow` — opt-in heavy tests, deselectable in fast CI runs.
-- `integration` — cross-component seam test (see the tier taxonomy above);
-  default-selected, so it gates merges.
-- `e2e` — full protocol-mirroring workflow; default-selected, so it gates
-  merges. Add the marker module-wide with `pytestmark = pytest.mark.integration`
-  (or `e2e`).
+- `integration` — cross-component seam test (see the tier taxonomy above); runs
+  in the dedicated `Integration & E2E Tests` workflow, excluded from the unit
+  matrix.
+- `e2e` — full protocol-mirroring workflow; same dedicated workflow. Add the
+  marker module-wide with `pytestmark = pytest.mark.integration` (or `e2e`).
 
 ### CPP regression anchor (ADR-0015)
 `tests/unit/cpp_tests/test_cpp_regression.py` runs a seeded `DOM_GSEC`

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -9,9 +9,40 @@ paths:
 - `pytest` + `hypothesis`. Coverage via `pytest-cov`.
 - Layout: `tests/unit/<class_or_topic>_tests/test_<class_or_method>.py`. One
   file per public method.
-- `tests/integration/` and `tests/e2e/` exist but are nearly empty —
-  integration / e2e coverage is **deferred to v2**. Do not add integration
-  tests proactively.
+- **Three tiers** (ADR-0031): `tests/unit/` (per-method, the bulk),
+  `tests/integration/` (cross-component *seams*), `tests/e2e/`
+  (full protocol-mirroring *workflows*). All three are default-selected and
+  **gate merges** (the blocking job runs `-m "not regression"`). See the
+  per-tier taxonomy below before adding to integration/e2e.
+
+## Tier taxonomy (what each tier tests — ADR-0031)
+Count is bounded by distinct *seams* and *workflows*, **not** by unit-test
+volume; cover each seam/workflow **once**. The governing rule: **don't re-test
+at a higher tier what a lower tier already covers.**
+
+| Aspect | Unit | Integration | E2e |
+|---|---|---|---|
+| Job | per-method correctness | seam contract holds | workflow → right artifact |
+| Positive | per-param, hypothesis-fuzzed | happy path | happy path |
+| Negative | per-param invalid-input sweep | **composition failures only** (NOT input validation) | minimal: degenerate dataset → clear error |
+| Hypothesis | per-argument strategies | **pipeline invariants / metamorphic** | **reproducibility** (seed→same artifact) |
+
+- **Integration negatives are composition failures** — failures invisible to
+  either component's unit tests (shape/label-set mismatch at a seam, PU dataset
+  with no unlabeled rows, sampler returns no windows → empty logo, single-class
+  labels into `CPP.run`). Do **not** re-run per-parameter invalid-input
+  negatives there — that is the unit layer's job (frontend `# Validate` block).
+- **Keep inputs tiny + seeded**, assert **structural/range** artifacts (shapes,
+  schema columns, metrics in `[0,1]`, finiteness) — **never frozen exact
+  values** (that is the regression anchor's job; e2e runs the full matrix where
+  3rd-decimal drift would flake). Hypothesis here uses small `max_examples`
+  (3–5) because each example runs the real pipeline.
+- **Shared seeded builders** live in `tests/_pipeline.py` (one definition of the
+  load→parts→CPP→matrix spine), exposed to integration as session fixtures in
+  `tests/integration/conftest.py` and imported directly by e2e.
+- `tests/integration/test_online_fetches.py` is a separate, `network`-marked
+  live-endpoint tier (deselected by default); it is *not* the cross-component
+  integration tier above.
 
 ## File header (current style)
 Each test file currently opens with:
@@ -97,11 +128,15 @@ inline (aligns with `reproducibility.md`).
 
 ## Test tiers & markers
 Register markers in `tests/pytest.ini` `markers =`; only stand up markers
-actually in use — **do not** create empty `integration`/`benchmark` tiers
-(integration/e2e stay deferred to v2, below).
+actually in use — **do not** create empty `benchmark` tiers.
 
 - `regression` — a frozen-value anchor (see below).
 - `slow` — opt-in heavy tests, deselectable in fast CI runs.
+- `integration` — cross-component seam test (see the tier taxonomy above);
+  default-selected, so it gates merges.
+- `e2e` — full protocol-mirroring workflow; default-selected, so it gates
+  merges. Add the marker module-wide with `pytestmark = pytest.mark.integration`
+  (or `e2e`).
 
 ### CPP regression anchor (ADR-0015)
 `tests/unit/cpp_tests/test_cpp_regression.py` runs a seeded `DOM_GSEC`

--- a/.github/workflows/integration_e2e.yml
+++ b/.github/workflows/integration_e2e.yml
@@ -1,0 +1,62 @@
+name: Integration & E2E Tests
+
+# Dedicated home for the cross-component (integration) and protocol-workflow
+# (e2e) tiers — see ADR-0031. These are excluded from the `Unit Tests` matrix
+# (main.yml `-m "not integration and not e2e"`) so they run once, here, as their
+# own PR check. Core-only + tiny + seeded, so this needs no FIMO/cd-hit/mmseqs
+# and no `pro` extra; Python is bracketed at the floor + ceiling on Linux.
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  integration-e2e:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ['3.10', '3.14']  # bracket the supported range
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Cache Python dependencies
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ matrix.python-version }}-
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install package and test dependencies
+      # Core install only — the integration/e2e tiers import no `pro` features.
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .
+        pip install pytest hypothesis pytest-xdist
+
+    - name: Run integration & e2e tiers
+      # One combined check over both directories. The network-marked live-endpoint
+      # file (test_online_fetches.py) is skipped by default and would need the `pro`
+      # extra just to import, so it is ignored here; it stays collected (and skipped)
+      # in the Unit Tests matrix and runs on demand / in the nightly.
+      run: >-
+        pytest tests/integration tests/e2e
+        --ignore=tests/integration/test_online_fetches.py
+        -m "not regression" -n auto -c tests/pytest.ini --durations=20
+      env:
+        MPLBACKEND: Agg

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,10 @@ jobs:
       # The exact-value regression anchor (-m regression) runs in the nightly
       # job, not in this fail-fast matrix (ADR-0015) — its frozen values are
       # canonical-cell-specific and must not gate every cell.
-      run: pytest tests -m "not regression" -x -n auto --durations=20
+      # The integration/e2e tiers have their own `Integration & E2E Tests`
+      # workflow (integration_e2e.yml, ADR-0031); excluded here to avoid a
+      # double-run.
+      run: pytest tests -m "not regression and not integration and not e2e" -x -n auto --durations=20
       env:
         MPLBACKEND: Agg
 

--- a/docs/adr/0031-integration-e2e-test-policy.md
+++ b/docs/adr/0031-integration-e2e-test-policy.md
@@ -34,12 +34,18 @@ drift-flaky, and add nothing the unit layer already covers.
 
 ## Decision
 
-- **D1 — Stand up two real tiers that gate merges.** `tests/integration/`
-  (cross-component *seams*) and `tests/e2e/` (full protocol-mirroring
-  *workflows*) are default-selected: the blocking job already runs
-  `-m "not regression"`, so both tiers run on every push/PR. New `integration`
-  and `e2e` markers are registered in `tests/pytest.ini` for selection/clarity,
-  **not** for deselection.
+- **D1 — Stand up two real tiers that gate merges, in their own CI action.**
+  `tests/integration/` (cross-component *seams*) and `tests/e2e/` (full
+  protocol-mirroring *workflows*) run in a **dedicated `Integration & E2E Tests`
+  workflow** (`.github/workflows/integration_e2e.yml`, one combined job over
+  both directories, Linux, Python bracketed at floor + ceiling). They are
+  **excluded from the `Unit Tests` matrix** (`main.yml` runs
+  `-m "not regression and not integration and not e2e"`) so they run once, as
+  their own PR check, rather than double-running across the full matrix. New
+  `integration` / `e2e` markers in `tests/pytest.ini` drive both the dedicated
+  selection and that exclusion. (They are core-only + offline, so the dedicated
+  workflow needs no `pro` extra and no FIMO/cd-hit/mmseqs; the network-marked
+  `test_online_fetches.py` stays in the unit matrix, skipped by default.)
 - **D2 — Count is bounded by seams × workflows, not by unit-test volume.** Each
   distinct component seam and each protocol notebook is covered **once**. The
   initial suite is ~12 integration seams and 10 e2e workflows.

--- a/docs/adr/0031-integration-e2e-test-policy.md
+++ b/docs/adr/0031-integration-e2e-test-policy.md
@@ -1,0 +1,102 @@
+# ADR-0031 — Integration & e2e test tiers: scope, taxonomy, and merge-gating
+
+Status: Accepted — 2026-06-13
+
+Relates to: the `testing.md` and `sharp-edges.md` path-scoped rules; ADR-0015
+(CPP regression anchor) and ADR-0016 (coverage policy).
+
+## Context
+
+`tests/integration/` and `tests/e2e/` had been **deferred to v2**
+(`sharp-edges.md`, `testing.md`: "do not add integration tests proactively").
+The only file in either tree was `tests/integration/test_online_fetches.py`, a
+`network`-marked live-endpoint contract — not a cross-component test. Two facts
+made the deferral costly:
+
+- **nbmake is not in any CI workflow.** The protocol notebooks under
+  `protocols/` run end to end *by hand only*; they assert nothing and gate
+  nothing. The tutorial/example nbmake job described in older notes is a
+  local-only gate.
+- **The CPP regression anchor (ADR-0015) is the only seeded multi-component
+  pipeline, and it is `@pytest.mark.regression`** — it runs only in the
+  non-gating nightly on the canonical cell.
+
+Net: there was **no blocking, assertion-bearing, multi-component test in CI**.
+Unit tests mock the seams; the contracts *between* components (CPP→TreeModel,
+dPULearn→TreeModel, AAclust→scales→features, sampler→logo, design→features,
+encoder→consumer, fasta round-trip) were asserted nowhere.
+
+A recurring question when adding higher tiers is "how many, given ~4k unit
+tests?" The naive test-pyramid ratio (70/20/10) would imply ~1100 integration
+tests, which is wrong here: e2e runs the real CPP pipeline (seconds each, on the
+full matrix), so redundant input-validation re-tests would be slow,
+drift-flaky, and add nothing the unit layer already covers.
+
+## Decision
+
+- **D1 — Stand up two real tiers that gate merges.** `tests/integration/`
+  (cross-component *seams*) and `tests/e2e/` (full protocol-mirroring
+  *workflows*) are default-selected: the blocking job already runs
+  `-m "not regression"`, so both tiers run on every push/PR. New `integration`
+  and `e2e` markers are registered in `tests/pytest.ini` for selection/clarity,
+  **not** for deselection.
+- **D2 — Count is bounded by seams × workflows, not by unit-test volume.** Each
+  distinct component seam and each protocol notebook is covered **once**. The
+  initial suite is ~12 integration seams and 10 e2e workflows.
+- **D3 — Per-tier division of labor: don't re-test at a higher tier what a
+  lower tier covers.**
+
+  | Aspect | Unit | Integration | E2e |
+  |---|---|---|---|
+  | Job | per-method correctness | seam contract holds | workflow → right artifact |
+  | Positive | per-param, hypothesis-fuzzed | happy path | happy path |
+  | Negative | per-param invalid-input sweep | **composition failures only** | minimal: degenerate dataset → clear error |
+  | Hypothesis | per-argument strategies | **pipeline invariants / metamorphic** | **reproducibility** (seed→same artifact) |
+
+- **D4 — Higher-tier negatives are composition failures only.** Failures that
+  emerge *when components meet* and are invisible to either component's unit
+  tests (shape/label-set mismatch at a seam, a PU dataset with no unlabeled
+  rows, a sampler that returns no windows feeding a logo, single-class labels
+  into `CPP.run`). Per-parameter invalid-input negatives stay in the unit layer
+  (the frontend `# Validate` block); re-running them at e2e is the anti-pattern
+  this ADR forbids.
+- **D5 — Higher-tier hypothesis is invariants/metamorphic + reproducibility,
+  with small `max_examples` (3–5).** Each example runs the real pipeline, so
+  broad per-argument fuzzing belongs to units. Examples: `len(X) == n_samples`;
+  same seed → identical `df_feat` / predictions / PU carve; row-permutation of
+  `df_seq` ⇒ same *set* of top features.
+- **D6 — Structural/range assertions, never frozen exact values.** These tiers
+  run on the full CI matrix where 3rd-decimal drift would flake; exact-value
+  freezing remains the regression anchor's job (ADR-0015). Assert shapes, schema
+  columns, metrics in `[0,1]`, monotonic ranking, finiteness.
+- **D7 — One shared seeded spine.** `tests/_pipeline.py` defines the
+  load→parts→CPP→feature-matrix builders once; `tests/integration/conftest.py`
+  exposes them as session fixtures and e2e imports the functions directly, so a
+  seam's call pattern is defined in exactly one place.
+- **D8 — Core-only, offline.** No `pro`/`embed` imports and no `network`
+  dependency in these tiers; where a protocol cell uses a pro feature
+  (protocol9's `ShapModel`) the core path (`TreeModel.add_feat_importance`) is
+  substituted.
+
+## Consequences
+
+- CI now has a blocking, assertion-bearing pipeline test for every documented
+  workflow and every cross-component seam — the protocol notebooks finally have
+  checked analogues even though nbmake is not in CI.
+- The `testing.md` taxonomy table and the `sharp-edges.md` deferral are updated
+  to match; "integration/e2e deferred to v2" is no longer true.
+- Reviewers have a bright line for higher-tier scope: a new integration test is
+  justified only by a *new seam* or a *new composition failure mode*, not by a
+  parameter that the unit layer already sweeps.
+- This supersedes the v2 deferral in `sharp-edges.md` for integration/e2e only;
+  lint/type-check tiers (ruff/mypy/pre-commit) remain v2-deferred per ADR-0016.
+
+## External practice
+
+The tier division follows the standard test pyramid: many fast unit tests, fewer
+integration tests at component seams, fewest end-to-end tests over full
+workflows (Cohn, *Succeeding with Agile*; Fowler, *TestPyramid* and
+*IntegrationTest*; *Software Engineering at Google*, ch. 11–14 on test sizes and
+scope). The "don't duplicate lower-tier coverage at a higher tier" rule and the
+preference for metamorphic/invariant checks over re-fuzzing are drawn from the
+same sources and from metamorphic-testing literature.

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,11 +13,46 @@ method, `Test<Method>` / `Test<Method>Complex` classes, negative tests with
 `pytest.raises(..., match=...)`, property tests with `@given` + `@settings(deadline=None)`,
 and golden-value checks for the scientific core.
 
+## Test tiers (unit · integration · e2e)
+
+Three tiers with **distinct jobs** (full taxonomy + rationale in
+`.claude/rules/testing.md` and **ADR-0031**). The rule that keeps them from
+overlapping: *don't re-test at a higher tier what a lower tier already covers.*
+
+| Tier | Directory | Job | Negatives are… | Hypothesis is… |
+|---|---|---|---|---|
+| **unit** | `tests/unit/` | one public method, in isolation | per-parameter invalid-input sweep | per-argument strategies |
+| **integration** | `tests/integration/` | a **seam** between two/three real classes (no mocks) | **composition failures only** | pipeline invariants / metamorphic |
+| **e2e** | `tests/e2e/` | a full **workflow** mirroring a `protocols/*.ipynb` | degenerate dataset → clear error | reproducibility (seed→same artifact) |
+
+- **Integration** (`test_feature_pipeline`, `test_prediction_pipeline`,
+  `test_seq_pipeline`, `test_data_pipeline`) asserts that one component's output is a
+  valid input to the next — e.g. `CPP.run` → `feature_matrix` → `TreeModel.fit`,
+  `dPULearn` carve → `TreeModel`, `AAWindowSampler` → `AAlogo`, `CPPGrid` sweep + `eval`,
+  fasta round-trip, encoder → consumer. Its negatives are failures that only emerge *when
+  components meet* (shape/label-set mismatch, PU dataset with no unlabeled rows, a sampler
+  that returns no windows) — never a re-run of unit-level input validation.
+- **e2e** (`test_protocols.py`) runs one tiny, seeded, assertion-bearing analogue of each
+  `protocol1`–`10` notebook (the notebooks themselves assert nothing). Core-only: where a
+  protocol uses a `pro` feature it substitutes the core path.
+- Both tiers assert **structural/range** artifacts (shapes, schema columns, metrics in
+  `[0, 1]`, finiteness, monotonic ranking) and **never frozen exact values** — exact-value
+  freezing is the CPP regression anchor's job (ADR-0015). Their shared seeded spine lives
+  in `tests/_pipeline.py`; integration exposes it as session fixtures in
+  `tests/integration/conftest.py`, and e2e imports the builders directly. Count is bounded
+  by *seams × workflows*, not by unit-test volume.
+
+`tests/integration/test_online_fetches.py` is a separate, `network`-marked live-endpoint
+tier (deselected by default), not part of the cross-component integration tier.
+
 ## Running
 
 ```bash
 # full suite (parallel)
 pytest tests -m "not regression" -n auto -c tests/pytest.ini
+
+# just the cross-component + workflow tiers
+pytest tests/integration tests/e2e -m "not regression" -n auto -c tests/pytest.ini
 
 # branch + line coverage gate (matches CI: line >=88, branch >=80)
 COVERAGE_CORE=sysmon pytest tests -m "not regression" \
@@ -25,8 +60,14 @@ COVERAGE_CORE=sysmon pytest tests -m "not regression" \
 python .github/scripts/check_branch_coverage.py
 ```
 
-Always pass `-c tests/pytest.ini` (it registers the `regression`/`slow` markers and the
-`filterwarnings` for the deliberate CPP advisories). Coverage config is `/.coveragerc`.
+Always pass `-c tests/pytest.ini` (it registers the `regression`/`slow`/`integration`/`e2e`
+markers and the `filterwarnings` for the deliberate CPP advisories). Coverage config is
+`/.coveragerc`.
+
+**In CI** the `integration`/`e2e` tiers run in their own **`Integration & E2E Tests`**
+workflow (`.github/workflows/integration_e2e.yml`) and are excluded from the `Unit Tests`
+matrix (`main.yml` runs `-m "not regression and not integration and not e2e"`) so they
+appear as their own check and never double-run.
 
 ## Coverage policy
 

--- a/tests/_pipeline.py
+++ b/tests/_pipeline.py
@@ -1,0 +1,54 @@
+"""Shared, tiny, seeded pipeline builders for the integration + e2e test tiers.
+
+These helpers wire the *real* public components together (no mocks) at a small,
+fixed size so the cross-component tests stay fast under xdist. Both
+``tests/integration`` (via fixtures in its ``conftest.py``) and ``tests/e2e``
+import from here, so a seam's call pattern is defined once. Assertions live in
+the test files; this module only builds artifacts. See ADR-0031.
+"""
+import aaanalysis as aa
+
+# A small balanced run: load_dataset(n=N) returns N rows per class (2N total).
+SEED = 0
+N_PER_CLASS = 10
+N_FILTER = 20
+N_SCALES = 20
+
+
+def small_scales(n_scales: int = N_SCALES):
+    """A small, fixed ``df_scales`` (rows = amino acids, cols = scales)."""
+    return aa.load_scales(top60_n=n_scales).T.head(n_scales).T
+
+
+def load_dom_gsec(n: int = N_PER_CLASS):
+    """Balanced domain-level df_seq (position-based: has ``tmd_start``/``tmd_stop``)."""
+    return aa.load_dataset(name="DOM_GSEC", n=n)
+
+
+def build_df_feat(df_parts, labels, df_scales, n_filter: int = N_FILTER):
+    """Run CPP on the given parts/labels/scales and return the ranked ``df_feat``."""
+    cpp = aa.CPP(df_parts=df_parts, df_scales=df_scales, verbose=False, random_state=SEED)
+    return cpp.run(labels=labels, n_filter=n_filter, n_jobs=1)
+
+
+def feature_matrix(df_feat, df_parts, df_scales):
+    """Build ``X`` from a feature set + parts, using the SAME scales as ``build_df_feat``."""
+    sf = aa.SequenceFeature()
+    return sf.feature_matrix(features=df_feat["feature"], df_parts=df_parts,
+                             df_scales=df_scales, n_jobs=1)
+
+
+def build_pipeline(n: int = N_PER_CLASS, n_filter: int = N_FILTER, n_scales: int = N_SCALES):
+    """Build the full load -> parts -> CPP -> feature-matrix spine once, seeded.
+
+    Returns a dict of the shared artifacts so callers can assert on any seam
+    without re-running the (relatively expensive) CPP step.
+    """
+    df_seq = load_dom_gsec(n=n)
+    labels = df_seq["label"].to_list()
+    df_parts = aa.SequenceFeature().get_df_parts(df_seq=df_seq)
+    df_scales = small_scales(n_scales=n_scales)
+    df_feat = build_df_feat(df_parts=df_parts, labels=labels, df_scales=df_scales, n_filter=n_filter)
+    X = feature_matrix(df_feat=df_feat, df_parts=df_parts, df_scales=df_scales)
+    return dict(df_seq=df_seq, labels=labels, df_parts=df_parts,
+                df_scales=df_scales, df_feat=df_feat, X=X)

--- a/tests/e2e/test_protocols.py
+++ b/tests/e2e/test_protocols.py
@@ -36,10 +36,10 @@ class TestProtocol1Signature:
         assert df_feat["abs_auc"].is_monotonic_decreasing  # ranked best-first
 
     def test_signature_reproducible(self):
-        # Reproducibility: the same seeded run yields the same top feature.
+        # Reproducibility: the same seeded run yields the identical ranked signature.
         a = _pipeline.build_pipeline()["df_feat"]
         b = _pipeline.build_pipeline()["df_feat"]
-        assert a["feature"].iloc[0] == b["feature"].iloc[0]
+        assert a["feature"].to_list() == b["feature"].to_list()
 
 
 # ---------------------------------------------------------------------------
@@ -212,7 +212,7 @@ class TestE2EDegenerate:
     def test_single_class_pipeline_rejected(self):
         # All-one-class labels cannot define a TEST-vs-REF contrast.
         p = _pipeline.build_pipeline()
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="more than one different value"):
             aa.CPP(df_parts=p["df_parts"], df_scales=p["df_scales"], verbose=False).run(
                 labels=[1] * len(p["labels"]), n_filter=5, n_jobs=1)
 
@@ -220,6 +220,6 @@ class TestE2EDegenerate:
         # One sample cannot train/evaluate a model; the error must be explicit.
         p = _pipeline.build_pipeline()
         X1 = np.asarray(p["X"])[:1]
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="should be >= 3"):
             aa.TreeModel(verbose=False, random_state=0).fit(
                 X1, labels=[1], use_rfe=False, n_cv=2, n_rounds=2)

--- a/tests/e2e/test_protocols.py
+++ b/tests/e2e/test_protocols.py
@@ -1,0 +1,225 @@
+"""This is a script to test the end-to-end protocol workflows.
+
+E2e tier (ADR-0031): one assertion-bearing test per ``protocols/*.ipynb`` —
+the protocol notebooks run end to end but assert nothing and are not in CI, so
+these are their checked analogues. Each runs the real pipeline at a tiny, seeded
+size and asserts a *final artifact* (range/shape/finiteness), never a frozen
+exact value. Where a protocol cell uses a ``pro`` feature (protocol9's
+ShapModel) the core path is substituted. A couple of degenerate-dataset
+negatives confirm a clear error instead of a cryptic crash.
+"""
+import numpy as np
+import pytest
+from hypothesis import given, settings
+import hypothesis.strategies as some
+
+import aaanalysis as aa
+from tests import _pipeline
+
+settings.register_profile("ci", deadline=None)
+settings.load_profile("ci")
+
+pytestmark = pytest.mark.e2e
+
+DF_FEAT_COLS = {"feature", "abs_auc", "mean_dif", "category"}
+
+
+# ---------------------------------------------------------------------------
+# protocol1 — CPP signature
+# ---------------------------------------------------------------------------
+class TestProtocol1Signature:
+    def test_signature_artifact(self, ):
+        p = _pipeline.build_pipeline()
+        df_feat = p["df_feat"]
+        assert DF_FEAT_COLS.issubset(df_feat.columns)
+        assert len(df_feat) == _pipeline.N_FILTER
+        assert df_feat["abs_auc"].is_monotonic_decreasing  # ranked best-first
+
+    def test_signature_reproducible(self):
+        # Reproducibility: the same seeded run yields the same top feature.
+        a = _pipeline.build_pipeline()["df_feat"]
+        b = _pipeline.build_pipeline()["df_feat"]
+        assert a["feature"].iloc[0] == b["feature"].iloc[0]
+
+
+# ---------------------------------------------------------------------------
+# protocol2 — sequence analysis (logo + conservation)
+# ---------------------------------------------------------------------------
+class TestProtocol2SequenceAnalysis:
+    def test_conservation_scalar_finite(self):
+        df_seq = aa.load_dataset(name="DOM_GSEC", n=15)
+        df_parts = aa.SequenceFeature().get_df_parts(
+            df_seq=df_seq, list_parts=["jmd_n", "tmd", "jmd_c"])
+        aal = aa.AAlogo(logo_type="probability")
+        df_logo_info = aal.get_df_logo_info(df_parts=df_parts, tmd_len=20)
+        cons = aal.get_conservation(df_logo_info=df_logo_info, value_type="mean")
+        assert np.isfinite(cons) and cons >= 0
+
+
+# ---------------------------------------------------------------------------
+# protocol3 — sampling (benchmark set)
+# ---------------------------------------------------------------------------
+class TestProtocol3Sampling:
+    ARMS = {"ctrl_freq": {"method": "synthetic", "n": 6, "window_size": 9, "generator": "global_freq"},
+            "ctrl_unif": {"method": "synthetic", "n": 6, "window_size": 9, "generator": "uniform"}}
+
+    def test_benchmark_set_schema_and_counts(self):
+        df_seq = aa.load_dataset(name="DOM_GSEC", n=8)
+        df_bench = aa.AAWindowSampler(random_state=0).sample_benchmark_set(
+            df_seq=df_seq, arms=self.ARMS, seed=0)
+        assert {"window", "label", "role", "arm"}.issubset(df_bench.columns)
+        assert df_bench["arm"].value_counts().to_dict() == {"ctrl_freq": 6, "ctrl_unif": 6}
+
+    def test_benchmark_set_reproducible(self):
+        df_seq = aa.load_dataset(name="DOM_GSEC", n=8)
+        a = aa.AAWindowSampler(random_state=0).sample_benchmark_set(df_seq=df_seq, arms=self.ARMS, seed=0)
+        b = aa.AAWindowSampler(random_state=0).sample_benchmark_set(df_seq=df_seq, arms=self.ARMS, seed=0)
+        assert a["window"].to_list() == b["window"].to_list()
+
+
+# ---------------------------------------------------------------------------
+# protocol4 — prediction tasks across levels (residue / domain / protein)
+# ---------------------------------------------------------------------------
+class TestProtocol4PredictionLevels:
+    @pytest.mark.parametrize("name", ["AA_CASPASE3", "DOM_GSEC", "SEQ_AMYLO"])
+    def test_level_pipeline_trains(self, name):
+        sf = aa.SequenceFeature()
+        df_scales = _pipeline.small_scales()
+        df_seq = aa.load_dataset(name=name, n=8)
+        labels = df_seq["label"].to_list()
+        if name == "DOM_GSEC":
+            df_parts = sf.get_df_parts(df_seq=df_seq)
+            split_kws = None
+        else:  # residue / protein windows are short -> small Segment-only splits
+            df_parts = sf.get_df_parts(df_seq=df_seq, list_parts=["tmd"], jmd_n_len=0, jmd_c_len=0)
+            split_kws = sf.get_split_kws(split_types=["Segment"], n_split_max=4)
+        df_feat = aa.CPP(df_parts=df_parts, split_kws=split_kws, df_scales=df_scales,
+                         verbose=False, random_state=0).run(labels=labels, n_filter=6, n_jobs=1)
+        X = sf.feature_matrix(features=df_feat["feature"], df_parts=df_parts,
+                              df_scales=df_scales, n_jobs=1)
+        tm = aa.TreeModel(verbose=False, random_state=0).fit(
+            X, labels=labels, use_rfe=False, n_cv=2, n_rounds=2)
+        assert len(df_feat) > 0
+        assert len(tm.feat_importance) == np.asarray(X).shape[1]
+
+
+# ---------------------------------------------------------------------------
+# protocol5 — engineer features
+# ---------------------------------------------------------------------------
+class TestProtocol5EngineerFeatures:
+    def test_feature_matrix_then_correlation_filter(self):
+        p = _pipeline.build_pipeline()
+        X = np.asarray(p["X"])
+        assert X.shape == (len(p["labels"]), _pipeline.N_FILTER)
+        mask = np.asarray(aa.NumericalFeature().filter_correlation(X, max_cor=0.7))
+        # The de-correlated set keeps at least one and no more than all features.
+        assert 1 <= mask.sum() <= X.shape[1]
+
+
+# ---------------------------------------------------------------------------
+# protocol6 — compositional vs positional signatures
+# ---------------------------------------------------------------------------
+class TestProtocol6CompositionalPositional:
+    def test_both_strategies_yield_categorised_features(self):
+        df_seq = aa.load_dataset(name="DOM_GSEC", n=12)
+        labels = df_seq["label"].to_list()
+        sf = aa.SequenceFeature()
+        df_parts = sf.get_df_parts(df_seq=df_seq)
+        df_scales = _pipeline.small_scales()
+        skw_comp = sf.get_split_kws(split_types=["Segment"], n_split_max=4)
+        skw_pos = sf.get_split_kws(split_types=["PeriodicPattern"])
+        df_comp = aa.CPP(df_parts=df_parts, split_kws=skw_comp, df_scales=df_scales,
+                         verbose=False, random_state=0).run(labels=labels, n_filter=8, n_jobs=1)
+        df_pos = aa.CPP(df_parts=df_parts, split_kws=skw_pos, df_scales=df_scales,
+                        verbose=False, random_state=0).run(labels=labels, n_filter=8, n_jobs=1)
+        for df_feat in (df_comp, df_pos):
+            assert len(df_feat) > 0
+            assert df_feat["category"].notna().all()
+
+
+# ---------------------------------------------------------------------------
+# protocol7 — feature selection
+# ---------------------------------------------------------------------------
+class TestProtocol7FeatureSelection:
+    def test_selection_reduces_feature_set(self):
+        p = _pipeline.build_pipeline()
+        X, labels = np.asarray(p["X"]), np.asarray(p["labels"])
+        auc = np.asarray(aa.comp_auc_adjusted(X=X, labels=labels, n_jobs=1))
+        # Keep the most discriminative half -> a strictly smaller, non-empty set.
+        keep = np.argsort(np.abs(auc))[::-1][: max(1, X.shape[1] // 2)]
+        assert 0 < len(keep) < X.shape[1]
+        tm = aa.TreeModel(verbose=False, random_state=0).fit(
+            X[:, keep], labels=labels.tolist(), use_rfe=False, n_cv=2, n_rounds=2)
+        assert len(tm.feat_importance) == len(keep)
+
+
+# ---------------------------------------------------------------------------
+# protocol8 — prediction (fit + eval + PU path)
+# ---------------------------------------------------------------------------
+class TestProtocol8Prediction:
+    def test_fit_and_eval_metrics(self):
+        p = _pipeline.build_pipeline()
+        tm = aa.TreeModel(verbose=False, random_state=0).fit(
+            p["X"], labels=p["labels"], use_rfe=False, n_cv=2, n_rounds=2)
+        df_eval = tm.eval(p["X"], labels=p["labels"], list_is_selected=[tm.is_selected_],
+                          n_cv=2, list_metrics=["accuracy", "f1"])
+        num = df_eval.select_dtypes("number").values
+        assert num.size > 0
+        assert ((num >= -1e-9) & (num <= 1 + 1e-9)).all()
+
+    def test_predictions_reproducible(self):
+        p = _pipeline.build_pipeline()
+        kws = dict(use_rfe=False, n_cv=2, n_rounds=2)
+        a = aa.TreeModel(verbose=False, random_state=0).fit(p["X"], labels=p["labels"], **kws)
+        b = aa.TreeModel(verbose=False, random_state=0).fit(p["X"], labels=p["labels"], **kws)
+        pred_a, _ = a.predict_proba(p["X"])
+        pred_b, _ = b.predict_proba(p["X"])
+        assert np.allclose(np.asarray(pred_a), np.asarray(pred_b))
+
+
+# ---------------------------------------------------------------------------
+# protocol9 — interpretability (core TreeModel path; ShapModel is pro)
+# ---------------------------------------------------------------------------
+class TestProtocol9Interpretability:
+    def test_importances_rank_features(self):
+        p = _pipeline.build_pipeline()
+        tm = aa.TreeModel(verbose=False, random_state=0).fit(
+            p["X"], labels=p["labels"], use_rfe=False, n_cv=2, n_rounds=2)
+        df_feat = tm.add_feat_importance(df_feat=p["df_feat"])
+        imp = df_feat["feat_importance"]
+        assert (imp >= 0).all() and imp.sum() > 0
+        assert len(df_feat) == len(p["df_feat"])
+
+
+# ---------------------------------------------------------------------------
+# protocol10 — validation (adjusted AUC + bootstrap CI)
+# ---------------------------------------------------------------------------
+class TestProtocol10Validation:
+    def test_auc_and_bootstrap_ci_finite(self):
+        p = _pipeline.build_pipeline()
+        X, labels = np.asarray(p["X"]), np.asarray(p["labels"])
+        auc = np.asarray(aa.comp_auc_adjusted(X=X, labels=labels, n_jobs=1))
+        assert np.isfinite(auc).all()
+        assert (np.abs(auc) <= 0.5 + 1e-9).all()  # adjusted AUC lives in [-0.5, 0.5]
+        ci = aa.comp_bootstrap_ci(values=auc.ravel(), n_rounds=200, ci=0.95, seed=0)
+        assert ci["ci_low"] <= ci["mean"] <= ci["ci_high"]
+
+
+# ---------------------------------------------------------------------------
+# Degenerate-dataset negatives (clear error, not a cryptic crash)
+# ---------------------------------------------------------------------------
+class TestE2EDegenerate:
+    def test_single_class_pipeline_rejected(self):
+        # All-one-class labels cannot define a TEST-vs-REF contrast.
+        p = _pipeline.build_pipeline()
+        with pytest.raises(ValueError):
+            aa.CPP(df_parts=p["df_parts"], df_scales=p["df_scales"], verbose=False).run(
+                labels=[1] * len(p["labels"]), n_filter=5, n_jobs=1)
+
+    def test_too_few_samples_for_model_rejected(self):
+        # One sample cannot train/evaluate a model; the error must be explicit.
+        p = _pipeline.build_pipeline()
+        X1 = np.asarray(p["X"])[:1]
+        with pytest.raises(ValueError):
+            aa.TreeModel(verbose=False, random_state=0).fit(
+                X1, labels=[1], use_rfe=False, n_cv=2, n_rounds=2)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,21 @@
+"""Fixtures for the integration tier.
+
+Wraps the shared seeded builders in ``tests/_pipeline.py`` as session-scoped
+fixtures so the (relatively expensive) ``CPP.run`` spine is built once and
+reused across the seam tests. Treat the returned artifacts as read-only.
+"""
+import pytest
+
+from tests import _pipeline
+
+
+@pytest.fixture(scope="session")
+def pipeline():
+    """The shared load -> parts -> CPP -> feature-matrix artifacts (built once)."""
+    return _pipeline.build_pipeline()
+
+
+@pytest.fixture(scope="session")
+def small_scales():
+    """A small, fixed ``df_scales`` (rows = amino acids, cols = scales)."""
+    return _pipeline.small_scales()

--- a/tests/integration/test_data_pipeline.py
+++ b/tests/integration/test_data_pipeline.py
@@ -1,0 +1,91 @@
+"""This is a script to test the data-handling seams (real components, no mocks).
+
+Integration tier (ADR-0031).
+
+Seams covered:
+  11. to_fasta -> read_fasta round-trip
+  12. SequencePreprocessor.encode_one_hot / encode_integer -> downstream consumer
+"""
+import numpy as np
+import pandas as pd
+import pytest
+from hypothesis import given, settings
+import hypothesis.strategies as some
+
+import aaanalysis as aa
+
+settings.register_profile("ci", deadline=None)
+settings.load_profile("ci")
+
+pytestmark = pytest.mark.integration
+
+ALPHABET = "ACDEFGHIKLMNPQRSTVWY"
+
+
+# ---------------------------------------------------------------------------
+# Seam 11: to_fasta -> read_fasta round-trip
+# ---------------------------------------------------------------------------
+class TestFastaRoundTrip:
+    """A df_seq survives a write/read round-trip through the FASTA layer."""
+
+    def test_round_trip_preserves_entries_and_sequences(self, tmp_path):
+        df = aa.load_dataset(name="DOM_GSEC", n=4)[["entry", "sequence"]].copy()
+        fp = str(tmp_path / "seqs.fasta")
+        aa.to_fasta(df, file_path=fp)
+        df_read = aa.read_fasta(fp)
+        assert {"entry", "sequence"}.issubset(df_read.columns)
+        assert sorted(df_read["entry"]) == sorted(df["entry"])
+        assert set(df_read["sequence"]) == set(df["sequence"])
+
+    def test_round_trip_is_stable_on_re_read(self, tmp_path):
+        # Property: a second write/read of the read-back frame is a fixed point.
+        df = aa.load_dataset(name="DOM_GSEC", n=3)[["entry", "sequence"]].copy()
+        fp1, fp2 = str(tmp_path / "a.fasta"), str(tmp_path / "b.fasta")
+        aa.to_fasta(df, file_path=fp1)
+        df_read1 = aa.read_fasta(fp1)
+        aa.to_fasta(df_read1, file_path=fp2)
+        df_read2 = aa.read_fasta(fp2)
+        pd.testing.assert_frame_equal(
+            df_read1.sort_values("entry").reset_index(drop=True),
+            df_read2.sort_values("entry").reset_index(drop=True))
+
+    def test_missing_sequence_column_rejected(self, tmp_path):
+        # Composition failure: to_fasta needs a df_seq carrying a sequence column.
+        with pytest.raises(ValueError, match="sequence"):
+            aa.to_fasta(pd.DataFrame({"entry": ["a"]}), file_path=str(tmp_path / "x.fasta"))
+
+
+# ---------------------------------------------------------------------------
+# Seam 12: SequencePreprocessor encoders -> downstream consumer
+# ---------------------------------------------------------------------------
+class TestEncoderToConsumer:
+    """One-hot / integer encodings are well-formed matrices for downstream use."""
+
+    def test_one_hot_feeds_clustering(self):
+        seqs = aa.load_dataset(name="DOM_GSEC", n=6)["sequence"].str[:10].to_list()
+        X, features = aa.SequencePreprocessor.encode_one_hot(list_seq=seqs)
+        X = np.asarray(X)
+        assert X.shape == (len(seqs), 10 * len(ALPHABET))
+        assert len(features) == X.shape[1]
+        # The encoded matrix is a valid feature matrix for AAclust.
+        aac = aa.AAclust(verbose=False).fit(X, n_clusters=3)
+        assert len(np.unique(aac.labels_)) == 3
+
+    @settings(max_examples=5, deadline=None)
+    @given(win=some.integers(min_value=4, max_value=12))
+    def test_one_hot_width_invariant(self, win):
+        # Property: one-hot width is always (sequence length) x (alphabet size).
+        seqs = aa.load_dataset(name="DOM_GSEC", n=4)["sequence"].str[:win].to_list()
+        X, _ = aa.SequencePreprocessor.encode_one_hot(list_seq=seqs)
+        assert np.asarray(X).shape[1] == win * len(ALPHABET)
+
+    def test_ragged_sequences_padded_to_common_width(self):
+        # Composition contract: variable-length inputs are padded to one width.
+        X, _ = aa.SequencePreprocessor.encode_one_hot(list_seq=["ACDE", "ACDEFGHI", "AC"])
+        X = np.asarray(X)
+        assert X.shape == (3, 8 * len(ALPHABET))  # widest sequence (8) sets the width
+
+    def test_out_of_alphabet_char_rejected(self):
+        # Composition failure: a residue outside the alphabet must raise clearly.
+        with pytest.raises(ValueError, match="alphabet"):
+            aa.SequencePreprocessor.encode_one_hot(list_seq=["ACDZ"])

--- a/tests/integration/test_feature_pipeline.py
+++ b/tests/integration/test_feature_pipeline.py
@@ -1,0 +1,179 @@
+"""This is a script to test the feature-engineering seams (real components, no mocks).
+
+Integration tier (ADR-0031): each test wires two/three public classes together
+and asserts the *seam contract* holds — structural/range assertions, never
+frozen exact values (that is the regression anchor's job). Negatives here are
+**composition failures** (only visible when components meet), not re-runs of
+unit-level input validation. Properties are pipeline invariants / metamorphic
+checks with small ``max_examples``.
+
+Seams covered:
+  1. load_scales -> AAclust.fit -> reduced scales -> CPP.run
+  2. load_dataset -> SequenceFeature parts/splits -> CPP.run df_feat schema
+  3. CPP df_feat -> TreeModel.add_feat_importance -> CPPPlot.ranking
+  4. SequenceFeature.feature_matrix -> NumericalFeature.filter_correlation
+  5. CPPGrid.run -> per-config df_feat
+"""
+import numpy as np
+import pytest
+from hypothesis import given, settings
+import hypothesis.strategies as some
+
+import aaanalysis as aa
+from tests import _pipeline
+
+settings.register_profile("ci", deadline=None)
+settings.load_profile("ci")
+
+pytestmark = pytest.mark.integration
+
+# df_feat columns CPP.run emits that downstream consumers rely on.
+DF_FEAT_COLS = {"feature", "abs_auc", "mean_dif", "category"}
+
+
+# ---------------------------------------------------------------------------
+# Seam 1: load_scales -> AAclust -> reduced scales -> CPP
+# ---------------------------------------------------------------------------
+class TestAAclustScaleReductionToCPP:
+    """A clustered, reduced scale set still drives a CPP run."""
+
+    def test_reduced_scales_feed_cpp(self, pipeline):
+        df_scales = _pipeline.small_scales()
+        aac = aa.AAclust(verbose=False).fit(df_scales.T.values, n_clusters=5,
+                                            names=list(df_scales.T.index))
+        df_scales_red = df_scales[aac.medoid_names_]
+        df_feat = aa.CPP(df_parts=pipeline["df_parts"], df_scales=df_scales_red,
+                         verbose=False, random_state=0).run(labels=pipeline["labels"],
+                                                            n_filter=10, n_jobs=1)
+        assert len(df_feat) > 0
+        assert DF_FEAT_COLS.issubset(df_feat.columns)
+
+    @settings(max_examples=5, deadline=None)
+    @given(n_clusters=some.integers(min_value=2, max_value=8))
+    def test_reduced_count_at_most_input(self, n_clusters):
+        # Property: the reduced (medoid) scale set is never larger than the input.
+        df_scales = _pipeline.small_scales()
+        aac = aa.AAclust(verbose=False).fit(df_scales.T.values, n_clusters=n_clusters,
+                                            names=list(df_scales.T.index))
+        assert len(aac.medoid_names_) == n_clusters
+        assert len(aac.medoid_names_) <= df_scales.shape[1]
+
+    def test_single_cluster_scale_still_runs(self, pipeline):
+        # Composition edge: collapsing to one representative scale must not crash CPP.
+        df_scales = _pipeline.small_scales()
+        aac = aa.AAclust(verbose=False).fit(df_scales.T.values, n_clusters=1,
+                                            names=list(df_scales.T.index))
+        df_scales_red = df_scales[aac.medoid_names_]
+        df_feat = aa.CPP(df_parts=pipeline["df_parts"], df_scales=df_scales_red,
+                         verbose=False, random_state=0).run(labels=pipeline["labels"],
+                                                            n_filter=5, n_jobs=1)
+        assert len(df_feat) > 0
+
+
+# ---------------------------------------------------------------------------
+# Seam 2: load_dataset -> SequenceFeature -> CPP df_feat
+# ---------------------------------------------------------------------------
+class TestSequenceFeatureToCPP:
+    """The parts/splits a SequenceFeature emits drive CPP and yield the df_feat schema."""
+
+    def test_df_feat_schema(self, pipeline):
+        df_feat = pipeline["df_feat"]
+        assert DF_FEAT_COLS.issubset(df_feat.columns)
+        assert len(df_feat) == _pipeline.N_FILTER
+        # abs_auc is a discriminative magnitude in [0, 0.5].
+        assert df_feat["abs_auc"].between(0, 0.5).all()
+
+    def test_same_seed_same_df_feat(self, pipeline):
+        # Reproducibility property across the parts->CPP seam.
+        df_feat_a = _pipeline.build_df_feat(df_parts=pipeline["df_parts"],
+                                            labels=pipeline["labels"],
+                                            df_scales=pipeline["df_scales"])
+        df_feat_b = _pipeline.build_df_feat(df_parts=pipeline["df_parts"],
+                                            labels=pipeline["labels"],
+                                            df_scales=pipeline["df_scales"])
+        assert df_feat_a["feature"].to_list() == df_feat_b["feature"].to_list()
+
+    def test_row_permutation_same_feature_set(self, pipeline):
+        # Metamorphic: reordering samples must not change the SET of selected features.
+        df_parts = pipeline["df_parts"]
+        labels = np.asarray(pipeline["labels"])
+        perm = np.argsort(labels, kind="stable")[::-1]  # deterministic reordering
+        df_parts_perm = df_parts.iloc[perm].reset_index(drop=True)
+        labels_perm = labels[perm].tolist()
+        df_feat_perm = _pipeline.build_df_feat(df_parts=df_parts_perm, labels=labels_perm,
+                                               df_scales=pipeline["df_scales"])
+        assert set(df_feat_perm["feature"]) == set(pipeline["df_feat"]["feature"])
+
+    def test_single_class_labels_rejected(self, pipeline):
+        # Composition failure: CPP needs two groups to contrast; all-one-class must raise.
+        labels_one = [1] * len(pipeline["labels"])
+        with pytest.raises(ValueError):
+            aa.CPP(df_parts=pipeline["df_parts"], df_scales=pipeline["df_scales"],
+                   verbose=False).run(labels=labels_one, n_filter=5, n_jobs=1)
+
+
+# ---------------------------------------------------------------------------
+# Seam 3: CPP df_feat -> TreeModel.add_feat_importance -> CPPPlot.ranking
+# ---------------------------------------------------------------------------
+class TestCPPFeatImportanceToPlot:
+    """A TreeModel injects feat_importance into df_feat, which CPPPlot then renders."""
+
+    def test_ranking_consumes_importance_annotated_feat(self, pipeline):
+        tm = aa.TreeModel(verbose=False, random_state=0).fit(
+            pipeline["X"], labels=pipeline["labels"], use_rfe=False, n_cv=2, n_rounds=2)
+        df_feat = tm.add_feat_importance(df_feat=pipeline["df_feat"])
+        assert "feat_importance" in df_feat.columns
+        fig, ax = aa.CPPPlot().ranking(df_feat=df_feat, n_top=5)
+        assert fig is not None
+
+    def test_plot_rejects_feat_without_importance(self, pipeline):
+        # Composition failure: ranking needs the importance column the TreeModel adds.
+        with pytest.raises(ValueError, match="feat_importance"):
+            aa.CPPPlot().ranking(df_feat=pipeline["df_feat"], n_top=5)
+
+
+# ---------------------------------------------------------------------------
+# Seam 4: feature_matrix -> NumericalFeature.filter_correlation
+# ---------------------------------------------------------------------------
+class TestFeatureMatrixToNumericalFeature:
+    """The X that SequenceFeature builds is consumable by NumericalFeature's filters."""
+
+    def test_filter_correlation_mask_shape(self, pipeline):
+        mask = aa.NumericalFeature().filter_correlation(pipeline["X"], max_cor=0.7)
+        mask = np.asarray(mask)
+        assert mask.dtype == bool
+        assert mask.shape[0] == np.asarray(pipeline["X"]).shape[1]
+
+    @settings(max_examples=5, deadline=None)
+    @given(max_cor=some.floats(min_value=0.3, max_value=0.95))
+    def test_mask_length_invariant(self, pipeline, max_cor):
+        # Property: the boolean mask always aligns 1:1 with the feature axis of X.
+        X = pipeline["X"]
+        mask = np.asarray(aa.NumericalFeature().filter_correlation(X, max_cor=max_cor))
+        assert mask.shape[0] == np.asarray(X).shape[1]
+        assert mask.any()  # at least one feature survives
+
+
+# ---------------------------------------------------------------------------
+# Seam 5: CPPGrid.run -> per-config df_feat
+# ---------------------------------------------------------------------------
+class TestCPPGridSweep:
+    """CPPGrid runs the full parts->splits->scales->CPP pipeline per configuration."""
+
+    def test_grid_returns_one_feat_table_per_config(self, pipeline):
+        cppg = aa.CPPGrid(df_seq=pipeline["df_seq"], labels=pipeline["labels"],
+                          verbose=False, random_state=0, n_jobs=1)
+        list_df_feat, df_params = cppg.run(params_cpp=dict(n_filter=[10, 15]),
+                                           params_scales=_pipeline.small_scales())
+        assert len(list_df_feat) == len(df_params) == 2
+        for df_feat in list_df_feat:
+            assert df_feat is not None and DF_FEAT_COLS.issubset(df_feat.columns)
+
+    def test_n_filter_sweep_sizes(self, pipeline):
+        # The two swept n_filter values produce feature tables of the matching sizes.
+        cppg = aa.CPPGrid(df_seq=pipeline["df_seq"], labels=pipeline["labels"],
+                          verbose=False, random_state=0, n_jobs=1)
+        list_df_feat, _ = cppg.run(params_cpp=dict(n_filter=[8, 12]),
+                                   params_scales=_pipeline.small_scales())
+        sizes = sorted(len(df) for df in list_df_feat)
+        assert sizes == [8, 12]

--- a/tests/integration/test_feature_pipeline.py
+++ b/tests/integration/test_feature_pipeline.py
@@ -86,14 +86,18 @@ class TestSequenceFeatureToCPP:
         # abs_auc is a discriminative magnitude in [0, 0.5].
         assert df_feat["abs_auc"].between(0, 0.5).all()
 
-    def test_same_seed_same_df_feat(self, pipeline):
-        # Reproducibility property across the parts->CPP seam.
-        df_feat_a = _pipeline.build_df_feat(df_parts=pipeline["df_parts"],
-                                            labels=pipeline["labels"],
-                                            df_scales=pipeline["df_scales"])
-        df_feat_b = _pipeline.build_df_feat(df_parts=pipeline["df_parts"],
-                                            labels=pipeline["labels"],
-                                            df_scales=pipeline["df_scales"])
+    def test_same_seed_same_df_feat(self):
+        # Reproducibility across the parts->CPP seam, rebuilt independently each run
+        # (fresh df_parts, not the shared fixture) so this is a true reproduction,
+        # not merely CPP determinism on one object.
+        sf = aa.SequenceFeature()
+        df_seq = _pipeline.load_dom_gsec()
+        labels = df_seq["label"].to_list()
+        df_scales = _pipeline.small_scales()
+        df_feat_a = _pipeline.build_df_feat(df_parts=sf.get_df_parts(df_seq=df_seq),
+                                            labels=labels, df_scales=df_scales)
+        df_feat_b = _pipeline.build_df_feat(df_parts=sf.get_df_parts(df_seq=df_seq),
+                                            labels=labels, df_scales=df_scales)
         assert df_feat_a["feature"].to_list() == df_feat_b["feature"].to_list()
 
     def test_row_permutation_same_feature_set(self, pipeline):
@@ -199,9 +203,13 @@ class TestCPPGridSweep:
         # CPPGrid.eval scores each swept config and ranks them, index-aligned to the runs.
         cppg = aa.CPPGrid(df_seq=pipeline["df_seq"], labels=pipeline["labels"],
                           verbose=False, random_state=0, n_jobs=1)
-        cppg.run(params_cpp=dict(n_filter=[8, 12]), params_scales=_pipeline.small_scales())
+        df_scales_a = _pipeline.small_scales()
+        df_scales_b = df_scales_a.iloc[:, :10]
+        # A 4-config sweep gives the ranking enough points to be a real check.
+        cppg.run(params_cpp=dict(n_filter=[8, 12]), params_scales=[df_scales_a, df_scales_b])
         df_eval = cppg.eval()
         assert {"avg_ABS_AUC", "n_features"}.issubset(df_eval.columns)
+        assert len(df_eval) == 4
         assert df_eval["avg_ABS_AUC"].is_monotonic_decreasing  # best-first
         # The product-order index still maps each row back to its feature table.
         top_idx = df_eval.index[0]

--- a/tests/integration/test_feature_pipeline.py
+++ b/tests/integration/test_feature_pipeline.py
@@ -45,8 +45,11 @@ class TestAAclustScaleReductionToCPP:
         df_feat = aa.CPP(df_parts=pipeline["df_parts"], df_scales=df_scales_red,
                          verbose=False, random_state=0).run(labels=pipeline["labels"],
                                                             n_filter=10, n_jobs=1)
-        assert len(df_feat) > 0
+        assert len(df_feat) == 10
         assert DF_FEAT_COLS.issubset(df_feat.columns)
+        # Every feature must reference one of the 5 reduced (medoid) scales only.
+        used_scales = {f.split("-")[-1] for f in df_feat["feature"]}
+        assert used_scales.issubset(set(aac.medoid_names_))
 
     @settings(max_examples=5, deadline=None)
     @given(n_clusters=some.integers(min_value=2, max_value=8))
@@ -67,7 +70,7 @@ class TestAAclustScaleReductionToCPP:
         df_feat = aa.CPP(df_parts=pipeline["df_parts"], df_scales=df_scales_red,
                          verbose=False, random_state=0).run(labels=pipeline["labels"],
                                                             n_filter=5, n_jobs=1)
-        assert len(df_feat) > 0
+        assert len(df_feat) == 5
 
 
 # ---------------------------------------------------------------------------
@@ -107,7 +110,7 @@ class TestSequenceFeatureToCPP:
     def test_single_class_labels_rejected(self, pipeline):
         # Composition failure: CPP needs two groups to contrast; all-one-class must raise.
         labels_one = [1] * len(pipeline["labels"])
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="more than one different value"):
             aa.CPP(df_parts=pipeline["df_parts"], df_scales=pipeline["df_scales"],
                    verbose=False).run(labels=labels_one, n_filter=5, n_jobs=1)
 
@@ -124,7 +127,7 @@ class TestCPPFeatImportanceToPlot:
         df_feat = tm.add_feat_importance(df_feat=pipeline["df_feat"])
         assert "feat_importance" in df_feat.columns
         fig, ax = aa.CPPPlot().ranking(df_feat=df_feat, n_top=5)
-        assert fig is not None
+        assert len(fig.axes) >= 1  # the ranking actually rendered onto axes
 
     def test_plot_rejects_feat_without_importance(self, pipeline):
         # Composition failure: ranking needs the importance column the TreeModel adds.
@@ -166,6 +169,9 @@ class TestCPPGridSweep:
         list_df_feat, df_params = cppg.run(params_cpp=dict(n_filter=[10, 15]),
                                            params_scales=_pipeline.small_scales())
         assert len(list_df_feat) == len(df_params) == 2
+        # df_params records the swept axis, so a silently-ignored sweep would be caught.
+        assert "n_filter" in df_params.columns
+        assert sorted(df_params["n_filter"]) == [10, 15]
         for df_feat in list_df_feat:
             assert df_feat is not None and DF_FEAT_COLS.issubset(df_feat.columns)
 
@@ -177,3 +183,33 @@ class TestCPPGridSweep:
                                    params_scales=_pipeline.small_scales())
         sizes = sorted(len(df) for df in list_df_feat)
         assert sizes == [8, 12]
+
+    def test_multi_axis_sweep_is_cartesian(self, pipeline):
+        # Sweeping two axes (n_filter x scale-set) yields their Cartesian product.
+        cppg = aa.CPPGrid(df_seq=pipeline["df_seq"], labels=pipeline["labels"],
+                          verbose=False, random_state=0, n_jobs=1)
+        df_scales_a = _pipeline.small_scales()
+        df_scales_b = df_scales_a.iloc[:, :10]  # a distinct, smaller scale set
+        list_df_feat, df_params = cppg.run(params_cpp=dict(n_filter=[8, 12]),
+                                           params_scales=[df_scales_a, df_scales_b])
+        assert len(list_df_feat) == len(df_params) == 4  # 2 n_filter x 2 scale sets
+        assert all(df is not None for df in list_df_feat)
+
+    def test_eval_ranks_configs_best_first(self, pipeline):
+        # CPPGrid.eval scores each swept config and ranks them, index-aligned to the runs.
+        cppg = aa.CPPGrid(df_seq=pipeline["df_seq"], labels=pipeline["labels"],
+                          verbose=False, random_state=0, n_jobs=1)
+        cppg.run(params_cpp=dict(n_filter=[8, 12]), params_scales=_pipeline.small_scales())
+        df_eval = cppg.eval()
+        assert {"avg_ABS_AUC", "n_features"}.issubset(df_eval.columns)
+        assert df_eval["avg_ABS_AUC"].is_monotonic_decreasing  # best-first
+        # The product-order index still maps each row back to its feature table.
+        top_idx = df_eval.index[0]
+        assert cppg.list_df_feat_[top_idx] is not None
+
+    def test_eval_before_run_raises(self, pipeline):
+        # Composition failure: eval has nothing to score until run() has populated it.
+        cppg = aa.CPPGrid(df_seq=pipeline["df_seq"], labels=pipeline["labels"],
+                          verbose=False, random_state=0, n_jobs=1)
+        with pytest.raises(RuntimeError, match="requires a prior 'run'"):
+            cppg.eval()

--- a/tests/integration/test_prediction_pipeline.py
+++ b/tests/integration/test_prediction_pipeline.py
@@ -48,7 +48,8 @@ class TestFeaturesToTreeModel:
         tm = aa.TreeModel(verbose=False, random_state=0).fit(
             pipeline["X"], labels=pipeline["labels"], use_rfe=False, n_cv=2, n_rounds=2)
         assert len(tm.feat_importance) == np.asarray(pipeline["X"]).shape[1]
-        assert tm.list_models_ is not None
+        assert len(tm.is_selected_) == 2          # one selection mask per round
+        assert len(tm.list_models_) == 2          # one model bundle per round
 
     def test_eval_metrics_in_range(self, pipeline):
         tm = aa.TreeModel(verbose=False, random_state=0).fit(
@@ -67,11 +68,12 @@ class TestFeaturesToTreeModel:
         tm_b = aa.TreeModel(verbose=False, random_state=0).fit(
             pipeline["X"], labels=pipeline["labels"], **kws)
         assert np.allclose(tm_a.feat_importance, tm_b.feat_importance)
+        assert np.array_equal(np.asarray(tm_a.is_selected_), np.asarray(tm_b.is_selected_))
 
     def test_label_length_mismatch_rejected(self, pipeline):
         # Composition failure: X rows and labels must align across the seam.
         labels_short = pipeline["labels"][:-1]
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="should contain"):
             aa.TreeModel(verbose=False, random_state=0).fit(
                 pipeline["X"], labels=labels_short, use_rfe=False, n_cv=2, n_rounds=2)
 
@@ -100,7 +102,7 @@ class TestPUToDPULearn:
 
     def test_standard_01_labels_rejected(self, pipeline):
         # Composition failure: dPULearn expects PU encoding {1, 2}, not {0, 1}.
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="does not contain required values"):
             aa.dPULearn(verbose=False, random_state=0).fit(
                 X=pipeline["X"], labels=pipeline["labels"], n_unl_to_neg=2)
 

--- a/tests/integration/test_prediction_pipeline.py
+++ b/tests/integration/test_prediction_pipeline.py
@@ -1,0 +1,134 @@
+"""This is a script to test the prediction seams (real components, no mocks).
+
+Integration tier (ADR-0031). Negatives are composition failures, properties are
+pipeline invariants / reproducibility.
+
+Seams covered:
+  6. CPP df_feat -> feature_matrix -> TreeModel.fit / .eval
+  7. load_dataset (PU) -> dPULearn.fit -> carved labels (0)
+  8. dPULearn carved labels -> TreeModel.fit
+"""
+import numpy as np
+import pytest
+from hypothesis import given, settings
+import hypothesis.strategies as some
+
+import aaanalysis as aa
+from tests import _pipeline
+
+settings.register_profile("ci", deadline=None)
+settings.load_profile("ci")
+
+pytestmark = pytest.mark.integration
+
+
+def _pu_feature_matrix(n=12, n_filter=15):
+    """Build (X, labels) for the PU dataset, reusing the DOM_GSEC feature set.
+
+    DOM_GSEC_PU is labelled 1 (positive) / 2 (unlabeled). We engineer features on
+    the labelled DOM_GSEC split, then project the PU sequences onto the same
+    feature set so the matrices are comparable.
+    """
+    base = _pipeline.build_pipeline(n=10, n_filter=n_filter)
+    df_seq_pu = aa.load_dataset(name="DOM_GSEC_PU", n=n)
+    labels_pu = df_seq_pu["label"].to_list()
+    df_parts_pu = aa.SequenceFeature().get_df_parts(df_seq=df_seq_pu)
+    X_pu = _pipeline.feature_matrix(df_feat=base["df_feat"], df_parts=df_parts_pu,
+                                    df_scales=base["df_scales"])
+    return np.asarray(X_pu), labels_pu
+
+
+# ---------------------------------------------------------------------------
+# Seam 6: CPP df_feat -> feature_matrix -> TreeModel
+# ---------------------------------------------------------------------------
+class TestFeaturesToTreeModel:
+    """The CPP feature matrix trains and evaluates a TreeModel."""
+
+    def test_fit_sets_importance_over_features(self, pipeline):
+        tm = aa.TreeModel(verbose=False, random_state=0).fit(
+            pipeline["X"], labels=pipeline["labels"], use_rfe=False, n_cv=2, n_rounds=2)
+        assert len(tm.feat_importance) == np.asarray(pipeline["X"]).shape[1]
+        assert tm.list_models_ is not None
+
+    def test_eval_metrics_in_range(self, pipeline):
+        tm = aa.TreeModel(verbose=False, random_state=0).fit(
+            pipeline["X"], labels=pipeline["labels"], use_rfe=False, n_cv=2, n_rounds=2)
+        df_eval = tm.eval(pipeline["X"], labels=pipeline["labels"],
+                          list_is_selected=[tm.is_selected_], n_cv=2,
+                          list_metrics=["accuracy", "f1"])
+        num = df_eval.select_dtypes("number")
+        assert ((num.values >= -1e-9) & (num.values <= 1 + 1e-9)).all()
+
+    def test_same_seed_same_importance(self, pipeline):
+        # Reproducibility property over the feature-matrix -> model seam.
+        kws = dict(use_rfe=False, n_cv=2, n_rounds=2)
+        tm_a = aa.TreeModel(verbose=False, random_state=0).fit(
+            pipeline["X"], labels=pipeline["labels"], **kws)
+        tm_b = aa.TreeModel(verbose=False, random_state=0).fit(
+            pipeline["X"], labels=pipeline["labels"], **kws)
+        assert np.allclose(tm_a.feat_importance, tm_b.feat_importance)
+
+    def test_label_length_mismatch_rejected(self, pipeline):
+        # Composition failure: X rows and labels must align across the seam.
+        labels_short = pipeline["labels"][:-1]
+        with pytest.raises(ValueError):
+            aa.TreeModel(verbose=False, random_state=0).fit(
+                pipeline["X"], labels=labels_short, use_rfe=False, n_cv=2, n_rounds=2)
+
+
+# ---------------------------------------------------------------------------
+# Seam 7: load_dataset (PU) -> dPULearn.fit -> carved labels
+# ---------------------------------------------------------------------------
+class TestPUToDPULearn:
+    """dPULearn carves reliable negatives (0) from the PU feature matrix."""
+
+    def test_carves_negatives(self):
+        X_pu, labels_pu = _pu_feature_matrix()
+        dpul = aa.dPULearn(verbose=False, random_state=0).fit(
+            X=X_pu, labels=labels_pu, n_unl_to_neg=3)
+        out = np.asarray(dpul.labels_)
+        assert out.shape[0] == X_pu.shape[0]
+        assert (out == 0).sum() == 3           # exactly the requested negatives
+        assert set(np.unique(out)).issubset({0, 1, 2})
+
+    def test_same_seed_same_carve(self):
+        # Reproducibility property of the PU carve.
+        X_pu, labels_pu = _pu_feature_matrix()
+        a = aa.dPULearn(verbose=False, random_state=0).fit(X=X_pu, labels=labels_pu, n_unl_to_neg=3)
+        b = aa.dPULearn(verbose=False, random_state=0).fit(X=X_pu, labels=labels_pu, n_unl_to_neg=3)
+        assert np.array_equal(np.asarray(a.labels_), np.asarray(b.labels_))
+
+    def test_standard_01_labels_rejected(self, pipeline):
+        # Composition failure: dPULearn expects PU encoding {1, 2}, not {0, 1}.
+        with pytest.raises(ValueError):
+            aa.dPULearn(verbose=False, random_state=0).fit(
+                X=pipeline["X"], labels=pipeline["labels"], n_unl_to_neg=2)
+
+
+# ---------------------------------------------------------------------------
+# Seam 8: dPULearn carved labels -> TreeModel
+# ---------------------------------------------------------------------------
+class TestDPULearnToTreeModel:
+    """The negatives dPULearn identifies become a trainable {0, 1} set for TreeModel."""
+
+    def test_carved_labels_train_a_model(self):
+        X_pu, labels_pu = _pu_feature_matrix(n=20, n_filter=15)
+        dpul = aa.dPULearn(verbose=False, random_state=0).fit(
+            X=X_pu, labels=labels_pu, n_unl_to_neg=8)
+        carved = np.asarray(dpul.labels_)
+        # Keep only the resolved {positive=1, reliable-negative=0} samples.
+        keep = carved != 2
+        X_train, y_train = np.asarray(X_pu)[keep], carved[keep]
+        assert set(np.unique(y_train)) == {0, 1}
+        tm = aa.TreeModel(verbose=False, random_state=0).fit(
+            X_train, labels=y_train.tolist(), use_rfe=False, n_cv=2, n_rounds=2)
+        assert len(tm.feat_importance) == X_train.shape[1]
+
+    @settings(max_examples=3, deadline=None)
+    @given(n_unl_to_neg=some.integers(min_value=2, max_value=6))
+    def test_carve_count_matches_request(self, n_unl_to_neg):
+        # Property: the carve produces exactly n_unl_to_neg negatives, feeding a {0,1} set.
+        X_pu, labels_pu = _pu_feature_matrix(n=20, n_filter=15)
+        dpul = aa.dPULearn(verbose=False, random_state=0).fit(
+            X=X_pu, labels=labels_pu, n_unl_to_neg=n_unl_to_neg)
+        assert (np.asarray(dpul.labels_) == 0).sum() == n_unl_to_neg

--- a/tests/integration/test_seq_pipeline.py
+++ b/tests/integration/test_seq_pipeline.py
@@ -41,12 +41,17 @@ class TestSamplerToLogo:
     @settings(max_examples=4, deadline=None)
     @given(window_size=some.integers(min_value=5, max_value=12))
     def test_logo_rows_equal_window_length(self, window_size):
-        # Property: the logo position axis always matches the sampled window length.
+        # Property across the seam: the sampler emits window_size-length windows
+        # AND the logo's position axis reflects that actual length.
         df_seq = aa.load_dataset(name="DOM_GSEC", n=10)
         df_win = aa.AAWindowSampler(random_state=0).sample_synthetic(
             df_seq=df_seq, n=6, window_size=window_size, generator="global_freq", seed=0)
+        # The sampler's real contract — every window is exactly window_size residues.
+        assert (df_win["window"].str.len() == window_size).all()
         df_parts = pd.DataFrame({"tmd": df_win["window"].to_list()})
-        df_logo = aa.AAlogo().get_df_logo(df_parts=df_parts, tmd_len=window_size)
+        # tmd_len omitted: the logo INFERS length from the windows, so the row count
+        # reflects the actual sampled length rather than a forced tmd_len.
+        df_logo = aa.AAlogo().get_df_logo(df_parts=df_parts)
         assert df_logo.shape[0] == window_size
 
     def test_absent_label_empties_logo(self):

--- a/tests/integration/test_seq_pipeline.py
+++ b/tests/integration/test_seq_pipeline.py
@@ -1,0 +1,115 @@
+"""This is a script to test the sequence-analysis / protein-design seams.
+
+Integration tier (ADR-0031). Real components, no mocks.
+
+Seams covered:
+  9.  AAWindowSampler.sample_* windows -> AAlogo logo matrix
+  10. SeqMut.mutate -> re-featurize via SequenceFeature (design loop closes);
+      and SeqMut.mutate(df_feat=...) -> ΔCPP against a real CPP feature set
+"""
+import numpy as np
+import pandas as pd
+import pytest
+from hypothesis import given, settings
+import hypothesis.strategies as some
+
+import aaanalysis as aa
+from tests import _pipeline
+
+settings.register_profile("ci", deadline=None)
+settings.load_profile("ci")
+
+pytestmark = pytest.mark.integration
+
+POS_COLS = ["entry", "sequence", "tmd_start", "tmd_stop", "label"]
+
+
+# ---------------------------------------------------------------------------
+# Seam 9: AAWindowSampler -> AAlogo
+# ---------------------------------------------------------------------------
+class TestSamplerToLogo:
+    """Sampled fixed-length windows drive an AAlogo composition matrix."""
+
+    def test_windows_feed_logo(self):
+        df_seq = aa.load_dataset(name="DOM_GSEC", n=10)
+        df_win = aa.AAWindowSampler(random_state=0).sample_synthetic(
+            df_seq=df_seq, n=8, window_size=9, generator="global_freq", seed=0)
+        df_parts = pd.DataFrame({"tmd": df_win["window"].to_list()})
+        df_logo = aa.AAlogo(logo_type="probability").get_df_logo(df_parts=df_parts, tmd_len=9)
+        assert df_logo.shape[0] == 9  # one row per window position
+
+    @settings(max_examples=4, deadline=None)
+    @given(window_size=some.integers(min_value=5, max_value=12))
+    def test_logo_rows_equal_window_length(self, window_size):
+        # Property: the logo position axis always matches the sampled window length.
+        df_seq = aa.load_dataset(name="DOM_GSEC", n=10)
+        df_win = aa.AAWindowSampler(random_state=0).sample_synthetic(
+            df_seq=df_seq, n=6, window_size=window_size, generator="global_freq", seed=0)
+        df_parts = pd.DataFrame({"tmd": df_win["window"].to_list()})
+        df_logo = aa.AAlogo().get_df_logo(df_parts=df_parts, tmd_len=window_size)
+        assert df_logo.shape[0] == window_size
+
+    def test_absent_label_empties_logo(self):
+        # Composition failure: window rows carry a label; selecting a label_test
+        # absent from the pool empties the set, and the logo step must say so.
+        df_seq = aa.load_dataset(name="DOM_GSEC", n=10)
+        df_win = aa.AAWindowSampler(random_state=0).sample_synthetic(
+            df_seq=df_seq, n=6, window_size=9, generator="global_freq", seed=0)
+        df_parts = pd.DataFrame({"tmd": df_win["window"].to_list()})
+        # Two distinct labels (0/2) so the homogeneity guard passes; neither is the
+        # requested label_test=1, so the post-filter pool is empty.
+        labels = np.array([0, 0, 0, 2, 2, 2])
+        with pytest.raises(ValueError, match="label_test"):
+            aa.AAlogo().get_df_logo(df_parts=df_parts, labels=labels, label_test=1, tmd_len=9)
+
+
+# ---------------------------------------------------------------------------
+# Seam 10: SeqMut.mutate -> re-featurize via SequenceFeature
+# ---------------------------------------------------------------------------
+class TestMutationToFeatures:
+    """A mutated sequence flows back through SequenceFeature (and CPP ΔCPP)."""
+
+    @staticmethod
+    def _df_seq():
+        return aa.load_dataset(name="DOM_GSEC", n=5)[POS_COLS].copy()
+
+    def test_refeaturize_mutated_sequence(self):
+        df_seq = self._df_seq()
+        row = df_seq.iloc[0]
+        muts = pd.DataFrame({"entry": [row["entry"]],
+                             "pos": [int(row["tmd_start"]) + 1], "to_aa": ["A"]})
+        df_mut = aa.SeqMut(verbose=False).mutate(df_seq=df_seq, mutations=muts)
+        df_seq_mut = df_seq.copy()
+        df_seq_mut.loc[df_seq_mut["entry"] == row["entry"], "sequence"] = df_mut["sequence_mut"].iloc[0]
+        dp_orig = aa.SequenceFeature().get_df_parts(df_seq=df_seq)
+        dp_mut = aa.SequenceFeature().get_df_parts(df_seq=df_seq_mut)
+        assert dp_orig.shape == dp_mut.shape                       # same matrix shape
+        assert (dp_orig["tmd"] != dp_mut["tmd"]).sum() == 1        # exactly one protein changed
+
+    def test_point_mutation_preserves_length(self):
+        # Metamorphic: a single substitution must not change sequence length.
+        df_seq = self._df_seq()
+        row = df_seq.iloc[0]
+        muts = pd.DataFrame({"entry": [row["entry"]],
+                             "pos": [int(row["tmd_start"]) + 1], "to_aa": ["A"]})
+        df_mut = aa.SeqMut(verbose=False).mutate(df_seq=df_seq, mutations=muts)
+        assert len(df_mut["sequence_mut"].iloc[0]) == len(row["sequence"])
+
+    def test_delta_cpp_against_real_feat_set(self):
+        # Closes the design loop: mutate scored against a real CPP feature set.
+        base = _pipeline.build_pipeline(n=5, n_filter=15)
+        df_seq = aa.load_dataset(name="DOM_GSEC", n=5)[POS_COLS].copy()
+        row = df_seq.iloc[0]
+        muts = pd.DataFrame({"entry": [row["entry"]],
+                             "pos": [int(row["tmd_start"]) + 1], "to_aa": ["A"]})
+        df_mut = aa.SeqMut(verbose=False).mutate(df_seq=df_seq, mutations=muts,
+                                                 df_feat=base["df_feat"])
+        assert "delta_cpp" in df_mut.columns
+        assert np.isfinite(df_mut["delta_cpp"]).all()
+
+    def test_mutation_unknown_entry_rejected(self):
+        # Composition failure: the mutations table must reference df_seq entries.
+        df_seq = self._df_seq()
+        muts = pd.DataFrame({"entry": ["NOT_AN_ENTRY"], "pos": [5], "to_aa": ["A"]})
+        with pytest.raises(ValueError):
+            aa.SeqMut(verbose=False).mutate(df_seq=df_seq, mutations=muts)

--- a/tests/integration/test_seq_pipeline.py
+++ b/tests/integration/test_seq_pipeline.py
@@ -111,5 +111,5 @@ class TestMutationToFeatures:
         # Composition failure: the mutations table must reference df_seq entries.
         df_seq = self._df_seq()
         muts = pd.DataFrame({"entry": ["NOT_AN_ENTRY"], "pos": [5], "to_aa": ["A"]})
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"is not in 'df_seq'"):
             aa.SeqMut(verbose=False).mutate(df_seq=df_seq, mutations=muts)

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -19,3 +19,5 @@ markers =
     regression: frozen exact-value CPP anchor; pinned to the canonical cell (Linux/py3.11) and skipped elsewhere (ADR-0015).
     slow: opt-in heavy test; deselect with -m "not slow" in fast CI runs.
     network: hits a live external endpoint (AlphaFold/UniProt/HF); deselected by default with -m "not network", run on demand / in the nightly to catch upstream API breakage.
+    integration: cross-component seam test (two/three real classes, no mocks). Default-selected, so it gates merges. See ADR-0031.
+    e2e: full user-facing pipeline mirroring a protocol notebook, tiny+seeded. Default-selected, so it gates merges. See ADR-0031.

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -19,5 +19,5 @@ markers =
     regression: frozen exact-value CPP anchor; pinned to the canonical cell (Linux/py3.11) and skipped elsewhere (ADR-0015).
     slow: opt-in heavy test; deselect with -m "not slow" in fast CI runs.
     network: hits a live external endpoint (AlphaFold/UniProt/HF); deselected by default with -m "not network", run on demand / in the nightly to catch upstream API breakage.
-    integration: cross-component seam test (two/three real classes, no mocks). Default-selected, so it gates merges. See ADR-0031.
-    e2e: full user-facing pipeline mirroring a protocol notebook, tiny+seeded. Default-selected, so it gates merges. See ADR-0031.
+    integration: cross-component seam test (two/three real classes, no mocks). Runs in the dedicated 'Integration & E2E Tests' workflow (excluded from the Unit Tests matrix). See ADR-0031.
+    e2e: full user-facing pipeline mirroring a protocol notebook, tiny+seeded. Runs in the dedicated 'Integration & E2E Tests' workflow (excluded from the Unit Tests matrix). See ADR-0031.


### PR DESCRIPTION
## Summary

Stands up the long-deferred `tests/integration/` and `tests/e2e/` tiers with **53 assertion-bearing, cross-component tests that gate merges**. Until now the only multi-component check was the nightly-only CPP regression anchor (ADR-0015) and the `network`-marked AlphaFold contract; the `protocols/*.ipynb` notebooks run end to end but assert nothing and are not in CI (nbmake is a local-only gate).

Completes the **"Start integration and e2e tests"** checkbox on #41.

## What's added

**Integration — 36 tests over 12 component seams** (real components, no mocks):
- `test_feature_pipeline.py` — AAclust→reduced scales→CPP; SequenceFeature→CPP df_feat; CPP→TreeModel→CPPPlot; feature_matrix→NumericalFeature; CPPGrid sweep
- `test_prediction_pipeline.py` — CPP→feature_matrix→TreeModel (fit/eval); PU→dPULearn carve; dPULearn→TreeModel
- `test_seq_pipeline.py` — AAWindowSampler→AAlogo; SeqMut.mutate→re-featurize (+ΔCPP)
- `test_data_pipeline.py` — to_fasta↔read_fasta round-trip; SequencePreprocessor encoders→consumer

**E2e — 17 tests**, one assertion-bearing analogue per `protocol1`–`10` notebook, plus reproducibility properties and degenerate-dataset negatives.

**Policy + docs (the meta-decision):**
- New `integration` / `e2e` markers in `tests/pytest.ini`, **default-selected** so they run in the blocking `-m "not regression"` job.
- `testing.md` gains the per-tier taxonomy table; `sharp-edges.md` drops the "deferred to v2" bullet.
- **ADR-0031** records the rationale: count is bounded by *seams × workflows* (not unit-test volume); higher-tier negatives are **composition failures only** (not re-run input validation); hypothesis here is **invariants/metamorphic + reproducibility** with small `max_examples`; **structural/range assertions, never frozen exact values** (that stays the regression anchor's job).

Shared seeded spine lives in `tests/_pipeline.py` (one definition of the load→parts→CPP→matrix pipeline), exposed to integration as session fixtures and imported directly by e2e.

## Test plan / local gates

- `pytest tests/integration tests/e2e -n auto -c tests/pytest.ini` → **53 passed, 3 skipped** (network)
- `pytest tests -m "not regression" -n auto -c tests/pytest.ini` → **4259 passed, 10 skipped** (full blocking suite, new tests included)
- `pytest tests/unit/api_tests/test_param_coverage.py` → green; markers collect with no unknown-marker warnings
- `flake8 --select=E9,F63,F7,F82` on new files → clean
- Core-only (no `pro`/`embed`/`network` deps); tiny, seeded inputs.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)