### PR TITLE
docs(adr-0032): record AAclust binary-search k measured-but-not-implemented (#200)

### DIFF
--- a/docs/adr/0032-numerical-equivalence-tolerance-policy.md
+++ b/docs/adr/0032-numerical-equivalence-tolerance-policy.md
@@ -91,6 +91,18 @@ reviewer acceptance checklist lives in `CONTRIBUTING.rst` (and the
 
 - The excluded queue (AAclust binary-search `k`, sparse one-hot, `ShapModel`
   rolling aggregation) is unblocked, each as its own tier-declared PR (D4).
+- **Measured outcome — AAclust binary-search `k` (#200): not implemented.** The
+  flagship T3 candidate above was built as an opt-in stage-2 bisection and
+  benchmarked against the exhaustive default on the canonical cell
+  (`load_scales().T`, seed 42) plus a size/threshold/seed sweep. It is
+  *statistically equivalent* (canonical cell identical; |Δk|/k median 0, medoid
+  Jaccard median 1.0) but **not faster** — median ≈ −5 %, 66 % slower on the
+  canonical cell — because KMeans cost grows with `k` and bisection probes
+  expensive high-`k` midpoints, while stage 1's lower-bound estimate already
+  lands near the answer (so stage 2 covers only a short, cheap range). The
+  ~35–50 % audit estimate counted *evaluations* assuming flat per-eval cost.
+  Failing D1's benefit bar, it was closed unimplemented (the #188 outcome).
+  Evidence: gitignored `dev_scripts/perf_aaclust_ksearch_validate.py`.
 - The nightly accumulates one anchor per landed T2/T3 optimization alongside the
   ADR-0015 CPP anchor; all run on the canonical Linux/floor-Python cell and are
   re-frozen only on intentional, reviewed change.


### PR DESCRIPTION
## Summary

Records the **measured-but-not-implemented** outcome of the ADR-0032 flagship T3 candidate (AAclust binary-search `k`) directly in `docs/adr/0032-numerical-equivalence-tolerance-policy.md`, so the candidate is not re-attempted.

Context: #200 (now closed unimplemented). Docs-only — no code, no API, no behavior change.

## What was measured (in #200)

An opt-in `k_search="binary"` (pure bisection of the step-2 `optimize_n_clusters`, exhaustive default unchanged) was implemented and benchmarked against the exhaustive default on the canonical cell (`aa.load_scales().T`, `random_state=42`) plus a 27-case size/threshold/seed sweep. Harness: gitignored `dev_scripts/perf_aaclust_ksearch_validate.py`.

- **Equivalence — excellent:** canonical cell identical (Δk=0, ΔSC=0, medoid Jaccard=1.0, ARI=1.0); across all cases |Δk|/k median 0, |ΔSC| median 0, Jaccard median 1.0.
- **Speed — fails the KPI:** canonical cell **66% slower**; median **−5%**, range −127%…+9%; never ≥35% faster.
- **Root cause:** KMeans cost grows with `k`; bisection probes expensive high-`k` midpoints, while stage 1 already lands near the answer. The audit's ~35–50% estimate counted evaluations assuming flat per-eval cost.

Per ADR-0032 D1 (a change must be a real benchmarked win), it is statistically equivalent but not faster, so it does not ship — the #188 outcome.

## Ripple

- `docs/adr/0032-...md` Consequences — the note (this PR).
- No code / `__init__.py` / examples / tests touched (nothing shipped). The ADR Context section is left as the original historical record; the Consequences note corrects the estimate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
