### PR TITLE
perf: pool + opt-in concurrent web fetches for AlphaFold/UniProt — #180 Part B

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,13 @@ and a suite of site-localization metrics and plotting helpers.
   (`contact_count_8A`/`12A`) vectorized (~50x, identical counts) and its
   per-(target, atom) sequence alignment cached across the ~26 redundant
   re-alignments each entry triggers (~12x off the alignment overhead, byte-identical encoder output).
+- `StructurePreprocessor.fetch_alphafold` and `AnnotationPreprocessor.fetch_uniprot`
+  reuse a pooled HTTP session (one `requests.Session` per worker thread) instead of
+  opening a fresh connection per request, and gain an opt-in `max_workers` parameter
+  for threaded bulk fetching. Concurrency is **off by default** (`max_workers=None`/`1`
+  is the unchanged sequential path) because parallel requests to AlphaFold DB / UniProt
+  risk HTTP-429 throttling; results are reassembled in input order, so the status
+  table / `df_annot` and on-disk files are byte-identical regardless of worker count.
 - `dPULearn.fit` gains flexible, package-consistent label handling via
   `label_pos` / `label_unl` / `label_neg` markers: pass standard `{0, 1}` labels
   directly with `label_unl=0`, or an arbitrary positive/unlabeled/negative

--- a/aaanalysis/data_handling_pro/_annot_preproc.py
+++ b/aaanalysis/data_handling_pro/_annot_preproc.py
@@ -168,6 +168,7 @@ class AnnotationPreprocessor:
         features: Optional[List[str]] = None,
         evidence: Literal["experimental", "manual", "all"] = "manual",
         timeout: float = 30.0,
+        max_workers: Optional[int] = None,
     ) -> pd.DataFrame:
         """Fetch UniProt features for every entry and map to ``df_annot``.
 
@@ -195,6 +196,13 @@ class AnnotationPreprocessor:
             in the ``evidence`` column regardless.
         timeout : float, default=30.0
             Per-request timeout in seconds.
+        max_workers : int, optional
+            Number of threads for concurrent fetches. ``None`` or ``1``
+            (default) fetches entries sequentially. Greater than ``1`` fetches
+            on a thread pool; rows are concatenated in input order and the
+            ``df_annot`` is identical to the sequential result. Concurrency is
+            opt-in because parallel requests to UniProt risk HTTP-429 throttling
+            that can turn successful fetches into failures.
 
         Returns
         -------
@@ -226,6 +234,9 @@ class AnnotationPreprocessor:
         ut.check_number_range(
             name="timeout", val=timeout, min_val=1, accept_none=False, just_int=False
         )
+        if max_workers is not None:
+            ut.check_number_range(name="max_workers", val=max_workers,
+                                  min_val=1, just_int=True)
         # Fetch + map
         entries = df_seq[ut.COL_ENTRY].tolist()
         evidence_codes = _evidence_codes_for_mode(evidence)
@@ -235,6 +246,7 @@ class AnnotationPreprocessor:
             evidence_codes=evidence_codes,
             timeout=timeout,
             verbose=verbose,
+            max_workers=max_workers,
         )
 
     # ------------------------------------------------------------------

--- a/aaanalysis/data_handling_pro/_backend/_fetch.py
+++ b/aaanalysis/data_handling_pro/_backend/_fetch.py
@@ -1,0 +1,64 @@
+"""
+This is a script for the shared HTTP-fetch backend of the data_handling_pro
+web acquisition tools (AlphaFold model/PAE downloads, UniProt annotation
+records). It owns the single transport seam (``http_get_``) and the
+order-preserving, opt-in-concurrent runner (``run_in_order_``) that both the
+struct_preproc and annot_preproc fetch backends share.
+
+``http_get_`` routes every request through a per-thread :class:`requests.Session`
+so connection pooling survives across a bulk loop (and across an entry's
+multiple files) without sharing a Session across threads — ``requests.Session``
+is not documented thread-safe, so the opt-in :class:`ThreadPoolExecutor` path in
+``run_in_order_`` hands each worker its own pooled session. Each fetch backend
+imports ``http_get_`` into its own namespace, so the test suite patches a
+module-local binding (``patch("<backend>.http_get_")``) per backend.
+"""
+from concurrent.futures import ThreadPoolExecutor
+from typing import Callable, List, Optional, Sequence
+import threading
+
+import requests
+
+
+# I Helper Functions
+_thread_local = threading.local()
+
+
+def _get_session() -> requests.Session:
+    """Return this thread's pooled :class:`requests.Session` (lazily created)."""
+    session = getattr(_thread_local, "session", None)
+    if session is None:
+        session = _thread_local.session = requests.Session()
+    return session
+
+
+# II Main Functions
+def http_get_(url: str, timeout: float = 30.0):
+    """GET ``url`` through the calling thread's pooled session.
+
+    The single transport seam for the pro web-fetch backends; returns the
+    :class:`requests.Response` exactly as ``requests.get(url, timeout=timeout)``
+    would, so callers and their tests are unchanged apart from the connection
+    reuse.
+    """
+    return _get_session().get(url, timeout=timeout)
+
+
+def run_in_order_(func: Callable, items: Sequence,
+                  max_workers: Optional[int] = None) -> List:
+    """Map ``func`` over ``items``, returning results in **input order**.
+
+    Serial (a plain list comprehension) when ``max_workers`` is ``None`` or
+    ``<= 1`` — byte-identical to the original sequential loop. Otherwise runs on
+    a :class:`ThreadPoolExecutor`; ``executor.map`` preserves input order, so the
+    reassembled result list is identical regardless of worker count. Concurrency
+    is opt-in because parallel requests to AlphaFold-DB / UniProt risk HTTP-429
+    throttling that would turn successes into failures (an output change).
+
+    The first exception raised by any item propagates (consumed in order),
+    matching the original loop's abort-on-failure semantics.
+    """
+    if max_workers is None or max_workers <= 1:
+        return [func(item) for item in items]
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        return list(executor.map(func, items))

--- a/aaanalysis/data_handling_pro/_backend/annot_preproc/_uniprot.py
+++ b/aaanalysis/data_handling_pro/_backend/annot_preproc/_uniprot.py
@@ -33,6 +33,7 @@ import requests
 
 import aaanalysis.utils as ut
 from .feature_registry import REGISTRY
+from .._fetch import http_get_, run_in_order_
 
 # I Helper Functions
 UNIPROT_JSON_URL = "https://rest.uniprot.org/uniprotkb/{acc}.json"
