### PR TITLE
feat(core): inherit Wrapper/Tool ABCs on model/tool classes (#134)

### DIFF
--- a/aaanalysis/explainable_ai/_tree_model.py
+++ b/aaanalysis/explainable_ai/_tree_model.py
@@ -9,6 +9,7 @@ import pandas as pd
 import numpy as np
 
 import aaanalysis.utils as ut
+from aaanalysis.template_classes import Wrapper
 
 from ._backend.check_models import (check_match_labels_X,
                                     check_match_X_is_selected)
@@ -137,10 +138,12 @@ def check_match_df_feat_feat_importance(df_feat=None, feat_importance=None):
 
 
 # II Main Functions
-class TreeModel:
+class TreeModel(Wrapper):
     """
     Tree Model class: A wrapper for tree-based models to obtain Monte Carlo estimates of feature
     importance and predictions [Breimann25a]_.
+
+    As a :class:`Wrapper`, it implements the ``.fit`` / ``.eval`` model contract.
 
     Monte Carlo estimates are derived by averaging feature importance or prediction probabilities across various
     tree-based models and training rounds, enhancing the robustness and reproducibility of these estimates.

--- a/aaanalysis/explainable_ai/_tree_model.py
+++ b/aaanalysis/explainable_ai/_tree_model.py
@@ -143,7 +143,7 @@ class TreeModel(Wrapper):
     Tree Model class: A wrapper for tree-based models to obtain Monte Carlo estimates of feature
     importance and predictions [Breimann25a]_.
 
-    As a :class:`Wrapper`, it implements the ``.fit`` / ``.eval`` model contract.
+    As a ``Wrapper``, it implements the ``.fit`` / ``.eval`` model contract.
 
     Monte Carlo estimates are derived by averaging feature importance or prediction probabilities across various
     tree-based models and training rounds, enhancing the robustness and reproducibility of these estimates.

--- a/aaanalysis/explainable_ai_pro/_shap_model.py
+++ b/aaanalysis/explainable_ai_pro/_shap_model.py
@@ -10,6 +10,7 @@ import warnings
 import shap
 
 import aaanalysis.utils as ut
+from aaanalysis.template_classes import Wrapper
 from ._backend.check_models import (check_match_labels_X,
                                     check_match_X_is_selected)
 from ._backend.shap_model.shap_model_fit import monte_carlo_shap_estimation
@@ -325,11 +326,13 @@ def check_match_df_feat_shap_values(df_feat=None, shap_values=None, drop=False, 
 
 
 # II Main Functions
-class ShapModel:
+class ShapModel(Wrapper):
     """
     SHAP Model class (**[pro]**, requires ``aaanalysis[pro]``): A wrapper for SHAP
     (SHapley Additive exPlanations) [Lundberg20]_ explainers to obtain Monte Carlo
     estimates for feature impact [Breimann25a]_.
+
+    As a :class:`Wrapper`, it implements the ``.fit`` / ``.eval`` model contract.
 
     `SHAP <https://shap.readthedocs.io/en/latest/index.html>`_ is an explainable Artificial Intelligence (AI) framework
     and game-theoretic approach to explain the output of any machine learning model using SHAP values. These SHAP values

--- a/aaanalysis/explainable_ai_pro/_shap_model.py
+++ b/aaanalysis/explainable_ai_pro/_shap_model.py
@@ -332,7 +332,7 @@ class ShapModel(Wrapper):
     (SHapley Additive exPlanations) [Lundberg20]_ explainers to obtain Monte Carlo
     estimates for feature impact [Breimann25a]_.
 
-    As a :class:`Wrapper`, it implements the ``.fit`` / ``.eval`` model contract.
+    As a ``Wrapper``, it implements the ``.fit`` / ``.eval`` model contract.
 
     `SHAP <https://shap.readthedocs.io/en/latest/index.html>`_ is an explainable Artificial Intelligence (AI) framework
     and game-theoretic approach to explain the output of any machine learning model using SHAP values. These SHAP values

--- a/aaanalysis/protein_design/_aamut.py
+++ b/aaanalysis/protein_design/_aamut.py
@@ -6,6 +6,7 @@ from typing import Optional, List, Union
 import pandas as pd
 
 import aaanalysis.utils as ut
+from aaanalysis.template_classes import Tool
 from ._backend.aamut.aamut import comp_substitution_impact, eval_substitution_impact
 
 
@@ -46,10 +47,12 @@ def check_scales_subset(scales=None, df_scales=None):
 
 
 # II Main Functions
-class AAMut:
+class AAMut(Tool):
     """
     Amino Acid Mutator (AAMut) class for analyzing the physicochemical impact of amino acid
     substitutions on property scales [Breimann24a]_.
+
+    As a :class:`Tool`, it implements the ``.run`` / ``.eval`` pipeline contract.
 
     ``AAMut`` is **CPP-agnostic**: it quantifies how substituting one amino acid for another
     shifts each physicochemical scale value, independent of any sequence or prediction task.

--- a/aaanalysis/protein_design/_aamut.py
+++ b/aaanalysis/protein_design/_aamut.py
@@ -52,7 +52,7 @@ class AAMut(Tool):
     Amino Acid Mutator (AAMut) class for analyzing the physicochemical impact of amino acid
     substitutions on property scales [Breimann24a]_.
 
-    As a :class:`Tool`, it implements the ``.run`` / ``.eval`` pipeline contract.
+    As a ``Tool``, it implements the ``.run`` / ``.eval`` pipeline contract.
 
     ``AAMut`` is **CPP-agnostic**: it quantifies how substituting one amino acid for another
     shifts each physicochemical scale value, independent of any sequence or prediction task.

--- a/aaanalysis/pu_learning/_dpulearn.py
+++ b/aaanalysis/pu_learning/_dpulearn.py
@@ -7,6 +7,7 @@ import pandas as pd
 from sklearn.decomposition import PCA
 
 import aaanalysis.utils as ut
+from aaanalysis.template_classes import Wrapper
 from ._backend.dpulearn.dpul_fit import (get_neg_via_distance, get_neg_via_pca)
 from ._backend.dpulearn.dpul_eval import eval_identified_negatives
 from ._backend.dpulearn.dpul_compare_sets_neg import compare_sets_negatives_
@@ -132,9 +133,11 @@ def check_match_X_X_neg(X=None, X_neg=None):
 
 
 # II Main Functions
-class dPULearn:
+class dPULearn(Wrapper):
     """
     Deterministic Positive-Unlabeled Learning (**dPULearn**) class for identifying reliable negatives from unlabeled data [Breimann25a]_.
+
+    As a :class:`Wrapper`, it implements the ``.fit`` / ``.eval`` model contract.
 
     dPULearn offers a deterministic approach to Positive-Unlabeled (PU) learning, featuring two distinct
     identification approaches:

--- a/aaanalysis/pu_learning/_dpulearn.py
+++ b/aaanalysis/pu_learning/_dpulearn.py
@@ -137,7 +137,7 @@ class dPULearn(Wrapper):
     """
     Deterministic Positive-Unlabeled Learning (**dPULearn**) class for identifying reliable negatives from unlabeled data [Breimann25a]_.
 
-    As a :class:`Wrapper`, it implements the ``.fit`` / ``.eval`` model contract.
+    As a ``Wrapper``, it implements the ``.fit`` / ``.eval`` model contract.
 
     dPULearn offers a deterministic approach to Positive-Unlabeled (PU) learning, featuring two distinct
     identification approaches:

--- a/aaanalysis/seq_analysis/_aa_window_sampler.py
+++ b/aaanalysis/seq_analysis/_aa_window_sampler.py
@@ -294,6 +294,7 @@ def _filter_aa_context(df_seq=None, aa_context_col=None, context_in=None, contex
 
 
 # II Main Function
+# Not a Wrapper/Tool: a sampler with sample_* methods, no .fit/.eval or .run/.eval contract.
 class AAWindowSampler:
     """
     Utility class for sampling amino-acid windows / segments from full protein sequences.

--- a/tests/unit/api_tests/test_template_inheritance.py
+++ b/tests/unit/api_tests/test_template_inheritance.py
@@ -1,0 +1,114 @@
+"""Meta-test enforcing the Wrapper/Tool template contract on the public API.
+
+``aaanalysis.template_classes`` defines two ABCs:
+
+* :class:`Wrapper` — the ``.fit`` / ``.eval`` model contract.
+* :class:`Tool` — the ``.run`` / ``.eval`` pipeline contract.
+
+Historically the "Wrapper"/"Tool" classification was only a documentation
+convention: some classes implemented the method set without inheriting the
+matching ABC, so ``isinstance`` / IDEs / type checkers could not verify it
+(issue #134). This test pins the contract: any public class that implements the
+full method set of an ABC must actually inherit that ABC.
+
+Keying:
+* ``.fit`` + ``.eval``  -> must be a :class:`Wrapper`.
+* ``.run`` + ``.eval``  -> must be a :class:`Tool`.
+
+Classes carrying only ``.eval`` (the ``*Plot`` pairs) or only one half of a
+pair (``SeqMut`` has ``.mutate``/``.scan``/``.suggest``/``.eval`` but no
+``.run``) are intentionally not bound by either contract and are skipped.
+Pro classes that degraded to a ``missing_feature_stub`` (a callable, not a
+class) when their optional dependency is absent are skipped by the
+``inspect.isclass`` filter.
+"""
+import inspect
+
+import pytest
+
+import aaanalysis as aa
+from aaanalysis.template_classes import Tool, Wrapper
+
+
+def _has(obj, method):
+    return callable(getattr(obj, method, None))
+
+
+def _public_classes():
+    """Yield (name, class) for every public class exported by aaanalysis."""
+    for name in aa.__all__:
+        obj = getattr(aa, name)
+        if inspect.isclass(obj):
+            yield name, obj
+
+
+WRAPPER_CLASSES = [
+    (name, cls)
+    for name, cls in _public_classes()
+    if _has(cls, "fit") and _has(cls, "eval")
+]
+TOOL_CLASSES = [
+    (name, cls)
+    for name, cls in _public_classes()
+    if _has(cls, "run") and _has(cls, "eval")
+]
+
+
+class TestTemplateInheritance:
+    """Every public class implementing an ABC's method set inherits that ABC."""
+
+    @pytest.mark.parametrize("name, cls", WRAPPER_CLASSES, ids=lambda x: x if isinstance(x, str) else "")
+    def test_fit_eval_classes_are_wrappers(self, name, cls):
+        assert issubclass(cls, Wrapper), (
+            f"'{name}' implements .fit/.eval but does not inherit Wrapper "
+            f"(template_classes.Wrapper); add the base."
+        )
+
+    @pytest.mark.parametrize("name, cls", TOOL_CLASSES, ids=lambda x: x if isinstance(x, str) else "")
+    def test_run_eval_classes_are_tools(self, name, cls):
+        assert issubclass(cls, Tool), (
+            f"'{name}' implements .run/.eval but does not inherit Tool "
+            f"(template_classes.Tool); add the base."
+        )
+
+    def test_some_wrapper_and_tool_classes_were_discovered(self):
+        # Guard against the discovery silently yielding nothing (e.g. import break).
+        wrapper_names = {name for name, _ in WRAPPER_CLASSES}
+        tool_names = {name for name, _ in TOOL_CLASSES}
+        assert {"AAclust", "dPULearn", "TreeModel"} <= wrapper_names
+        assert {"CPP", "CPPGrid", "AAMut"} <= tool_names
+
+
+class TestIssue134Acceptance:
+    """The exact isinstance KPIs from issue #134 hold True."""
+
+    def test_treemodel_is_wrapper(self):
+        assert isinstance(aa.TreeModel(), Wrapper)
+
+    def test_dpulearn_is_wrapper(self):
+        assert isinstance(aa.dPULearn(), Wrapper)
+
+    def test_shapmodel_is_wrapper(self):
+        if not inspect.isclass(aa.ShapModel):
+            pytest.skip("ShapModel is a missing-feature stub (aaanalysis[pro] not installed)")
+        assert isinstance(aa.ShapModel(), Wrapper)
+
+    def test_aamut_is_tool(self):
+        assert isinstance(aa.AAMut(), Tool)
+
+
+class TestSamplerNotBound:
+    """AAWindowSampler is a sampler, not a Wrapper/Tool: it must NOT be bound."""
+
+    def test_aa_window_sampler_is_not_wrapper_or_tool(self):
+        # It only exposes sample_* methods (no .fit/.eval or .run/.eval pair),
+        # so it is intentionally outside both contracts.
+        assert not issubclass(aa.AAWindowSampler, (Wrapper, Tool))
+
+    def test_seqmut_has_no_run_method(self):
+        # SeqMut implements mutate/scan/suggest/eval but no .run, so it does not
+        # satisfy the Tool ABC and is (correctly) not bound to it. Inheriting Tool
+        # would require adding a .run method (a behavior/API change, out of scope
+        # for the non-breaking #134).
+        assert not _has(aa.SeqMut, "run")
+        assert not issubclass(aa.SeqMut, Tool)


### PR DESCRIPTION
Implements the Wrapper/Tool template contract by inheritance (issue #134), run unattended as an overnight session lane.

## What changed
- `dPULearn`, `TreeModel`, `ShapModel` → inherit `Wrapper` (`.fit`/`.eval`)
- `AAMut` → inherits `Tool` (`.run`/`.eval`)
- `AAWindowSampler` left unbound (sampler, no contract pair) with an explanatory comment
- New meta-test `tests/unit/api_tests/test_template_inheritance.py` (14 tests) asserting the `isinstance` contract

Non-breaking: methods already existed; each class was verified to satisfy the ABC's abstract methods with no metaclass conflict. `template_classes.py` (CONFIRM-FIRST) was **not** touched. Combined suite: 554 passed.

## ⚠️ Needs a decision — SeqMut
The issue assumed `SeqMut` implements `.run`/`.eval`, but it actually exposes `mutate`/`scan`/`suggest`/`eval` — **there is no `.run`**. Binding it to `Tool` would be a behavioral API change (mapping one of those to `run`) and/or a `template_classes.py` edit, so it was **left unbound** and the meta-test asserts the as-is reality. Decide before merge: map a method to `run`, or accept SeqMut as a non-Tool.

Because of this, #134 is **not fully complete**. This PR body intentionally omits a closing keyword so the issue stays open — but note the squash commit message currently contains "Closes #134"; **strip it at merge** if you want #134 to remain open.

Refs #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)
