### PR TITLE
perf: cache encode_pdb per-(target,atom) alignment (same output) — #180 Part A

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,9 @@ and a suite of site-localization metrics and plotting helpers.
   candidate-center band filtering (~40x) and `sample_motif_matched` PWM scoring
   (~12x), and `SequencePreprocessor.encode_one_hot` (~3x), vectorized with
   identical output. Plus `StructurePreprocessor.encode_pdb` CA-CA contact counts
-  (`contact_count_8A`/`12A`) vectorized (~50x, identical counts).
+  (`contact_count_8A`/`12A`) vectorized (~50x, identical counts) and its
+  per-(target, atom) sequence alignment cached across the ~26 redundant
+  re-alignments each entry triggers (~12x off the alignment overhead, byte-identical encoder output).
 - `dPULearn.fit` gains flexible, package-consistent label handling via
   `label_pos` / `label_unl` / `label_neg` markers: pass standard `{0, 1}` labels
   directly with `label_unl=0`, or an arbitrary positive/unlabeled/negative

--- a/aaanalysis/data_handling_pro/_backend/struct_preproc/encode_pdb.py
+++ b/aaanalysis/data_handling_pro/_backend/struct_preproc/encode_pdb.py
@@ -5,6 +5,7 @@ and from biopython's surface tools (``Bio.PDB.ResidueDepth``, which needs
 the external ``msms`` binary). The frontend ``encode_pdb`` validates inputs,
 opens the PDB once per entry, then dispatches by feature key.
 """
+from functools import lru_cache
 from typing import List, Optional, Tuple
 
 import numpy as np
@@ -48,11 +49,25 @@ def _make_aligner():
     return aligner
 
 
-def _identity_fraction(target_seq: str, atom_seq: str, aligner) -> float:
+@lru_cache(maxsize=128)
+def _alignment_strings(target_seq: str, atom_seq: str) -> Tuple[str, str]:
+    """Global-aligned ``(target, atom)`` string pair for two sequences.
+
+    The alignment depends only on the two sequences, so within one ``encode_pdb``
+    entry every encoder that aligns the same ``target`` against the same ``atom``
+    sequence (chain pick + each per-feature value mapping) reuses one computation
+    instead of re-running the O(L^2) aligner ~26x. ``aligner.align(...)[0]`` is the
+    deterministic first optimal alignment, so the cached result is identical to
+    recomputing it."""
+    aligner = _make_aligner()
+    alignment = aligner.align(target_seq, atom_seq)[0]
+    return str(alignment[0]), str(alignment[1])
+
+
+def _identity_fraction(target_seq: str, atom_seq: str) -> float:
     if not target_seq or not atom_seq:
         return 0.0
-    alignment = aligner.align(target_seq, atom_seq)[0]
-    a, b = str(alignment[0]), str(alignment[1])
+    a, b = _alignment_strings(target_seq, atom_seq)
     return sum(1 for x, y in zip(a, b)
                if x == y and x != "-") / len(target_seq)
 
@@ -60,13 +75,12 @@ def _identity_fraction(target_seq: str, atom_seq: str, aligner) -> float:
 def _pick_best_chain_records(target_seq: str, chains):
     """Return (chain, residues, identity) for the chain best matching target."""
     from Bio.PDB.Polypeptide import protein_letters_3to1
-    aligner = _make_aligner()
     best = None
     best_score = -1.0
     for chain, residues in chains:
         atom_seq = "".join(
             _residue_one_letter(r, protein_letters_3to1) for r, _ in residues)
-        score = _identity_fraction(target_seq, atom_seq, aligner)
+        score = _identity_fraction(target_seq, atom_seq)
         if score > best_score:
             best_score = score
             best = (chain, residues, atom_seq)
@@ -80,9 +94,7 @@ def _align_atom_values_to_target(target_seq: str,
                                  atom_seq: str,
                                  atom_values: List[float]) -> List[float]:
     """Map per-ATOM-residue floats onto target positions; gaps -> NaN."""
-    aligner = _make_aligner()
-    alignment = aligner.align(target_seq, atom_seq)[0]
-    a_aln, b_aln = str(alignment[0]), str(alignment[1])
+    a_aln, b_aln = _alignment_strings(target_seq, atom_seq)
     out: List[float] = []
     atom_idx = 0
     for ta, ab in zip(a_aln, b_aln):

--- a/docs/source/index/release_notes.rst
+++ b/docs/source/index/release_notes.rst
@@ -196,6 +196,11 @@ Changed
   byte-identical feature matrix. And ``StructurePreprocessor.encode_pdb`` CA-CA
   contact counts (``contact_count_8A`` / ``contact_count_12A``) use a vectorized
   per-residue distance computation (~50x at scale) with byte-identical counts.
+  ``encode_pdb`` additionally caches the per-(target, atom) global sequence
+  alignment that its encoders otherwise re-run ~26 times per entry (chain pick
+  plus each per-feature value mapping); the first optimal alignment is
+  deterministic, so cached and recomputed encoder output are byte-identical
+  (~12x off the repeated-alignment overhead).
 - **dPULearn.fit**: Flexible, package-consistent label handling via ``label_pos`` /
   ``label_unl`` / ``label_neg`` markers. Pass standard ``{0, 1}`` labels directly with
   ``label_unl=0`` (``0`` = unlabeled, ``1`` = positive), or any positive / unlabeled /

--- a/tests/unit/data_handling_pro_tests/test_struct_alignment_cache_equiv.py
+++ b/tests/unit/data_handling_pro_tests/test_struct_alignment_cache_equiv.py
@@ -1,0 +1,108 @@
+"""Equivalence test for the encode_pdb alignment cache: every encoder must
+produce byte-identical output whether the per-(target, atom) global alignment
+is recomputed each call (the original behaviour) or served from the shared
+``lru_cache``. The cache keys only on the two sequences and stores
+``aligner.align(...)[0]`` (the deterministic first optimal alignment), so a
+primed cache must never change a single value."""
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import aaanalysis as aa
+from aaanalysis.data_handling_pro._backend.struct_preproc import encode_pdb as ep
+from aaanalysis.data_handling_pro._backend.struct_preproc.encode_pdb import (
+    load_structure, _ca_coords_and_residues)
+
+aa.options["verbose"] = False
+PDB_FIXTURES = Path(__file__).resolve().parents[3] / "aaanalysis" / "_data" / "pdb_test"
+
+# Encoders that align target vs atom_seq with no external binary / heavy
+# biopython surface tool (depth=msms, hse=HSExposure, chi=internal coords are
+# excluded — the suite never runs those). Each routes through
+# ``_pick_best_chain_records`` (-> ``_identity_fraction``) and
+# ``_align_atom_values_to_target``, i.e. the two callers of the cache.
+ENCODERS = [
+    ("bfactor", ep.encode_bfactor),
+    ("plddt", ep.encode_plddt),
+    ("plddt_disorder", ep.encode_plddt_disorder),
+    ("plddt_tier", ep.encode_plddt_tier),
+    ("ca_centroid_dist", ep.encode_ca_centroid_dist),
+    ("ca_centroid_dist_norm", ep.encode_ca_centroid_dist_norm),
+    ("contact_count_8A", ep.encode_contact_count_8A),
+    ("contact_count_12A", ep.encode_contact_count_12A),
+    ("disulfide", ep.encode_disulfide),
+]
+
+
+def _fresh_alignment_strings(target_seq, atom_seq):
+    """Recompute the aligned (target, atom) string pair with NO cache — the
+    reference for the original per-call alignment behaviour."""
+    aligner = ep._make_aligner()
+    alignment = aligner.align(target_seq, atom_seq)[0]
+    return str(alignment[0]), str(alignment[1])
+
+
+@pytest.mark.parametrize("pdb,seq", [
+    ("P1.pdb", "ACDEFGHIKLMNPQRS"),
+    ("P2.pdb", "VLIMKRSTGADE"),
+    ("AF_TINY.pdb", None),  # use the structure's own CA sequence
+])
+class TestAlignmentCacheEquivalence:
+    def _resolve_seq(self, structure, seq):
+        if seq is not None:
+            return seq
+        _c, _r, atom_seq, _id = _ca_coords_and_residues(structure, "A")
+        return atom_seq
+
+    def test_cached_strings_match_uncached(self, pdb, seq):
+        """The cached alignment strings equal a fresh, uncached recompute."""
+        structure = load_structure(PDB_FIXTURES / pdb)
+        seq = self._resolve_seq(structure, seq)
+        _c, _r, atom_seq, _id = _ca_coords_and_residues(structure, seq)
+        ep._alignment_strings.cache_clear()
+        cached = ep._alignment_strings(seq, atom_seq)
+        assert cached == _fresh_alignment_strings(seq, atom_seq)
+
+    def test_encoders_identical_with_vs_without_cache(self, monkeypatch, pdb, seq):
+        """Every encoder is byte-identical: cache bypassed vs. shared cache."""
+        structure = load_structure(PDB_FIXTURES / pdb)
+        seq = self._resolve_seq(structure, seq)
+
+        # Reference: bypass the lru_cache entirely (recompute every call).
+        monkeypatch.setattr(ep, "_alignment_strings", _fresh_alignment_strings)
+        ref = {name: enc(structure, seq) for name, enc in ENCODERS}
+        monkeypatch.undo()
+
+        # Real path: shared lru_cache, primed across encoders within the entry.
+        ep._alignment_strings.cache_clear()
+        got = {name: enc(structure, seq) for name, enc in ENCODERS}
+
+        for name, _enc in ENCODERS:
+            np.testing.assert_array_equal(got[name][0], ref[name][0])
+            assert got[name][1] == ref[name][1]
+
+    def test_priming_cache_does_not_change_output(self, pdb, seq):
+        """A cold first pass and a primed second pass yield identical output."""
+        structure = load_structure(PDB_FIXTURES / pdb)
+        seq = self._resolve_seq(structure, seq)
+        ep._alignment_strings.cache_clear()
+        cold = {name: enc(structure, seq) for name, enc in ENCODERS}
+        primed = {name: enc(structure, seq) for name, enc in ENCODERS}  # cache warm
+        for name, _enc in ENCODERS:
+            np.testing.assert_array_equal(cold[name][0], primed[name][0])
+            assert cold[name][1] == primed[name][1]
+
+
+def test_cache_does_not_cross_contaminate_distinct_inputs():
+    """Distinct (target, atom) keys return their own correct alignment — a
+    shared cache must not leak one pair's strings into another's."""
+    ep._alignment_strings.cache_clear()
+    pairs = [("ACDEFGHIK", "ACDEFGHIK"),
+             ("ACDEFGHIK", "ACDFGHIK"),
+             ("VLIMKRST", "VLIMKRST"),
+             ("VLIMKRST", "VLIM")]
+    for target, atom in pairs:  # prime in one order
+        ep._alignment_strings(target, atom)
+    for target, atom in pairs:  # each key still matches its own recompute
+        assert ep._alignment_strings(target, atom) == _fresh_alignment_strings(target, atom)


### PR DESCRIPTION
## Part A of #180 — `encode_pdb` alignment cache

The 13 `encode_pdb` encoders each re-run the **same** global `PairwiseAligner`
alignment of `target_seq` vs the chain's `atom_seq` (chain pick + every
per-feature value mapping) — ~26 `O(L^2)` alignments per entry on identical
inputs (~19 ms/entry at L=500, ~74 ms at L=1000).

This factors the alignment into an `lru_cache`d `_alignment_strings(target_seq,
atom_seq)` shared by `_identity_fraction` and `_align_atom_values_to_target`.
`aligner.align(...)[0]` is the deterministic first optimal alignment, so the
cached strings are identical → **byte-identical encoder output**; no
encoder-signature change. ~12x off the repeated-alignment overhead.

### Same-output guarantee
`tests/.../test_struct_alignment_cache_equiv.py` proves every no-external-dep
encoder is byte-identical with the cache **bypassed** vs **served from the
shared `lru_cache`**, on the bundled `P1`/`P2`/`AF_TINY` fixtures, plus a
cross-contamination guard on distinct keys. Full local suite green
(4324 passed, 11 skipped).

### Scope
- Code: `aaanalysis/data_handling_pro/_backend/struct_preproc/encode_pdb.py`
- Test: `test_struct_alignment_cache_equiv.py`
- Docs: `CHANGELOG.md` + `release_notes.rst`

Part B (pro-IO fetch `Session` reuse + opt-in concurrency) lands as a separate
PR — **#180 deliberately stays open** until both strands land (no closing
keyword here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)