@@ -78,7 +79,7 @@ def fetch_uniprot_json(accession: str, timeout: float = 30.0) -> dict:
     """
     url = UNIPROT_JSON_URL.format(acc=accession)
     try:
-        resp = requests.get(url, timeout=timeout)
+        resp = http_get_(url, timeout=timeout)
     except requests.RequestException as e:
         raise RuntimeError(f"UniProt request for '{accession}' failed: {e}") from e
     if resp.status_code != 200:
@@ -251,26 +252,48 @@ def map_record_to_rows(
     return rows
 
 
+def _fetch_uniprot_one(
+    entry: str,
+    allowed_features: Optional[List[str]],
+    evidence_codes: Optional[List[str]],
+    timeout: float,
+) -> List[list]:
+    """Fetch + map one entry to its ``df_annot`` rows (network work only).
+
+    No logging, so it is safe to run on a worker thread; the caller emits the
+    verbose prints from the main thread in input order.
+    """
+    data = fetch_uniprot_json(entry, timeout=timeout)
+    return map_record_to_rows(entry, data, allowed_features, evidence_codes)
+
+
 def fetch_and_map(
     entries: List[str],
     allowed_features: Optional[List[str]],
     evidence_codes: Optional[List[str]],
     timeout: float = 30.0,
     verbose: bool = True,
+    max_workers: Optional[int] = None,
 ) -> pd.DataFrame:
     """Fetch every entry and concatenate the mapped rows into a ``df_annot``.
+
+    With ``max_workers`` greater than 1 the per-entry fetches run on a thread
+    pool; rows are concatenated in input order, so the ``df_annot`` is identical
+    to the sequential path regardless of worker count. The verbose prints are
+    emitted from the main thread.
 
     Raises
     ------
     RuntimeError
         Propagated from :func:`fetch_uniprot_json` on network failure.
     """
+    results = run_in_order_(
+        lambda entry: _fetch_uniprot_one(entry, allowed_features,
+                                         evidence_codes, timeout),
+        entries, max_workers=max_workers)
     all_rows: List[list] = []
-    for entry in entries:
+    for entry, rows in zip(entries, results):
         if verbose:
             ut.print_out(f"Fetching UniProt features for '{entry}'")
-        data = fetch_uniprot_json(entry, timeout=timeout)
-        all_rows.extend(
-            map_record_to_rows(entry, data, allowed_features, evidence_codes)
-        )
+        all_rows.extend(rows)
     return pd.DataFrame(all_rows, columns=ut.COLS_ANNOT)

--- a/aaanalysis/data_handling_pro/_backend/struct_preproc/_alphafold.py
+++ b/aaanalysis/data_handling_pro/_backend/struct_preproc/_alphafold.py
@@ -14,7 +14,7 @@ on network / response failures other than a 404 (the soft "accession not in
 AlphaFold DB" case), so missing structures do not abort a bulk download.
 """
 from pathlib import Path
-from typing import List
+from typing import List, Optional, Tuple
 import warnings
 
 import pandas as pd
@@ -22,6 +22,7 @@ import requests
 
 import aaanalysis.utils as ut
 from ._file_format import _af_canonical_pae_name
+from .._fetch import http_get_, run_in_order_
 
 # I Helper Functions
 AF_FILES_URL = "https://alphafold.ebi.ac.uk/files/"
@@ -68,7 +69,7 @@ def _af_resolve_urls(entry: str, file_format: str, timeout: float = 30.0):
     """
     api_url = f"{AF_API_URL}{entry}"
     try:
-        resp = requests.get(api_url, timeout=timeout)
+        resp = http_get_(api_url, timeout=timeout)
     except requests.RequestException as e:
         raise RuntimeError(
             f"AlphaFold API request for '{entry}' ('{api_url}') failed: {e}") from e
@@ -111,7 +112,7 @@ def fetch_af_file(url: str, dest_path: Path, timeout: float = 30.0) -> bool:
         On any other non-200 response or transport error.
     """
     try:
-        resp = requests.get(url, timeout=timeout)
+        resp = http_get_(url, timeout=timeout)
     except requests.RequestException as e:
         raise RuntimeError(f"AlphaFold request for '{url}' failed: {e}") from e
     if resp.status_code == 404:
@@ -127,6 +128,39 @@ def fetch_af_file(url: str, dest_path: Path, timeout: float = 30.0) -> bool:
 
 
 # II Main Functions
