### PR TITLE
perf: vectorize encode_one_hot (same output)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,8 @@ and a suite of site-localization metrics and plotting helpers.
   Kullback-Leibler divergence used by `dPULearn.eval(comp_kld=True)`
   (parallelized, honors `options['n_jobs']`). Plus `AAWindowSampler`
   candidate-center band filtering (~40x) and `sample_motif_matched` PWM scoring
-  (~12x), vectorized with identical output.
+  (~12x), and `SequencePreprocessor.encode_one_hot` (~3x), vectorized with
+  identical output.
 
 ### Deprecated
 - None. The strict-semver deprecation policy and the `deprecated` decorator are

--- a/aaanalysis/data_handling/_backend/seq_preproc/encode_one_hot.py
+++ b/aaanalysis/data_handling/_backend/seq_preproc/encode_one_hot.py
@@ -9,16 +9,6 @@ from ._utils import pad_sequences
 
 
 # I Helper Functions
-def _one_hot_encode(amino_acid=None, alphabet=None, gap="_"):
-    """
-    Encodes a single amino acid into a one-hot vector based on a specified alphabet.
-    Returns a zero vector for gaps represented as '_'.
-    """
-    dict_aa_index = {aa: i for i, aa in enumerate(alphabet)}
-    vector = np.zeros(len(alphabet), dtype=int)
-    if amino_acid != gap:
-        vector[dict_aa_index[amino_acid]] = 1
-    return vector
 
 
 # II Main Functions
@@ -32,12 +22,20 @@ def encode_one_hot(list_seq=None, alphabet="ACDEFGHIKLMNPQRSTVWY", gap="-", pad_
     # Create feature names
     max_length = len(padded_sequences[0])
     list_features = [f"{i}{aa}" for i in range(1, max_length+1) for aa in alphabet]
-    # Create one-hot-encoding
+    # One-hot-encoding (vectorized; identical output to the per-residue form). A gap — which
+    # the frontend guarantees is not in the alphabet — maps to index -1 and yields an all-zero
+    # block; every other residue sets a single 1 at its alphabet index. Column order is
+    # position-major then alphabet, matching ``list_features`` and the original flatten.
     num_amino_acids = len(alphabet)
-    feature_matrix = np.zeros((len(padded_sequences), max_length * num_amino_acids), dtype=int)
-    args = dict(alphabet=alphabet, gap=gap)
-    for idx, seq in enumerate(padded_sequences):
-        encoded_seq = [_one_hot_encode(amino_acid=aa, **args) for aa in seq]
-        feature_matrix[idx, :] = np.array(encoded_seq).flatten()
+    n_seq = len(padded_sequences)
+    char_matrix = np.array([list(seq) for seq in padded_sequences])
+    aa_to_index = {aa: i for i, aa in enumerate(alphabet)}
+    index_matrix = np.full(char_matrix.shape, -1, dtype=int)
+    for aa, i in aa_to_index.items():
+        index_matrix[char_matrix == aa] = i
+    one_hot = np.zeros((n_seq, max_length, num_amino_acids), dtype=int)
+    valid = index_matrix >= 0
+    rows, positions = np.nonzero(valid)
+    one_hot[rows, positions, index_matrix[valid]] = 1
+    feature_matrix = one_hot.reshape(n_seq, max_length * num_amino_acids)
     return feature_matrix, list_features
-

--- a/docs/source/index/release_notes.rst
+++ b/docs/source/index/release_notes.rst
@@ -192,6 +192,8 @@ Changed
   A further pass vectorizes ``AAWindowSampler`` window-sampling internals:
   candidate-center band filtering (~40x faster at scale) and per-window PWM
   scoring in ``sample_motif_matched`` (~12x), again with identical results.
+  ``SequencePreprocessor.encode_one_hot`` is also vectorized (~3x), with a
+  byte-identical feature matrix.
 
 
 Version 1.0 (Stable Version)

--- a/tests/unit/data_handling_tests/test_sp_encode_one_hot.py
+++ b/tests/unit/data_handling_tests/test_sp_encode_one_hot.py
@@ -116,6 +116,42 @@ class TestEncodeOneHotComplex:
         assert isinstance(result[0], np.ndarray)
         assert isinstance(result[1], list)
 
+
+def _ref_one_hot(list_seq, alphabet="ACDEFGHIKLMNPQRSTVWY", gap="-", pad_at="C"):
+    """Reference (per-residue) one-hot encoder used to pin the vectorized output."""
+    from aaanalysis.data_handling._backend.seq_preproc._utils import pad_sequences
+    padded = pad_sequences(list_seq, pad_at=pad_at, gap=gap)
+    max_length, num = len(padded[0]), len(alphabet)
+    feats = [f"{i}{aa}" for i in range(1, max_length + 1) for aa in alphabet]
+    fm = np.zeros((len(padded), max_length * num), dtype=int)
+    d = {a: i for i, a in enumerate(alphabet)}
+    for r, seq in enumerate(padded):
+        rows = []
+        for aa_ in seq:
+            v = np.zeros(num, dtype=int)
+            if aa_ != gap:
+                v[d[aa_]] = 1
+            rows.append(v)
+        fm[r, :] = np.array(rows).flatten()
+    return fm, feats
+
+
+class TestEncodeOneHotEquivalence:
+    """The vectorized encoder must return output identical to the per-residue reference."""
+
+    @pytest.mark.parametrize("pad_at", ["C", "N"])
+    @pytest.mark.parametrize("seed", [0, 1, 2, 7])
+    def test_matches_reference(self, pad_at, seed):
+        rng = np.random.default_rng(seed)
+        aas = "ACDEFGHIKLMNPQRSTVWY"
+        seqs = ["".join(rng.choice(list(aas), int(rng.integers(5, 40)))) for _ in range(60)]
+        sp = aa.SequencePreprocessor()
+        fm, feats = sp.encode_one_hot(list_seq=seqs, pad_at=pad_at)
+        ref_fm, ref_feats = _ref_one_hot(seqs, pad_at=pad_at)
+        assert feats == ref_feats
+        assert fm.dtype == ref_fm.dtype
+        assert np.array_equal(fm, ref_fm)
+
     @settings(max_examples=10, deadline=None)
     @given(
         list_seq=st.none(),


### PR DESCRIPTION
## Summary

Finishes Batch 3: vectorizes `SequencePreprocessor.encode_one_hot`. The per-residue loop (which rebuilt the alphabet→index dict for *every* residue, then built a list of arrays and flattened per sequence) is replaced with a char-matrix → index-matrix → scatter. **Byte-identical output**, ~3x faster.

- Same `int64` dtype, same position-major-then-alphabet column order (matches `list_features` and the original flatten), gaps → all-zero blocks.
- The frontend (`check_match_list_seq_alphabet`) already guarantees every residue is in `alphabet + gap`, so the original's `KeyError`-on-unknown path is unreachable — vectorizing changes nothing observable.
- Verified identical (matrix + features + dtype) across `pad_at` C/N and custom alphabets.

`encode_integer` was benchmarked too (0.009s / 5000 seqs — already fast, not a hot path) and **left unchanged** to avoid a no-op change.

Equivalence test added (`TestEncodeOneHotEquivalence`) pinning the output to a per-residue reference. Full fast unit suite green (4243 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)