### PR TITLE
perf(struct): share per-entry chain pick across encode_pdb encoders — byte-identical (#201)

### DIFF
--- a/aaanalysis/data_handling_pro/_backend/struct_preproc/encode_pdb.py
+++ b/aaanalysis/data_handling_pro/_backend/struct_preproc/encode_pdb.py
@@ -93,6 +93,13 @@ def _pick_best_chain_records(target_seq: str, chains):
 def _resolve_best_chain(structure, sequence: str):
     """Collect chains and pick the best-matching one **once** per entry.
 
+    "Best-matching" means the chain whose ATOM-record residue sequence has the
+    highest **identity fraction** to the target ``sequence`` — i.e. the number
+    of matched (non-gap) positions in the global alignment of the two, divided
+    by ``len(sequence)`` (see :func:`_identity_fraction`). Ties are broken by
+    chain order (the first chain reaching the maximum wins). This is the chain
+    every encoder aligns against and reads per-residue values from.
+
     ``_collect_chain_residues`` + ``_pick_best_chain_records`` are pure,
     deterministic functions of ``(structure, sequence)``, so the result can be
     computed once and shared across every encoder for the same entry instead of

--- a/aaanalysis/data_handling_pro/_backend/struct_preproc/encode_pdb.py
+++ b/aaanalysis/data_handling_pro/_backend/struct_preproc/encode_pdb.py
@@ -90,6 +90,23 @@ def _pick_best_chain_records(target_seq: str, chains):
     return chain, residues, atom_seq, best_score
 
 
+def _resolve_best_chain(structure, sequence: str):
+    """Collect chains and pick the best-matching one **once** per entry.
+
+    ``_collect_chain_residues`` + ``_pick_best_chain_records`` are pure,
+    deterministic functions of ``(structure, sequence)``, so the result can be
+    computed once and shared across every encoder for the same entry instead of
+    re-walking the structure (and rebuilding each chain's atom sequence) ~13x.
+    Returns ``(chain, residues, atom_seq, identity)``; ``chain`` is ``None``
+    when the structure has no amino-acid chains — the encoders map that to an
+    all-NaN block with identity 0.0, collapsing the former ``not chains`` and
+    ``chain is None`` early-returns into one check."""
+    chains = _collect_chain_residues(structure)
+    if not chains:
+        return None, None, None, 0.0
+    return _pick_best_chain_records(sequence, chains)
+
+
 def _align_atom_values_to_target(target_seq: str,
                                  atom_seq: str,
                                  atom_values: List[float]) -> List[float]:
@@ -125,8 +142,14 @@ def load_structure(pdb_path):
     return parser.get_structure("s", str(pdb_path))
 
 
-def encode_bfactor(structure, sequence: str) -> Tuple[np.ndarray, float]:
+def encode_bfactor(structure, sequence: str, chain_pick=None
+                   ) -> Tuple[np.ndarray, float]:
     """Per-residue mean B-factor as ``(L, 1)`` ndarray, aligned to ``sequence``.
+
+    ``chain_pick`` optionally supplies a precomputed
+    ``(chain, residues, atom_seq, identity)`` from :func:`_resolve_best_chain`
+    so all encoders for one entry share a single chain walk + best-chain pick;
+    recomputed when omitted. Output is identical either way.
 
     Returns
     -------
@@ -137,11 +160,9 @@ def encode_bfactor(structure, sequence: str) -> Tuple[np.ndarray, float]:
         Identity fraction of the chosen chain vs. ``sequence`` — caller can
         use this for diagnostics.
     """
-    chains = _collect_chain_residues(structure)
-    if not chains:
-        return np.full((len(sequence), 1), np.nan), 0.0
-    chain, residues, atom_seq, identity = _pick_best_chain_records(sequence,
-                                                                   chains)
+    chain, residues, atom_seq, identity = (
+        chain_pick if chain_pick is not None
+        else _resolve_best_chain(structure, sequence))
     if chain is None:
         return np.full((len(sequence), 1), np.nan), 0.0
     atom_b: List[float] = []
@@ -156,18 +177,25 @@ def encode_bfactor(structure, sequence: str) -> Tuple[np.ndarray, float]:
     return normalize("bfactor", raw), identity
 
 
-def encode_depth(structure, sequence: str) -> Tuple[np.ndarray, float]:
+def encode_depth(structure, sequence: str, chain_pick=None
+                 ) -> Tuple[np.ndarray, float]:
     """Per-residue residue depth as ``(L, 1)`` ndarray, aligned to ``sequence``.
 
     Uses :class:`Bio.PDB.ResidueDepth.ResidueDepth`, which shells out to the
     external ``msms`` binary. The caller is expected to have verified that
     ``msms`` is on PATH via :func:`_extras.check_msms_available` before
     reaching this function.
+
+    ``chain_pick`` optionally supplies a precomputed
+    ``(chain, residues, atom_seq, identity)`` (see :func:`encode_bfactor`);
+    recomputed when omitted.
     """
     check_msms_available()
     from Bio.PDB.ResidueDepth import ResidueDepth
-    chains = _collect_chain_residues(structure)
-    if not chains:
+    chain, residues, atom_seq, identity = (
+        chain_pick if chain_pick is not None
+        else _resolve_best_chain(structure, sequence))
+    if chain is None:
         return np.full((len(sequence), 1), np.nan), 0.0
     try:
         model = next(structure.get_models())
@@ -177,10 +205,6 @@ def encode_depth(structure, sequence: str) -> Tuple[np.ndarray, float]:
         rd = ResidueDepth(model)
     except Exception as e:
         raise RuntimeError(f"ResidueDepth failed (msms error?): {e}") from e
-    chain, residues, atom_seq, identity = _pick_best_chain_records(sequence,
-                                                                   chains)
-    if chain is None:
-        return np.full((len(sequence), 1), np.nan), 0.0
     atom_depth: List[float] = []
     for residue, key in residues:
         try:
@@ -194,19 +218,21 @@ def encode_depth(structure, sequence: str) -> Tuple[np.ndarray, float]:
 
 
 # --- AF model-file encoders (commit 2) ---------------------------------------
-def _plddt_per_residue(structure, sequence: str):
+def _plddt_per_residue(structure, sequence: str, chain_pick=None):
     """Shared CA-B-factor read used by all three pLDDT keys.
 
     AlphaFold stores pLDDT (0–100) in the B-factor column of model PDB / CIF
     files. We read the CA-atom B-factor (preferred when available; falls
     back to mean over all atoms in the residue) which is consistent with the
     AF-DB confidence convention. Returns (aligned values list, identity).
+
+    ``chain_pick`` optionally supplies a precomputed
+    ``(chain, residues, atom_seq, identity)`` (see :func:`encode_bfactor`);
+    recomputed when omitted.
     """
-    chains = _collect_chain_residues(structure)
-    if not chains:
-        return None, 0.0
-    chain, residues, atom_seq, identity = _pick_best_chain_records(
-        sequence, chains)
+    chain, residues, atom_seq, identity = (
+        chain_pick if chain_pick is not None
+        else _resolve_best_chain(structure, sequence))
     if chain is None:
         return None, 0.0
     atom_plddt: List[float] = []
@@ -228,15 +254,18 @@ def _plddt_per_residue(structure, sequence: str):
     return aligned, identity
 
 
-def encode_plddt(structure, sequence: str, plddt=None) -> Tuple[np.ndarray, float]:
+def encode_plddt(structure, sequence: str, plddt=None, chain_pick=None
+                 ) -> Tuple[np.ndarray, float]:
     """Per-residue pLDDT (AF B-factor column) as ``(L, 1)``, ``[0, 1]``.
 
     ``plddt`` optionally supplies a precomputed ``(aligned, identity)`` pair
     from :func:`_plddt_per_residue` so the three pLDDT encoders share one
     structure walk + alignment per entry; recomputed when omitted. Output is
-    identical either way.
+    identical either way. ``chain_pick`` (see :func:`encode_bfactor`) is used
+    only when ``plddt`` is omitted.
     """
-    aligned, identity = _plddt_per_residue(structure, sequence) if plddt is None else plddt
+    aligned, identity = (_plddt_per_residue(structure, sequence, chain_pick)
+                         if plddt is None else plddt)
     if aligned is None:
         return np.full((len(sequence), 1), np.nan), 0.0
     raw = np.asarray(aligned, dtype=np.float64).reshape(-1, 1)
@@ -246,13 +275,16 @@ def encode_plddt(structure, sequence: str, plddt=None) -> Tuple[np.ndarray, floa
 def encode_plddt_disorder(structure, sequence: str,
                           threshold: float = 70.0,
                           plddt=None,
+                          chain_pick=None,
                           ) -> Tuple[np.ndarray, float]:
     """Boolean ``pLDDT < threshold`` as ``(L, 1)``, ``{0, 1}``.
 
     ``plddt`` optionally supplies a precomputed ``(aligned, identity)`` pair
-    (see :func:`encode_plddt`); recomputed when omitted.
+    (see :func:`encode_plddt`); recomputed when omitted. ``chain_pick`` (see
+    :func:`encode_bfactor`) is used only when ``plddt`` is omitted.
     """
-    aligned, identity = _plddt_per_residue(structure, sequence) if plddt is None else plddt
+    aligned, identity = (_plddt_per_residue(structure, sequence, chain_pick)
+                         if plddt is None else plddt)
     if aligned is None:
         return np.full((len(sequence), 1), np.nan), 0.0
     arr = np.asarray(aligned, dtype=np.float64)
@@ -261,7 +293,7 @@ def encode_plddt_disorder(structure, sequence: str,
     return normalize("plddt_disorder", out.reshape(-1, 1)), identity
 
 
-def encode_plddt_tier(structure, sequence: str, plddt=None
+def encode_plddt_tier(structure, sequence: str, plddt=None, chain_pick=None
                       ) -> Tuple[np.ndarray, float]:
     """Per-residue pLDDT tier one-hot ``[<50, 50-70, 70-90, ≥90]`` as ``(L, 4)``.
 
@@ -269,9 +301,11 @@ def encode_plddt_tier(structure, sequence: str, plddt=None
       very_low <50, low 50-70, confident 70-90, very_high ≥90.
 
     ``plddt`` optionally supplies a precomputed ``(aligned, identity)`` pair
-    (see :func:`encode_plddt`); recomputed when omitted.
+    (see :func:`encode_plddt`); recomputed when omitted. ``chain_pick`` (see
+    :func:`encode_bfactor`) is used only when ``plddt`` is omitted.
     """
-    aligned, identity = _plddt_per_residue(structure, sequence) if plddt is None else plddt
+    aligned, identity = (_plddt_per_residue(structure, sequence, chain_pick)
+                         if plddt is None else plddt)
     if aligned is None:
         return np.full((len(sequence), 4), np.nan), 0.0
     arr = np.asarray(aligned, dtype=np.float64)
@@ -316,13 +350,12 @@ def _chi_sincos_for_residue(residue, chi_index: int):
 
 
 def _encode_chi_sincos(structure, sequence: str, chi_index: int,
-                       feature_key: str) -> Tuple[np.ndarray, float]:
+                       feature_key: str, chain_pick=None
+                       ) -> Tuple[np.ndarray, float]:
     """Shared chi1 / chi2 backbone for the two registry keys."""
-    chains = _collect_chain_residues(structure)
-    if not chains:
-        return np.full((len(sequence), 2), np.nan), 0.0
-    chain, residues, atom_seq, identity = _pick_best_chain_records(
-        sequence, chains)
+    chain, residues, atom_seq, identity = (
+        chain_pick if chain_pick is not None
+        else _resolve_best_chain(structure, sequence))
     if chain is None:
         return np.full((len(sequence), 2), np.nan), 0.0
     # Initialise internal coordinates on the chain (idempotent).
@@ -343,25 +376,30 @@ def _encode_chi_sincos(structure, sequence: str, chi_index: int,
     return normalize(feature_key, raw), identity
 
 
-def encode_chi1_sincos(structure, sequence: str
+def encode_chi1_sincos(structure, sequence: str, chain_pick=None
                        ) -> Tuple[np.ndarray, float]:
     """sin/cos of chi1 per residue as ``(L, 2)``, ``[0, 1]``."""
-    return _encode_chi_sincos(structure, sequence, 1, "chi1_sincos")
+    return _encode_chi_sincos(structure, sequence, 1, "chi1_sincos",
+                              chain_pick=chain_pick)
 
 
-def encode_chi2_sincos(structure, sequence: str
+def encode_chi2_sincos(structure, sequence: str, chain_pick=None
                        ) -> Tuple[np.ndarray, float]:
     """sin/cos of chi2 per residue as ``(L, 2)``, ``[0, 1]``."""
-    return _encode_chi_sincos(structure, sequence, 2, "chi2_sincos")
+    return _encode_chi_sincos(structure, sequence, 2, "chi2_sincos",
+                              chain_pick=chain_pick)
 
 
-def _ca_coords_and_residues(structure, sequence: str):
-    """Pick best chain and return (CA coordinates ndarray, residues, atom_seq, identity)."""
-    chains = _collect_chain_residues(structure)
-    if not chains:
-        return None, None, None, 0.0
-    chain, residues, atom_seq, identity = _pick_best_chain_records(
-        sequence, chains)
+def _ca_coords_and_residues(structure, sequence: str, chain_pick=None):
+    """Pick best chain; return (CA coords ndarray, residues, atom_seq, identity).
+
+    ``chain_pick`` optionally supplies a precomputed
+    ``(chain, residues, atom_seq, identity)`` (see :func:`encode_bfactor`);
+    recomputed when omitted.
+    """
+    chain, residues, atom_seq, identity = (
+        chain_pick if chain_pick is not None
+        else _resolve_best_chain(structure, sequence))
     if chain is None:
         return None, None, None, 0.0
     ca_coords: List[np.ndarray] = []
@@ -379,11 +417,11 @@ def _ca_coords_and_residues(structure, sequence: str):
     return coords, residues, atom_seq, identity
 
 
-def encode_ca_centroid_dist(structure, sequence: str
+def encode_ca_centroid_dist(structure, sequence: str, chain_pick=None
                             ) -> Tuple[np.ndarray, float]:
     """Per-residue ``||CA - centroid(CA)||`` as ``(L, 1)``, ``[0, 1]``."""
     coords, _residues, atom_seq, identity = _ca_coords_and_residues(
-        structure, sequence)
+        structure, sequence, chain_pick=chain_pick)
     if coords is None or len(coords) == 0:
         return np.full((len(sequence), 1), np.nan), 0.0
     finite = coords[~np.isnan(coords).any(axis=1)]
@@ -396,7 +434,7 @@ def encode_ca_centroid_dist(structure, sequence: str
     return normalize("ca_centroid_dist", raw), identity
 
 
-def encode_ca_centroid_dist_norm(structure, sequence: str
+def encode_ca_centroid_dist_norm(structure, sequence: str, chain_pick=None
                                   ) -> Tuple[np.ndarray, float]:
     """Per-residue ``||CA - centroid|| / Rg`` as ``(L, 1)``, ``[0, 1]``.
 
@@ -405,7 +443,7 @@ def encode_ca_centroid_dist_norm(structure, sequence: str
     inputs yield NaN.
     """
     coords, _residues, atom_seq, identity = _ca_coords_and_residues(
-        structure, sequence)
+        structure, sequence, chain_pick=chain_pick)
     if coords is None or len(coords) == 0:
         return np.full((len(sequence), 1), np.nan), 0.0
     finite = coords[~np.isnan(coords).any(axis=1)]
@@ -423,11 +461,11 @@ def encode_ca_centroid_dist_norm(structure, sequence: str
 
 
 def _encode_contact_count(structure, sequence: str, radius_A: float,
-                          min_seq_sep: int, feature_key: str
+                          min_seq_sep: int, feature_key: str, chain_pick=None
                           ) -> Tuple[np.ndarray, float]:
     """Shared CA-CA contact-count backbone for the two radius variants."""
     coords, _residues, atom_seq, identity = _ca_coords_and_residues(
-        structure, sequence)
+        structure, sequence, chain_pick=chain_pick)
     if coords is None or len(coords) == 0:
         return np.full((len(sequence), 1), np.nan), 0.0
     n = len(coords)
@@ -451,23 +489,26 @@ def _encode_contact_count(structure, sequence: str, radius_A: float,
     return normalize(feature_key, raw), identity
 
 
-def encode_contact_count_8A(structure, sequence: str
+def encode_contact_count_8A(structure, sequence: str, chain_pick=None
                             ) -> Tuple[np.ndarray, float]:
     """Per-residue CA-CA contacts within 8 Å, seq-sep ≥ 5; ``(L, 1)`` in ``[0, 1]``."""
     return _encode_contact_count(structure, sequence,
                                  radius_A=8.0, min_seq_sep=5,
-                                 feature_key="contact_count_8A")
+                                 feature_key="contact_count_8A",
+                                 chain_pick=chain_pick)
 
 
-def encode_contact_count_12A(structure, sequence: str
+def encode_contact_count_12A(structure, sequence: str, chain_pick=None
                              ) -> Tuple[np.ndarray, float]:
     """Per-residue CA-CA contacts within 12 Å, seq-sep ≥ 5; ``(L, 1)`` in ``[0, 1]``."""
     return _encode_contact_count(structure, sequence,
                                  radius_A=12.0, min_seq_sep=5,
-                                 feature_key="contact_count_12A")
+                                 feature_key="contact_count_12A",
+                                 chain_pick=chain_pick)
 
 
-def encode_hse(structure, sequence: str) -> Tuple[np.ndarray, float]:
+def encode_hse(structure, sequence: str, chain_pick=None
+               ) -> Tuple[np.ndarray, float]:
     """Per-residue half-sphere exposure (HSE-Cα) as ``(L, 2)`` in ``[0, 1]``.
 
     Uses :class:`Bio.PDB.HSExposure.HSExposureCA` with the standard 13 Å
@@ -480,10 +521,16 @@ def encode_hse(structure, sequence: str) -> Tuple[np.ndarray, float]:
     Counts are normalized by the registry recipe ``clip(x / 30, 0, 1)``;
     real counts above 30 are rare (typical 13 Å sphere holds 10-20
     neighbors).
+
+    ``chain_pick`` optionally supplies a precomputed
+    ``(chain, residues, atom_seq, identity)`` (see :func:`encode_bfactor`);
+    recomputed when omitted.
     """
     from Bio.PDB.HSExposure import HSExposureCA
-    chains = _collect_chain_residues(structure)
-    if not chains:
+    chain, residues, atom_seq, identity = (
+        chain_pick if chain_pick is not None
+        else _resolve_best_chain(structure, sequence))
+    if chain is None:
         return np.full((len(sequence), 2), np.nan), 0.0
     try:
         model = next(structure.get_models())
@@ -493,10 +540,6 @@ def encode_hse(structure, sequence: str) -> Tuple[np.ndarray, float]:
         HSExposureCA(model, radius=13.0)
     except Exception as e:
         raise RuntimeError(f"HSExposureCA failed: {e}") from e
-    chain, residues, atom_seq, identity = _pick_best_chain_records(
-        sequence, chains)
-    if chain is None:
-        return np.full((len(sequence), 2), np.nan), 0.0
     atom_up: List[float] = []
     atom_down: List[float] = []
     for residue, _ in residues:
@@ -512,7 +555,7 @@ def encode_hse(structure, sequence: str) -> Tuple[np.ndarray, float]:
 
 
 # --- Disulfide-bond encoder (v1.2) -------------------------------------------
-def encode_disulfide(structure, sequence: str
+def encode_disulfide(structure, sequence: str, chain_pick=None
                      ) -> Tuple[np.ndarray, float]:
     """Per-residue disulfide bond as ``(L, 2)``: [participates, partner_distance].
 
@@ -529,12 +572,14 @@ def encode_disulfide(structure, sequence: str
     Both columns are normalized by the registry's `disulfide` recipe to
     `[0, 1]`: the participates dim is identity (already boolean), and the
     distance dim is `clip(x / 5, 0, 1)` (5 Å as a generous upper bound).
+
+    ``chain_pick`` optionally supplies a precomputed
+    ``(chain, residues, atom_seq, identity)`` (see :func:`encode_bfactor`);
+    recomputed when omitted.
     """
-    chains = _collect_chain_residues(structure)
-    if not chains:
-        return np.full((len(sequence), 2), np.nan), 0.0
-    chain, residues, atom_seq, identity = _pick_best_chain_records(
-        sequence, chains)
+    chain, residues, atom_seq, identity = (
+        chain_pick if chain_pick is not None
+        else _resolve_best_chain(structure, sequence))
     if chain is None:
         return np.full((len(sequence), 2), np.nan), 0.0
     # Build per-residue SG coordinates (NaN rows for non-CYS / missing SG).

--- a/aaanalysis/data_handling_pro/_struct_preproc.py
+++ b/aaanalysis/data_handling_pro/_struct_preproc.py
@@ -37,7 +37,7 @@ from ._backend.struct_preproc.encode_dssp import (
 from ._backend.struct_preproc.encode_pdb import (
     load_structure, encode_bfactor, encode_depth,
     encode_plddt, encode_plddt_disorder, encode_plddt_tier,
-    _plddt_per_residue,
+    _plddt_per_residue, _resolve_best_chain,
     encode_chi1_sincos, encode_chi2_sincos,
     encode_ca_centroid_dist, encode_ca_centroid_dist_norm,
     encode_contact_count_8A, encode_contact_count_12A,
@@ -1033,30 +1033,45 @@ class StructurePreprocessor:
                 continue
             blocks: List[np.ndarray] = []
             entry_ok = True
-            # Compute the per-residue pLDDT (structure walk + alignment) at
-            # most ONCE per entry and reuse it across the pLDDT keys. It is
-            # computed lazily inside the per-key ``try`` below (not hoisted
-            # here) so that a RuntimeError degrades just this row
-            # (pdb_ok=False) exactly as when each encoder computed it
-            # internally — hoisting it out of the try would let the error
-            # abort the whole encode_pdb call instead of the single entry.
+            # Collect the structure's amino-acid chains and pick the best match
+            # for this sequence at most ONCE per entry, then share that
+            # (chain, residues, atom_seq, identity) across every encoder rather
+            # than re-walking the structure ~13x. The pick is a deterministic
+            # function of (structure, seq), so sharing is byte-identical to
+            # per-encoder recompute. Computed lazily inside the per-key ``try``
+            # below (not hoisted here) so a RuntimeError degrades just this row
+            # (pdb_ok=False) exactly as when each encoder resolved it
+            # internally — hoisting it out of the try would let the error abort
+            # the whole encode_pdb call instead of the single entry.
+            chain_pick = None
+            chain_pick_done = False
+            # The per-residue pLDDT read (structure walk + alignment) is shared
+            # across the three pLDDT keys, computed at most once per entry, with
+            # the same per-entry error-envelope rationale.
             plddt_shared = None
             plddt_done = False
             for key in features:
                 try:
+                    if not chain_pick_done:
+                        chain_pick = _resolve_best_chain(structure, seq)
+                        chain_pick_done = True
                     if key == "bfactor":
-                        block, identity = encode_bfactor(structure, seq)
+                        block, identity = encode_bfactor(
+                            structure, seq, chain_pick=chain_pick)
                     elif key == "depth":
-                        block, identity = encode_depth(structure, seq)
+                        block, identity = encode_depth(
+                            structure, seq, chain_pick=chain_pick)
                     elif key == "plddt":
                         if not plddt_done:
-                            plddt_shared = _plddt_per_residue(structure, seq)
+                            plddt_shared = _plddt_per_residue(
+                                structure, seq, chain_pick)
                             plddt_done = True
                         block, identity = encode_plddt(structure, seq,
                                                        plddt=plddt_shared)
                     elif key == "plddt_disorder":
                         if not plddt_done:
-                            plddt_shared = _plddt_per_residue(structure, seq)
+                            plddt_shared = _plddt_per_residue(
+                                structure, seq, chain_pick)
                             plddt_done = True
                         block, identity = encode_plddt_disorder(
                             structure, seq,
@@ -1064,31 +1079,35 @@ class StructurePreprocessor:
                             plddt=plddt_shared)
                     elif key == "plddt_tier":
                         if not plddt_done:
-                            plddt_shared = _plddt_per_residue(structure, seq)
+                            plddt_shared = _plddt_per_residue(
+                                structure, seq, chain_pick)
                             plddt_done = True
                         block, identity = encode_plddt_tier(
                             structure, seq, plddt=plddt_shared)
                     elif key == "chi1_sincos":
-                        block, identity = encode_chi1_sincos(structure, seq)
+                        block, identity = encode_chi1_sincos(
+                            structure, seq, chain_pick=chain_pick)
                     elif key == "chi2_sincos":
-                        block, identity = encode_chi2_sincos(structure, seq)
+                        block, identity = encode_chi2_sincos(
+                            structure, seq, chain_pick=chain_pick)
                     elif key == "ca_centroid_dist":
                         block, identity = encode_ca_centroid_dist(
-                            structure, seq)
+                            structure, seq, chain_pick=chain_pick)
                     elif key == "ca_centroid_dist_norm":
                         block, identity = encode_ca_centroid_dist_norm(
-                            structure, seq)
+                            structure, seq, chain_pick=chain_pick)
                     elif key == "contact_count_8A":
                         block, identity = encode_contact_count_8A(
-                            structure, seq)
+                            structure, seq, chain_pick=chain_pick)
                     elif key == "contact_count_12A":
                         block, identity = encode_contact_count_12A(
-                            structure, seq)
+                            structure, seq, chain_pick=chain_pick)
                     elif key == "hse":
-                        block, identity = encode_hse(structure, seq)
+                        block, identity = encode_hse(
+                            structure, seq, chain_pick=chain_pick)
                     elif key == "disulfide":
                         block, identity = encode_disulfide(
-                            structure, seq)
+                            structure, seq, chain_pick=chain_pick)
                     else:
                         raise RuntimeError(
                             f"Internal: feature key {key!r} not in "

--- a/docs/source/index/release_notes.rst
+++ b/docs/source/index/release_notes.rst
@@ -224,7 +224,13 @@ Changed
   single session-scoped ``PairwiseAligner`` across all entries (and across the
   chain-pick, mismatch-count and feature-align steps) rather than constructing
   three fresh aligners per entry. Identity fractions and alignments are
-  byte-identical in every case.
+  byte-identical in every case. Completing this sharing, ``encode_pdb`` now
+  collects the structure's amino-acid chains and picks the best-matching chain
+  **once per entry** and threads that result through every requested encoder,
+  rather than re-walking the structure (and rebuilding each chain's atom
+  sequence) once per feature — up to ~13 redundant walks collapsed to one. The
+  pick is a deterministic function of the structure and target sequence, so the
+  shared and per-encoder results are byte-identical.
   A further "Batch 6" pass replaces two more hotspots in place with
   byte-identical implementations: ``AAMut.comp_substitution_impact`` now
   accumulates the per-(from, to) delta columns and builds a single DataFrame

--- a/tests/unit/data_handling_pro_tests/test_struct_chain_cache_equiv.py
+++ b/tests/unit/data_handling_pro_tests/test_struct_chain_cache_equiv.py
@@ -1,0 +1,114 @@
+"""Equivalence test for the encode_pdb shared per-entry chain pick (#201, the
+last same-output T1 tail of #186).
+
+Every encoder re-walked the structure to collect amino-acid chain residues
+(``_collect_chain_residues``) and rebuilt each chain's atom sequence to pick the
+best-matching chain (``_pick_best_chain_records``) — ~13x per entry. That pick is
+now computed once via ``_resolve_best_chain`` and threaded into each encoder as
+``chain_pick``. The pick is a deterministic function of ``(structure, sequence)``,
+so a shared pick must produce byte-identical output to each encoder recomputing
+it independently (``chain_pick=None``), which is the original behaviour.
+
+Mirrors ``test_struct_batch6_equiv.py`` section 3 (the pLDDT shared-vs-independent
+test) and the alignment-cache equivalence test. Encoders needing an external
+binary / heavy biopython surface tool (``depth``=msms, ``hse``=HSExposure,
+``chi``=internal coords) are excluded — the suite never runs those.
+"""
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import aaanalysis as aa
+from aaanalysis.data_handling_pro._backend.struct_preproc import encode_pdb as ep
+from aaanalysis.data_handling_pro._backend.struct_preproc.encode_pdb import (
+    load_structure, _collect_chain_residues, _residue_one_letter,
+    _resolve_best_chain)
+
+aa.options["verbose"] = False
+PDB_FIXTURES = Path(__file__).resolve().parents[3] / "aaanalysis" / "_data" / "pdb_test"
+
+# No-external-tool encoders (msms / HSExposure / internal coords excluded, as in
+# the alignment-cache equivalence suite). Each routes its chain pick through
+# ``chain_pick`` -> ``_resolve_best_chain``. The three pLDDT encoders accept the
+# pick via ``chain_pick`` only when their own ``plddt`` share is omitted.
+ENCODERS = [
+    ("bfactor", ep.encode_bfactor),
+    ("plddt", ep.encode_plddt),
+    ("plddt_disorder", ep.encode_plddt_disorder),
+    ("plddt_tier", ep.encode_plddt_tier),
+    ("ca_centroid_dist", ep.encode_ca_centroid_dist),
+    ("ca_centroid_dist_norm", ep.encode_ca_centroid_dist_norm),
+    ("contact_count_8A", ep.encode_contact_count_8A),
+    ("contact_count_12A", ep.encode_contact_count_12A),
+    ("disulfide", ep.encode_disulfide),
+]
+
+
+def _chain_seq(structure):
+    """Atom 1-letter sequence of the first chain (perfect-identity target)."""
+    from Bio.PDB.Polypeptide import protein_letters_3to1
+    chains = _collect_chain_residues(structure)
+    _c, residues = chains[0]
+    return "".join(_residue_one_letter(r, protein_letters_3to1)
+                   for r, _ in residues)
+
+
+@pytest.mark.parametrize("pdb,seq", [
+    ("P1.pdb", "ACDEFGHIKLMNPQRS"),
+    ("P2.pdb", "VLIMKRSTGADE"),
+    ("AF_TINY.pdb", None),    # use the structure's own CA sequence
+    ("SS_BOND.pdb", None),    # real disulfide -> non-trivial disulfide path
+])
+class TestChainPickEquivalence:
+    def _resolve_seq(self, structure, seq):
+        return seq if seq is not None else _chain_seq(structure)
+
+    def test_encoders_identical_shared_vs_independent(self, pdb, seq):
+        """Each encoder is byte-identical whether it resolves the chain pick
+        itself (``chain_pick=None``, the original behaviour) or receives one
+        shared pick computed once per entry."""
+        structure = load_structure(PDB_FIXTURES / pdb)
+        seq = self._resolve_seq(structure, seq)
+        # Independent: every encoder resolves its own chain pick.
+        ind = {name: enc(structure, seq) for name, enc in ENCODERS}
+        # Shared: compute the pick once, thread it into every encoder.
+        chain_pick = _resolve_best_chain(structure, seq)
+        shared = {name: enc(structure, seq, chain_pick=chain_pick)
+                  for name, enc in ENCODERS}
+        for name, _enc in ENCODERS:
+            np.testing.assert_array_equal(shared[name][0], ind[name][0])
+            assert shared[name][1] == ind[name][1]
+
+    def test_resolve_best_chain_matches_inline_collect_pick(self, pdb, seq):
+        """``_resolve_best_chain`` == the inline collect + pick it replaces."""
+        from aaanalysis.data_handling_pro._backend.struct_preproc.encode_pdb \
+            import _pick_best_chain_records
+        structure = load_structure(PDB_FIXTURES / pdb)
+        seq = self._resolve_seq(structure, seq)
+        chains = _collect_chain_residues(structure)
+        ref = _pick_best_chain_records(seq, chains) if chains \
+            else (None, None, None, 0.0)
+        got = _resolve_best_chain(structure, seq)
+        assert got[0] is ref[0]              # same chain object
+        assert got[2] == ref[2]              # same atom_seq
+        assert got[3] == ref[3]              # same identity fraction
+
+
+def test_resolve_best_chain_no_aa_chains_returns_none():
+    """A structure with no amino-acid chains yields (None, None, None, 0.0),
+    which every encoder maps to an all-NaN block at identity 0.0 — collapsing
+    the former ``not chains`` and ``chain is None`` early-returns into one."""
+
+    class _EmptyStructure:
+        def get_models(self):
+            return iter(())
+
+    chain, residues, atom_seq, identity = _resolve_best_chain(
+        _EmptyStructure(), "ACDEF")
+    assert chain is None and residues is None and atom_seq is None
+    assert identity == 0.0
+    # An encoder handed that pick returns the all-NaN block, identity 0.0.
+    arr, ident = ep.encode_bfactor(_EmptyStructure(), "ACDEF",
+                                   chain_pick=(None, None, None, 0.0))
+    assert arr.shape == (5, 1) and np.isnan(arr).all() and ident == 0.0

--- a/tests/unit/data_handling_pro_tests/test_structure_preprocessor_edges.py
+++ b/tests/unit/data_handling_pro_tests/test_structure_preprocessor_edges.py
@@ -103,7 +103,12 @@ class TestEncodePdbEdges:
     def test_encoder_fail_sets_not_ok(self, tmp_path):
         (tmp_path / "P1.pdb").write_text("x")
         stp = aa.StructurePreprocessor(verbose=False)
+        # The shared per-entry chain pick runs in the frontend before the
+        # encoders, so stub it (the dummy structure is never really walked);
+        # the encoder still raises to exercise the row-degrade path.
         with patch(f"{MODULE}.load_structure", return_value=object()), \
+             patch(f"{MODULE}._resolve_best_chain",
+                   return_value=(None, None, None, 0.0)), \
              patch(f"{MODULE}.encode_bfactor", side_effect=RuntimeError("enc boom")):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
@@ -136,6 +141,8 @@ class TestEncodePdbEdges:
         import numpy as np
         stp = aa.StructurePreprocessor(verbose=True)
         with patch(f"{MODULE}.load_structure", return_value=object()), \
+             patch(f"{MODULE}._resolve_best_chain",
+                   return_value=(None, None, None, 0.0)), \
              patch(f"{MODULE}.encode_bfactor",
                    return_value=(np.zeros((9, 1)), 1.0)):
             stp.encode_pdb(df_seq=_df_one(), pdb_folder=str(tmp_path),


### PR DESCRIPTION
Closes #201 — the last open same-output (T1) tail of #186.

## Problem
`encode_pdb` runs ~13 per-residue encoders per structure. Each encoder independently re-walked the structure to collect amino-acid chain residues (`_collect_chain_residues`) and rebuilt each chain's atom sequence to pick the best-matching chain (`_pick_best_chain_records`). The #183 alignment cache covered only the O(L²) aligner, **not** this structure-walk + chain-pick — the #186 triage measured ~12× redundancy off it.

## Change (T1 — byte-identical, ADR-0032)
- **Backend** (`_backend/struct_preproc/encode_pdb.py`): add `_resolve_best_chain` (collect + best-chain pick, collapsing the former `not chains` / `chain is None` early-returns into one) and thread an optional `chain_pick` through every encoder + shared helper (`_plddt_per_residue`, `_encode_chi_sincos`, `_ca_coords_and_residues`, `_encode_contact_count`). `encode_depth` / `encode_hse` keep their ordering (resolve → `chain is None` short-circuit → external tool), so an empty structure still returns NaN rather than erroring.
- **Frontend** (`_struct_preproc.py`): the pick is computed **once per entry**, lazily inside the existing per-feature `try/except` (mirroring the #194 pLDDT precedent already in the dispatch loop). A `RuntimeError` during resolution degrades just that row (`pdb_ok=False`) with the identical `"PDB encoder '<key>' failed"` message; a non-`RuntimeError` propagates exactly as before — **byte-identical output AND error envelope**.

The pick is a deterministic function of `(structure, sequence)`; the external tools mutate `residue.xtra` / internal coords but never chain membership or resnames, so a once-computed pick equals every per-encoder recompute.

## Equivalence (committed test)
`tests/unit/data_handling_pro_tests/test_struct_chain_cache_equiv.py` pins each no-external-tool encoder byte-identical **shared-vs-independent** on **P1 / P2 / AF_TINY / SS_BOND** (36 checks), plus `_resolve_best_chain == inline collect+pick` and the empty-structure → `(None, …)` path.

## Benchmark (measured in isolation — audit %s are unreliable)
- The redundant per-encoder structure walk + chain pick is removed **N → 1 per entry** (N = requested PDB features, up to 13) — this *is* the "~12×", i.e. the **walk-redundancy factor**.
- **End-to-end** `encode_pdb` gain is **modest and feature-mix-dependent** (the per-residue value extraction, notably the two O(n²) contact-count encoders, dominates; #183 already cached the costly alignment leg). This lands as a **same-output structural-redundancy removal**, not a headline wall-clock speedup.

Per ADR-0032, T1 requires no nightly regression anchor; the committed equivalence test + existing parity suite suffice.

## Tier checklist (ADR-0032 / CONTRIBUTING)
- [x] Tier declared: **T1 — byte-identical**
- [x] Validation harness (gitignored `dev_scripts/perf_encode_pdb_chaincache_validate.py`) + committed equivalence test
- [x] One optimization per PR
- [x] Local gates green: full fast unit gate (4542 passed / 12 skipped), `data_handling_pro` + param-coverage + backend-hygiene (818 passed), docs build OK, CI lint subset clean, no new flake8-88 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)