+def _fetch_af_one(
+    entry: str,
+    out_folder: Path,
+    file_format: str,
+    timeout: float,
+    skip_existing: bool,
+) -> Tuple[bool, bool, bool, Path, Path]:
+    """Resolve + download model/PAE for one entry; do the network/disk work only.
+
+    Returns ``(was_skip, model_ok, pae_ok, model_path, pae_path)``. Pure
+    network/filesystem work with no logging or warnings so it is safe to run on
+    a worker thread; the caller emits the verbose prints and UserWarnings from
+    the main thread in input order.
+    """
+    model_path = out_folder / _af_model_filename(entry, file_format)
+    pae_path = out_folder / _af_canonical_pae_name(entry)
+    model_present = skip_existing and model_path.is_file()
+    pae_present = skip_existing and pae_path.is_file()
+    if model_present and pae_present:
+        return True, True, True, model_path, pae_path
+    # Resolve current download URLs via the API (version-agnostic). None =>
+    # the accession is not in AlphaFold DB; both files are then not-ok.
+    resolved = _af_resolve_urls(entry, file_format, timeout)
+    if resolved is None:
+        model_ok, pae_ok = model_present, pae_present
+    else:
+        model_url, pae_url = resolved
+        model_ok = model_present or fetch_af_file(model_url, model_path, timeout)
+        pae_ok = pae_present or (
+            pae_url is not None and fetch_af_file(pae_url, pae_path, timeout))
+    return False, model_ok, pae_ok, model_path, pae_path
+
+
 def fetch_alphafold_bulk(
     entries: List[str],
     out_folder: Path,
@@ -134,6 +168,7 @@ def fetch_alphafold_bulk(
     timeout: float = 30.0,
     skip_existing: bool = True,
     verbose: bool = True,
+    max_workers: Optional[int] = None,
 ) -> pd.DataFrame:
     """Download model + PAE for every entry; return a per-entry status table.
 
@@ -141,19 +176,25 @@ def fetch_alphafold_bulk(
     missing file when ``skip_existing`` is set. Entries missing from AlphaFold
     DB (404) are reported as not-ok via a ``UserWarning`` rather than raising.
 
+    With ``max_workers`` greater than 1 the per-entry downloads run on a thread
+    pool; results are reassembled in input order, so the status table is
+    identical to the sequential path regardless of worker count. The verbose
+    prints and the not-found ``UserWarning``s are emitted from the main thread.
+
     Raises
     ------
     RuntimeError
         Propagated from :func:`fetch_af_file` on network failure (non-404).
     """
     out_folder = Path(out_folder)
+    results = run_in_order_(
+        lambda entry: _fetch_af_one(entry, out_folder, file_format, timeout,
+                                    skip_existing),
+        entries, max_workers=max_workers)
     rows: List[list] = []
-    for entry in entries:
-        model_path = out_folder / _af_model_filename(entry, file_format)
-        pae_path = out_folder / _af_canonical_pae_name(entry)
-        model_present = skip_existing and model_path.is_file()
-        pae_present = skip_existing and pae_path.is_file()
-        if model_present and pae_present:
+    for entry, (was_skip, model_ok, pae_ok, model_path, pae_path) in zip(
+            entries, results):
+        if was_skip:
             if verbose:
                 ut.print_out(
                     f"Skipping '{entry}' (model + PAE already present)")
@@ -163,16 +204,6 @@ def fetch_alphafold_bulk(
         if verbose:
             ut.print_out(
                 f"Fetching AlphaFold {file_format} + PAE for '{entry}'")
-        # Resolve current download URLs via the API (version-agnostic). None =>
-        # the accession is not in AlphaFold DB; both files are then not-ok.
-        resolved = _af_resolve_urls(entry, file_format, timeout)
-        if resolved is None:
-            model_ok, pae_ok = model_present, pae_present
-        else:
-            model_url, pae_url = resolved
-            model_ok = model_present or fetch_af_file(model_url, model_path, timeout)
-            pae_ok = pae_present or (
-                pae_url is not None and fetch_af_file(pae_url, pae_path, timeout))
         if not model_ok:
             warnings.warn(
                 f"AlphaFold model for '{entry}' not found in AlphaFold DB "

--- a/aaanalysis/data_handling_pro/_struct_preproc.py
+++ b/aaanalysis/data_handling_pro/_struct_preproc.py
@@ -457,6 +457,7 @@ class StructurePreprocessor:
         skip_existing: bool = True,
         on_failure: Literal["nan", "drop", "raise"] = "nan",
         return_df: bool = False,
+        max_workers: Optional[int] = None,
     ) -> Union[pd.DataFrame, Tuple[pd.DataFrame, pd.DataFrame]]:
         """Download AlphaFold model + Predicted Aligned Error (PAE) files for
         every entry into a folder.
@@ -505,6 +506,13 @@ class StructurePreprocessor:
         return_df : bool, default=False
             If ``True``, also return an echo of ``df_seq`` with an appended
             boolean ``alphafold_ok`` column as a second element.
+        max_workers : int, optional
+            Number of threads for concurrent downloads. ``None`` or ``1``
+            (default) fetches entries sequentially. Greater than ``1`` downloads
+            on a thread pool; the status table is reassembled in input order and
+            is identical to the sequential result. Concurrency is opt-in because
+            parallel requests to AlphaFold DB risk HTTP-429 throttling that can
+            turn successful downloads into failures.
 
         Returns
         -------
@@ -550,6 +558,9 @@ class StructurePreprocessor:
         ut.check_bool(name="skip_existing", val=skip_existing)
         _check_handle_failure(on_failure)
         ut.check_bool(name="return_df", val=return_df)
+        if max_workers is not None:
+            ut.check_number_range(name="max_workers", val=max_workers,
+                                  min_val=1, just_int=True)
         if COL_ALPHAFOLD_OK in df_seq.columns:
             raise ValueError(
                 f"'df_seq' should not already contain a "
@@ -568,7 +579,8 @@ class StructurePreprocessor:
         # Download
         df_status = fetch_alphafold_bulk(
             entries=entries, out_folder=out_folder, file_format=file_format,
-            timeout=timeout, skip_existing=skip_existing, verbose=verbose)
+            timeout=timeout, skip_existing=skip_existing, verbose=verbose,
+            max_workers=max_workers)
         ok_per_row = df_status[COL_ALPHAFOLD_OK].tolist()
         df_status, ok_after, keep_idx = _drop_or_raise_failed_entries(
             df_seq=df_status, ok_per_row=ok_per_row, on_failure=on_failure,

--- a/docs/source/index/release_notes.rst
+++ b/docs/source/index/release_notes.rst
@@ -201,6 +201,16 @@ Changed
   plus each per-feature value mapping); the first optimal alignment is
   deterministic, so cached and recomputed encoder output are byte-identical
   (~12x off the repeated-alignment overhead).
+- **Pooled, optionally concurrent web fetches**:
+  ``StructurePreprocessor.fetch_alphafold`` and
+  ``AnnotationPreprocessor.fetch_uniprot`` now route every request through a
+  pooled ``requests.Session`` (one per worker thread) rather than opening a
+  fresh connection per request, and accept a new ``max_workers`` parameter for
+  threaded bulk fetching. Concurrency is **off by default** (``max_workers=None``
+  or ``1`` keeps the unchanged sequential path) because parallel requests to
+  AlphaFold DB / UniProt risk HTTP-429 throttling; when enabled, results are
+  reassembled in input order, so the returned status table / ``df_annot`` and
+  the on-disk files are byte-identical regardless of worker count.
 - **dPULearn.fit**: Flexible, package-consistent label handling via ``label_pos`` /
   ``label_unl`` / ``label_neg`` markers. Pass standard ``{0, 1}`` labels directly with
   ``label_unl=0`` (``0`` = unlabeled, ``1`` = positive), or any positive / unlabeled /

--- a/examples/data_handling_pro/ap_fetch_uniprot.ipynb
+++ b/examples/data_handling_pro/ap_fetch_uniprot.ipynb
@@ -33,7 +33,7 @@
    "id": "29c924ab",
    "metadata": {},
    "source": [
-    "**Further parameters.** ``AnnotationPreprocessor.fetch_uniprot`` also accepts: ``timeout`` — Per-request timeout in seconds."
+    "**Further parameters.** ``AnnotationPreprocessor.fetch_uniprot`` also accepts: ``timeout`` — Per-request timeout in seconds. ``max_workers`` — Number of threads for concurrent fetches; ``None`` / ``1`` (default) fetches sequentially, ``>1`` fetches on a thread pool with input-order, byte-identical results (opt-in: parallel UniProt requests risk HTTP-429 throttling)."
    ]
   }
  ],

--- a/examples/data_handling_pro/stp_fetch_alphafold.ipynb
+++ b/examples/data_handling_pro/stp_fetch_alphafold.ipynb
@@ -38,7 +38,7 @@
    "id": "879da258",
    "metadata": {},
    "source": [
-    "**Further parameters.** ``StructurePreprocessor.fetch_alphafold`` also accepts: ``file_format`` — Structure file type to download; ``timeout`` — Per-request timeout in seconds; ``skip_existing`` — If ``True``, an entry whose model and PAE files both already exist in ``out_folder`` is not re-downloaded; an entry with only one of the two present re-fetches only the missing file; ``return_df`` — If ``True``, also return an echo of ``df_seq`` with an appended boolean ``alphafold_ok`` column as a second element."
+    "**Further parameters.** ``StructurePreprocessor.fetch_alphafold`` also accepts: ``file_format`` — Structure file type to download; ``timeout`` — Per-request timeout in seconds; ``skip_existing`` — If ``True``, an entry whose model and PAE files both already exist in ``out_folder`` is not re-downloaded; an entry with only one of the two present re-fetches only the missing file; ``return_df`` — If ``True``, also return an echo of ``df_seq`` with an appended boolean ``alphafold_ok`` column as a second element. ``max_workers`` — Number of threads for concurrent downloads; ``None`` / ``1`` (default) fetches sequentially, ``>1`` downloads on a thread pool with input-order, byte-identical results (opt-in: parallel AlphaFold-DB requests risk HTTP-429 throttling);"
    ]
   }
  ],

--- a/tests/unit/data_handling_pro_tests/test_alphafold_backend.py
+++ b/tests/unit/data_handling_pro_tests/test_alphafold_backend.py
@@ -2,7 +2,8 @@
 ``data_handling_pro/_backend/struct_preproc/_alphafold.py``
 (fetch_af_file / fetch_alphafold_bulk and the URL/filename helpers).
 
-The network endpoint is never hit by the suite; ``requests.get`` is mocked.
+The network endpoint is never hit by the suite; the backend's ``http_get_``
+transport seam is mocked.
 A parity test asserts that the filenames written by the backend are exactly
 the ones the StructurePreprocessor file resolvers find, so a download feeds
 ``encode_pdb`` / ``encode_pae`` / ``get_dssp`` with no glue.
@@ -67,47 +68,47 @@ class TestResolveUrls:
     (the live-endpoint guard is the network test in tests/integration/)."""
 
     def test_valid_returns_pdb_and_pae_urls(self):
-        with patch(f"{MODULE}.requests.get", return_value=_api_resp()):
+        with patch(f"{MODULE}.http_get_", return_value=_api_resp()):
             model_url, pae_url = af._af_resolve_urls("P1", "pdb", 5.0)
         assert model_url.endswith("model_v6.pdb")
         assert pae_url.endswith("predicted_aligned_error_v6.json")
 
     def test_valid_cif_uses_cif_url(self):
-        with patch(f"{MODULE}.requests.get", return_value=_api_resp()):
+        with patch(f"{MODULE}.http_get_", return_value=_api_resp()):
             model_url, _ = af._af_resolve_urls("P1", "cif", 5.0)
         assert model_url.endswith("model_v6.cif")
 
     def test_valid_404_returns_none(self):
-        with patch(f"{MODULE}.requests.get", return_value=_api_resp(404)):
+        with patch(f"{MODULE}.http_get_", return_value=_api_resp(404)):
             assert af._af_resolve_urls("P1", "pdb", 5.0) is None
 
     def test_valid_400_returns_none(self):
-        with patch(f"{MODULE}.requests.get", return_value=_api_resp(400)):
+        with patch(f"{MODULE}.http_get_", return_value=_api_resp(400)):
             assert af._af_resolve_urls("BADACC", "pdb", 5.0) is None
 
     def test_valid_empty_records_returns_none(self):
-        with patch(f"{MODULE}.requests.get", return_value=_api_resp(records=[])):
+        with patch(f"{MODULE}.http_get_", return_value=_api_resp(records=[])):
             assert af._af_resolve_urls("P1", "pdb", 5.0) is None
 
     def test_valid_no_pae_doc_url(self):
-        with patch(f"{MODULE}.requests.get",
+        with patch(f"{MODULE}.http_get_",
                    return_value=_api_resp(records=[{"pdbUrl": "http://m.pdb"}])):
             model_url, pae_url = af._af_resolve_urls("P1", "pdb", 5.0)
         assert model_url == "http://m.pdb" and pae_url is None
 
     def test_invalid_500_raises(self):
-        with patch(f"{MODULE}.requests.get", return_value=_api_resp(500)):
+        with patch(f"{MODULE}.http_get_", return_value=_api_resp(500)):
             with pytest.raises(RuntimeError, match="HTTP 500"):
                 af._af_resolve_urls("P1", "pdb", 5.0)
 
     def test_invalid_missing_model_key_raises(self):
-        with patch(f"{MODULE}.requests.get",
+        with patch(f"{MODULE}.http_get_",
                    return_value=_api_resp(records=[{"paeDocUrl": "x"}])):
             with pytest.raises(RuntimeError, match="no 'pdbUrl'"):
                 af._af_resolve_urls("P1", "pdb", 5.0)
 
     def test_invalid_transport_error_raises(self):
-        with patch(f"{MODULE}.requests.get",
+        with patch(f"{MODULE}.http_get_",
                    side_effect=requests.RequestException("boom")):
             with pytest.raises(RuntimeError, match="failed"):
                 af._af_resolve_urls("P1", "pdb", 5.0)
@@ -118,38 +119,38 @@ class TestFetchAfFile:
 
     def test_valid_200_writes_and_returns_true(self, tmp_path):
         dest = tmp_path / "P1.pdb"
-        with patch(f"{MODULE}.requests.get", return_value=_resp(200, b"XYZ")):
+        with patch(f"{MODULE}.http_get_", return_value=_resp(200, b"XYZ")):
             ok = af.fetch_af_file("http://x", dest, timeout=5.0)
         assert ok is True
         assert dest.read_bytes() == b"XYZ"
 
     def test_valid_404_returns_false_no_file(self, tmp_path):
         dest = tmp_path / "P1.pdb"
-        with patch(f"{MODULE}.requests.get", return_value=_resp(404)):
+        with patch(f"{MODULE}.http_get_", return_value=_resp(404)):
             ok = af.fetch_af_file("http://x", dest)
         assert ok is False
         assert not dest.exists()
 
     def test_valid_passes_timeout(self, tmp_path):
         dest = tmp_path / "P1.pdb"
-        with patch(f"{MODULE}.requests.get",
+        with patch(f"{MODULE}.http_get_",
                    return_value=_resp(200)) as mg:
             af.fetch_af_file("http://x", dest, timeout=12.0)
         assert mg.call_args.kwargs["timeout"] == 12.0
 
     def test_valid_atomic_no_part_left(self, tmp_path):
         dest = tmp_path / "P1.pdb"
-        with patch(f"{MODULE}.requests.get", return_value=_resp(200)):
+        with patch(f"{MODULE}.http_get_", return_value=_resp(200)):
             af.fetch_af_file("http://x", dest)
         assert not (tmp_path / "P1.pdb.part").exists()
 
     def test_invalid_500_raises(self, tmp_path):
-        with patch(f"{MODULE}.requests.get", return_value=_resp(500)):
+        with patch(f"{MODULE}.http_get_", return_value=_resp(500)):
             with pytest.raises(RuntimeError, match="HTTP 500"):
                 af.fetch_af_file("http://x", tmp_path / "P1.pdb")
 
     def test_invalid_transport_error_raises(self, tmp_path):
-        with patch(f"{MODULE}.requests.get",
+        with patch(f"{MODULE}.http_get_",
                    side_effect=requests.RequestException("boom")):
             with pytest.raises(RuntimeError, match="failed"):
                 af.fetch_af_file("http://x", tmp_path / "P1.pdb")
@@ -177,7 +178,7 @@ class TestFetchAlphafoldBulk:
         assert not bool(df.iloc[0]["model_ok"]) and not bool(df.iloc[0]["pae_ok"])
 
     def test_valid_single_entry_both_ok(self, tmp_path):
-        with patch(f"{MODULE}.requests.get",
+        with patch(f"{MODULE}.http_get_",
                    side_effect=_seq_responses(200, 200)):
             df = af.fetch_alphafold_bulk(["P1"], tmp_path, "pdb",
                                          30.0, True, False)
@@ -187,7 +188,7 @@ class TestFetchAlphafoldBulk:
         assert (tmp_path / "AF-P1-F1-predicted_aligned_error_v4.json").is_file()
 
     def test_valid_multiple_entries(self, tmp_path):
-        with patch(f"{MODULE}.requests.get",
+        with patch(f"{MODULE}.http_get_",
                    side_effect=_seq_responses(200, 200, 200, 200)):
             df = af.fetch_alphafold_bulk(["P1", "P2"], tmp_path, "pdb",
                                          30.0, True, False)
@@ -195,7 +196,7 @@ class TestFetchAlphafoldBulk:
         assert df["alphafold_ok"].all()
 
     def test_valid_cif_format(self, tmp_path):
-        with patch(f"{MODULE}.requests.get",
+        with patch(f"{MODULE}.http_get_",
                    side_effect=_seq_responses(200, 200)):
             af.fetch_alphafold_bulk(["P1"], tmp_path, "cif", 30.0, True, False)
         assert (tmp_path / "P1.cif").is_file()
@@ -203,7 +204,7 @@ class TestFetchAlphafoldBulk:
     def test_valid_skip_existing_skips(self, tmp_path):
         (tmp_path / "P1.pdb").write_text("x")
         (tmp_path / "AF-P1-F1-predicted_aligned_error_v4.json").write_text("{}")
-        with patch(f"{MODULE}.requests.get") as mg:
+        with patch(f"{MODULE}.http_get_") as mg:
             df = af.fetch_alphafold_bulk(["P1"], tmp_path, "pdb",
                                          30.0, True, False)
         mg.assert_not_called()
@@ -213,7 +214,7 @@ class TestFetchAlphafoldBulk:
     def test_valid_partial_refetches_only_missing(self, tmp_path):
         # Model already present, PAE missing -> only one GET (for PAE).
         (tmp_path / "P1.pdb").write_text("x")
-        with patch(f"{MODULE}.requests.get",
+        with patch(f"{MODULE}.http_get_",
                    side_effect=_seq_responses(200)) as mg:
             df = af.fetch_alphafold_bulk(["P1"], tmp_path, "pdb",
                                          30.0, True, False)
@@ -223,7 +224,7 @@ class TestFetchAlphafoldBulk:
     def test_valid_skip_existing_false_always_downloads(self, tmp_path):
         (tmp_path / "P1.pdb").write_text("x")
         (tmp_path / "AF-P1-F1-predicted_aligned_error_v4.json").write_text("{}")
-        with patch(f"{MODULE}.requests.get",
+        with patch(f"{MODULE}.http_get_",
                    side_effect=_seq_responses(200, 200)) as mg:
             af.fetch_alphafold_bulk(["P1"], tmp_path, "pdb",
                                     30.0, False, False)
@@ -231,7 +232,7 @@ class TestFetchAlphafoldBulk:
 
     def test_valid_mixed_success_and_404(self, tmp_path):
         # P1 ok; P2 model ok, PAE 404.
-        with patch(f"{MODULE}.requests.get",
+        with patch(f"{MODULE}.http_get_",
                    side_effect=_seq_responses(200, 200, 200, 404)):
             with pytest.warns(UserWarning, match="PAE for 'P2'"):
                 df = af.fetch_alphafold_bulk(["P1", "P2"], tmp_path, "pdb",
@@ -242,7 +243,7 @@ class TestFetchAlphafoldBulk:
         assert df.iloc[1]["pae_path"] == ""
 
     def test_valid_404_model_warns(self, tmp_path):
-        with patch(f"{MODULE}.requests.get",
+        with patch(f"{MODULE}.http_get_",
                    side_effect=_seq_responses(404, 200)):
             with pytest.warns(UserWarning, match="model for 'P1'"):
                 df = af.fetch_alphafold_bulk(["P1"], tmp_path, "pdb",
@@ -251,20 +252,20 @@ class TestFetchAlphafoldBulk:
         assert df.iloc[0]["model_path"] == ""
 
     def test_valid_verbose_prints_entry(self, tmp_path, capsys):
-        with patch(f"{MODULE}.requests.get",
+        with patch(f"{MODULE}.http_get_",
                    side_effect=_seq_responses(200, 200)):
             af.fetch_alphafold_bulk(["P1"], tmp_path, "pdb", 30.0, True, True)
         assert "P1" in capsys.readouterr().out
 
     def test_valid_columns_schema(self, tmp_path):
-        with patch(f"{MODULE}.requests.get",
+        with patch(f"{MODULE}.http_get_",
                    side_effect=_seq_responses(200, 200)):
             df = af.fetch_alphafold_bulk(["P1"], tmp_path, "pdb",
                                          30.0, True, False)
         assert list(df.columns) == af.COLS_AF_STATUS
 
     def test_invalid_network_error_propagates(self, tmp_path):
-        with patch(f"{MODULE}.requests.get",
+        with patch(f"{MODULE}.http_get_",
                    side_effect=requests.RequestException("down")):
             with pytest.raises(RuntimeError):
                 af.fetch_alphafold_bulk(["P1"], tmp_path, "pdb",
@@ -283,7 +284,7 @@ class TestFetchAlphafoldBulkComplex:
     def test_written_names_resolve_via_resolvers(self, tmp_path):
         # The no-glue contract: backend-written filenames are exactly what
         # encode_pdb / encode_pae find.
-        with patch(f"{MODULE}.requests.get",
+        with patch(f"{MODULE}.http_get_",
                    side_effect=_seq_responses(200, 200)):
             af.fetch_alphafold_bulk(["P12345"], tmp_path, "pdb",
                                     30.0, True, False)
@@ -293,14 +294,14 @@ class TestFetchAlphafoldBulkComplex:
         assert pae_path is not None
 
     def test_cif_names_resolve(self, tmp_path):
-        with patch(f"{MODULE}.requests.get",
+        with patch(f"{MODULE}.http_get_",
                    side_effect=_seq_responses(200, 200)):
             af.fetch_alphafold_bulk(["P9"], tmp_path, "cif", 30.0, True, False)
         struct_path, fmt = resolve_structure_path(tmp_path, "P9")
         assert struct_path is not None and fmt == "cif"
 
     def test_status_paths_point_at_real_files(self, tmp_path):
-        with patch(f"{MODULE}.requests.get",
+        with patch(f"{MODULE}.http_get_",
                    side_effect=_seq_responses(200, 200)):
             df = af.fetch_alphafold_bulk(["P1"], tmp_path, "pdb",
                                          30.0, True, False)
@@ -308,14 +309,14 @@ class TestFetchAlphafoldBulkComplex:
         assert Path(df.iloc[0]["pae_path"]).is_file()
 
     def test_skipped_false_when_downloaded(self, tmp_path):
-        with patch(f"{MODULE}.requests.get",
+        with patch(f"{MODULE}.http_get_",
                    side_effect=_seq_responses(200, 200)):
             df = af.fetch_alphafold_bulk(["P1"], tmp_path, "pdb",
                                          30.0, True, False)
         assert bool(df.iloc[0]["skipped"]) is False
 
     def test_returns_dataframe(self, tmp_path):
-        with patch(f"{MODULE}.requests.get",
+        with patch(f"{MODULE}.http_get_",
                    side_effect=_seq_responses(200, 200)):
             df = af.fetch_alphafold_bulk(["P1"], tmp_path, "pdb",
                                          30.0, True, False)

--- a/tests/unit/data_handling_pro_tests/test_fetch_concurrency_equiv.py
+++ b/tests/unit/data_handling_pro_tests/test_fetch_concurrency_equiv.py
@@ -1,0 +1,192 @@
+"""Same-output tests for the opt-in concurrent fetch path (issue #180 Part B).
+
+The pro web-fetch backends gained a ``max_workers`` thread-pool option behind a
+shared, order-preserving runner (``_fetch.run_in_order_``). These tests prove:
+
+* ``run_in_order_`` preserves input order independent of completion time and is
+  byte-identical serial vs. concurrent, and propagates the first exception;
+* ``fetch_alphafold_bulk`` / ``fetch_and_map`` return identical results (status
+  table / ``df_annot`` and on-disk files) at any worker count, in input order;
+* the frontend ``max_workers`` validation rejects bad values.
+
+Per-accession mocks (a side-effect *function*, not a call-order list) keep the
+expected response deterministic regardless of the order threads make calls.
+"""
+import time
+from unittest.mock import patch, MagicMock
+
+import pandas as pd
+import pytest
+
+import aaanalysis as aa
+import aaanalysis.utils as ut
+from aaanalysis import StructurePreprocessor, AnnotationPreprocessor
+from aaanalysis.data_handling_pro._backend import _fetch
+from aaanalysis.data_handling_pro._backend.struct_preproc import _alphafold as af
+from aaanalysis.data_handling_pro._backend.annot_preproc import _uniprot as up
+
+AF_MODULE = "aaanalysis.data_handling_pro._backend.struct_preproc._alphafold"
+UP_MODULE = "aaanalysis.data_handling_pro._backend.annot_preproc._uniprot"
+SEQ = "ACDEFGHIKLMNPQRSTVWY"
+
+
+# I Helper Functions
+def _resp(status=200, content=b"DATA"):
+    m = MagicMock()
+    m.status_code = status
+    m.content = content
+    return m
+
+
+def _af_http(url, timeout=30.0):
+    """Deterministic per-URL response (content = URL bytes), thread-safe."""
+    return _resp(200, content=url.encode())
+
+
+def _af_resolve(entry, file_format, timeout):
+    """Per-entry model/PAE URLs so each accession's files are distinct."""
+    return f"https://af/{entry}/model", f"https://af/{entry}/pae"
+
+
+def _uniprot_record(acc, timeout=30.0):
+    """Deterministic per-accession UniProt record: one phospho site."""
+    pos = (int(acc[1:]) % len(SEQ)) + 1
+    feat = {"type": "Modified residue", "description": "Phosphoserine",
+            "location": {"start": {"value": pos}, "end": {"value": pos}},
+            "evidences": [{"evidenceCode": "ECO:0000269"}]}
+    return {"sequence": {"value": SEQ}, "features": [feat]}
+
+
+# II Test Classes
+class TestRunInOrder:
+    """The shared order-preserving, opt-in-concurrent runner."""
+
+    def test_serial_none_preserves_order(self):
+        assert _fetch.run_in_order_(lambda x: x * 2, [1, 2, 3, 4],
+                                    max_workers=None) == [2, 4, 6, 8]
+
+    def test_serial_one_preserves_order(self):
+        assert _fetch.run_in_order_(lambda x: x * 2, [1, 2, 3, 4],
+                                    max_workers=1) == [2, 4, 6, 8]
+
+    @pytest.mark.parametrize("max_workers", [2, 4, 8])
+    def test_concurrent_matches_serial(self, max_workers):
+        items = list(range(20))
+        serial = _fetch.run_in_order_(lambda x: x * x, items, max_workers=1)
+        concurrent = _fetch.run_in_order_(lambda x: x * x, items,
+                                          max_workers=max_workers)
+        assert concurrent == serial == [x * x for x in items]
+
+    def test_order_independent_of_completion_time(self):
+        # Earlier items sleep the longest; the output must still be in input
+        # order, proving order comes from the submission index, not completion.
+        def slow(i):
+            time.sleep(0.01 * (5 - i))
+            return i
+        assert _fetch.run_in_order_(slow, [0, 1, 2, 3, 4],
+                                    max_workers=5) == [0, 1, 2, 3, 4]
+
+    def test_empty_items(self):
+        assert _fetch.run_in_order_(lambda x: x, [], max_workers=4) == []
+
+    @pytest.mark.parametrize("max_workers", [1, 4])
+    def test_exception_propagates(self, max_workers):
+        def boom(x):
+            if x == 2:
+                raise RuntimeError("kaboom")
+            return x
+        with pytest.raises(RuntimeError, match="kaboom"):
+            _fetch.run_in_order_(boom, [0, 1, 2, 3], max_workers=max_workers)
+
+
+class TestAlphafoldConcurrencyEquivalence:
+    """fetch_alphafold_bulk: concurrent == sequential (status table + files)."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_resolve(self):
+        with patch(f"{AF_MODULE}._af_resolve_urls", side_effect=_af_resolve):
+            yield
+
+    @pytest.mark.parametrize("max_workers", [2, 4, 8])
+    def test_identical_status_table_and_order(self, tmp_path, max_workers):
+        entries = [f"P{i}" for i in range(12)]
+        folder = tmp_path / "af"
+        folder.mkdir()
+        with patch(f"{AF_MODULE}.http_get_", side_effect=_af_http):
+            serial = af.fetch_alphafold_bulk(entries, folder, "pdb", 30.0,
+                                             False, False, max_workers=1)
+            concurrent = af.fetch_alphafold_bulk(entries, folder, "pdb", 30.0,
+                                                 False, False,
+                                                 max_workers=max_workers)
+        # Byte-identical status table, including row (input) order.
+        pd.testing.assert_frame_equal(serial, concurrent)
+        assert list(concurrent[ut.COL_ENTRY]) == entries
+        assert concurrent["alphafold_ok"].all()
+
+    def test_files_written_with_expected_content(self, tmp_path):
+        entries = [f"P{i}" for i in range(6)]
+        folder = tmp_path / "af"
+        folder.mkdir()
+        with patch(f"{AF_MODULE}.http_get_", side_effect=_af_http):
+            af.fetch_alphafold_bulk(entries, folder, "pdb", 30.0, False, False,
+                                    max_workers=4)
+        for entry in entries:
+            model = folder / f"{entry}.pdb"
+            assert model.is_file()
+            assert model.read_bytes() == f"https://af/{entry}/model".encode()
+
+
+class TestUniprotConcurrencyEquivalence:
+    """fetch_and_map: concurrent == sequential (df_annot rows + order)."""
+
+    @pytest.mark.parametrize("max_workers", [2, 4, 8])
+    def test_identical_df_and_order(self, max_workers):
+        entries = [f"P{i}" for i in range(12)]
+        with patch(f"{UP_MODULE}.fetch_uniprot_json", side_effect=_uniprot_record):
+            serial = up.fetch_and_map(entries, None, None, 30.0, False,
+                                      max_workers=1)
+            concurrent = up.fetch_and_map(entries, None, None, 30.0, False,
+                                          max_workers=max_workers)
+        pd.testing.assert_frame_equal(serial, concurrent)
+        # One row per entry, concatenated in input order.
+        assert list(concurrent[ut.COL_PROTEIN_ID]) == entries
+
+
+class TestFrontendMaxWorkers:
+    """Frontend plumbing + validation of the new ``max_workers`` parameter."""
+
+    def _df_seq(self, entries=("P1",)):
+        return pd.DataFrame({ut.COL_ENTRY: list(entries),
+                             ut.COL_SEQ: [SEQ] * len(entries)})
+
+    @pytest.mark.parametrize("bad", [0, -1, 2.5])
+    def test_fetch_alphafold_invalid_max_workers_raises(self, tmp_path, bad):
+        stp = StructurePreprocessor(verbose=False)
+        with pytest.raises(ValueError):
+            stp.fetch_alphafold(df_seq=self._df_seq(), out_folder=tmp_path / "o",
+                                max_workers=bad)
+
+    @pytest.mark.parametrize("bad", [0, -1, 2.5])
+    def test_fetch_uniprot_invalid_max_workers_raises(self, bad):
+        ap = AnnotationPreprocessor(verbose=False)
+        with pytest.raises(ValueError):
+            ap.fetch_uniprot(df_seq=self._df_seq(), max_workers=bad)
+
+    def test_fetch_alphafold_max_workers_plumbs_through(self, tmp_path):
+        stp = StructurePreprocessor(verbose=False)
+        entries = ["P1", "P2", "P3"]
+        with patch(f"{AF_MODULE}._af_resolve_urls", side_effect=_af_resolve), \
+                patch(f"{AF_MODULE}.http_get_", side_effect=_af_http):
+            df = stp.fetch_alphafold(df_seq=self._df_seq(entries),
+                                     out_folder=tmp_path / "o", skip_existing=False,
+                                     max_workers=4)
+        assert list(df[ut.COL_ENTRY]) == entries
+        assert df["alphafold_ok"].all()
+
+    def test_fetch_uniprot_max_workers_plumbs_through(self):
+        ap = AnnotationPreprocessor(verbose=False)
+        entries = ["P1", "P2", "P3"]
+        with patch(f"{UP_MODULE}.fetch_uniprot_json", side_effect=_uniprot_record):
+            df = ap.fetch_uniprot(df_seq=self._df_seq(entries), evidence="all",
+                                  max_workers=4)
+        assert list(df[ut.COL_PROTEIN_ID]) == entries

--- a/tests/unit/data_handling_pro_tests/test_structure_preprocessor_fetch_alphafold.py
+++ b/tests/unit/data_handling_pro_tests/test_structure_preprocessor_fetch_alphafold.py
@@ -9,7 +9,8 @@ import aaanalysis as aa
 
 aa.options["verbose"] = False
 
-# requests.get lives in the download backend; patch it there (no network).
+# http_get_ (the pooled transport seam) lives in the download backend; patch it
+# there (no network).
 BACKEND = "aaanalysis.data_handling_pro._backend.struct_preproc._alphafold"
 
 
@@ -33,12 +34,12 @@ def _df(entries=("P1",)):
 
 
 def _patch_get(*statuses):
-    return patch(f"{BACKEND}.requests.get", side_effect=_responses(*statuses))
+    return patch(f"{BACKEND}.http_get_", side_effect=_responses(*statuses))
 
 
 @pytest.fixture(autouse=True)
 def _stub_af_resolve_urls():
-    """Resolve URLs without the network so the ``requests.get`` mocks below
+    """Resolve URLs without the network so the ``http_get_`` mocks below
     drive only the two file downloads (model + PAE). The resolver itself is
     unit-tested in test_alphafold_backend.py::TestResolveUrls and live-checked
     by the network test."""
@@ -82,7 +83,7 @@ class TestFetchAlphafold:
 
     def test_valid_timeout_passed_through(self, tmp_path):
         stp = aa.StructurePreprocessor(verbose=False)
-        with patch(f"{BACKEND}.requests.get",
+        with patch(f"{BACKEND}.http_get_",
                    side_effect=_responses(200, 200)) as mg:
             stp.fetch_alphafold(df_seq=_df(), out_folder=str(tmp_path),
                                 timeout=7.0)
@@ -92,7 +93,7 @@ class TestFetchAlphafold:
         (tmp_path / "P1.pdb").write_text("x")
         (tmp_path / "AF-P1-F1-predicted_aligned_error_v4.json").write_text("{}")
         stp = aa.StructurePreprocessor(verbose=False)
-        with patch(f"{BACKEND}.requests.get") as mg:
+        with patch(f"{BACKEND}.http_get_") as mg:
             out = stp.fetch_alphafold(df_seq=_df(), out_folder=str(tmp_path),
                                       skip_existing=True)
         mg.assert_not_called()
@@ -102,7 +103,7 @@ class TestFetchAlphafold:
         (tmp_path / "P1.pdb").write_text("x")
         (tmp_path / "AF-P1-F1-predicted_aligned_error_v4.json").write_text("{}")
         stp = aa.StructurePreprocessor(verbose=False)
-        with patch(f"{BACKEND}.requests.get",
+        with patch(f"{BACKEND}.http_get_",
                    side_effect=_responses(200, 200)) as mg:
             stp.fetch_alphafold(df_seq=_df(), out_folder=str(tmp_path),
                                 skip_existing=False)
@@ -263,7 +264,7 @@ class TestFetchAlphafoldComplex:
     def test_valid_partial_present_one_get(self, tmp_path):
         (tmp_path / "P1.pdb").write_text("x")
         stp = aa.StructurePreprocessor(verbose=False)
-        with patch(f"{BACKEND}.requests.get",
+        with patch(f"{BACKEND}.http_get_",
                    side_effect=_responses(200)) as mg:
             stp.fetch_alphafold(df_seq=_df(), out_folder=str(tmp_path))
         assert mg.call_count == 1
@@ -285,7 +286,7 @@ class TestFetchAlphafoldComplex:
 
     def test_invalid_transport_error_raises(self, tmp_path):
         stp = aa.StructurePreprocessor(verbose=False)
-        with patch(f"{BACKEND}.requests.get",
+        with patch(f"{BACKEND}.http_get_",
                    side_effect=requests.RequestException("down")):
             with pytest.raises(RuntimeError):
                 stp.fetch_alphafold(df_seq=_df(), out_folder=str(tmp_path))

--- a/tests/unit/data_handling_pro_tests/test_uniprot_backend.py
+++ b/tests/unit/data_handling_pro_tests/test_uniprot_backend.py
@@ -6,7 +6,8 @@ _get_sequence and the evidence/classification helpers).
 The network endpoint is never hit by the suite; the existing frontend test calls
 ``map_record_to_rows`` on hand-built JSON dicts. Here we additionally cover the
 ``requests``-backed ``fetch_uniprot_json`` / ``fetch_and_map`` paths by mocking
-``requests.get`` (no network), plus the feature-classification and skip branches.
+the backend's ``http_get_`` transport seam (no network), plus the
+feature-classification and skip branches.
 """
 from unittest.mock import patch, MagicMock
 
@@ -49,24 +50,24 @@ class TestFetchUniprotJson:
     """fetch_uniprot_json: success, non-200, transport error."""
 
     def test_valid_returns_json(self):
-        with patch(f"{MODULE}.requests.get",
+        with patch(f"{MODULE}.http_get_",
                    return_value=_resp(200, {"primaryAccession": "P1"})):
             out = up.fetch_uniprot_json("P1")
         assert out["primaryAccession"] == "P1"
 
     def test_valid_passes_timeout(self):
-        with patch(f"{MODULE}.requests.get",
+        with patch(f"{MODULE}.http_get_",
                    return_value=_resp(200, {})) as mg:
             up.fetch_uniprot_json("P1", timeout=12.0)
         assert mg.call_args.kwargs["timeout"] == 12.0
 
     def test_invalid_non_200(self):
-        with patch(f"{MODULE}.requests.get", return_value=_resp(404, {})):
+        with patch(f"{MODULE}.http_get_", return_value=_resp(404, {})):
             with pytest.raises(RuntimeError, match="HTTP 404"):
                 up.fetch_uniprot_json("MISSING")
 
     def test_invalid_transport_error(self):
-        with patch(f"{MODULE}.requests.get",
+        with patch(f"{MODULE}.http_get_",
                    side_effect=requests.RequestException("boom")):
             with pytest.raises(RuntimeError, match="failed"):
                 up.fetch_uniprot_json("P1")


### PR DESCRIPTION
## Part B of #180 — pro-IO fetch (AlphaFold + UniProt)

The AlphaFold (`_alphafold.py`) and UniProt (`_uniprot.py`) bulk fetchers opened
a fresh TCP+TLS connection per request and fetched entries strictly sequentially.

### What changed
**Shared transport seam** (`_backend/_fetch.py`, used by both fetch backends):
- `http_get_(url, timeout)` — GETs through a **per-thread pooled `requests.Session`**,
  so connection reuse survives the bulk loop (and an entry's model+PAE) without
  sharing a Session across threads (`requests.Session` is not documented
  thread-safe). Each backend imports the name, so the suite patches a module-local
  binding (`patch("<backend>.http_get_")`) per backend.
- `run_in_order_(func, items, max_workers)` — maps `func` over items in **input
  order**. Serial list-comp when `max_workers` is `None`/`1` (byte-identical to the
  original loop); otherwise `ThreadPoolExecutor` whose `executor.map` preserves
  order, so the result is identical at any worker count.

`fetch_alphafold_bulk` / `fetch_and_map` extract a pure (no log/warn) per-entry
worker run through `run_in_order_`; the verbose prints and not-found
`UserWarning`s are emitted from the main thread in input order (so `pytest.warns`
still catches them). Frontends `fetch_alphafold` / `fetch_uniprot` gain a
validated, **OFF-by-default** `max_workers` param.

### Why off by default
Parallel requests to AlphaFold DB / UniProt risk HTTP-429 throttling that would
turn successful fetches into failures (an output change). `max_workers=None`/`1`
is the unchanged sequential path; concurrency is explicit opt-in.

### Same-output guarantee
`test_fetch_concurrency_equiv.py` (24 tests) proves `run_in_order_` preserves
order independent of completion time + propagates the first exception, and that
both bulk fetchers return **byte-identical** status table / `df_annot` **and
on-disk files** serial-vs-concurrent (per-accession mocks, worker counts 2/4/8),
plus frontend `max_workers` validation. The ~45 existing `requests.get` patch
sites were mechanically migrated to the `http_get_` seam (identical mock
semantics). Full local suite green (4349 passed, 10 skipped); docstring checker 0
defects; flake8 error-gate clean; nbmake on both touched notebooks pass.

### Ripple
Release notes + CHANGELOG + the two example notebooks (`stp_fetch_alphafold`,
`ap_fetch_uniprot`) updated with the `max_workers` parameter.

Closes #180 — this is the final strand (Part A, the encode_pdb alignment cache,
merged in #183).

🤖 Generated with [Claude Code](https://claude.com/claude-code)