### PR TITLE
perf: candidate_centers_ nearest-excluded via searchsorted (O(n) memory, same output)

### DIFF
--- a/aaanalysis/seq_analysis/_backend/aa_window_sampler/_utils.py
+++ b/aaanalysis/seq_analysis/_backend/aa_window_sampler/_utils.py
@@ -97,11 +97,16 @@ def candidate_centers_(seq_len, window_size, exclude_positions=None,
         return centers
     if min_distance is None and max_distance is None:
         return centers
-    # Nearest-excluded L1 distance per center, vectorized. Distances are integers, so the
-    # band comparisons reproduce the scalar keep/drop decisions exactly.
+    # Nearest-excluded L1 distance per center via binary search into the sorted excluded
+    # positions: the nearest excluded position is one of the two neighbours bracketing the
+    # center. O(n_centers · log n_excl) time and O(n_centers) memory — no n_centers × n_excl
+    # matrix. Distances are integers, so the band comparisons reproduce the scalar decisions.
     centers_arr = np.asarray(centers)
-    excl = np.asarray([p - 1 for p in exclude_positions])
-    d = np.abs(centers_arr[:, None] - excl[None, :]).min(axis=1)
+    excl = np.unique(np.asarray([p - 1 for p in exclude_positions]))
+    pos = np.searchsorted(excl, centers_arr)
+    left = np.abs(centers_arr - excl[np.clip(pos - 1, 0, len(excl) - 1)])
+    right = np.abs(centers_arr - excl[np.clip(pos, 0, len(excl) - 1)])
+    d = np.minimum(left, right)
     keep = np.ones(len(centers_arr), dtype=bool)
     if min_distance is not None:
         keep &= d >= min_distance


### PR DESCRIPTION
## What
`candidate_centers_`'s vectorized band filter built an `(n_centers × n_excludes)` distance matrix — **~6.5 MB peak** on a 2000-residue / 199-exclude case (≈0 in the original scalar loop), an **O(n·m) memory blow-up that grows with input**. Replaced with `np.searchsorted` into the sorted excluded positions: the nearest excluded position is one of the two bracketing neighbours, giving **O(n_centers) memory** and O(n_centers·log n_excl) time.

## Why
A speed optimization must not trade a new O(n·m) intermediate for the gain (memory guard, ADR-0033). A per-function speed+peak-RSS audit found this was the one swept function whose vectorization materially grew peak memory.

## Result (measured)
- **Byte-identical** to the brute-force `min`-over-all-excludes (300 random cases).
- **Peak memory 6.5 MB → ~0 MB**; slightly faster than the matrix form.
- Window-sampler suite: 315 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)