### PR TITLE
feat(cpp_plot): df_seq/entry + sample= on profile/feature_map (#127, #214)

### DIFF
--- a/aaanalysis/feature_engineering/_cpp_plot.py
+++ b/aaanalysis/feature_engineering/_cpp_plot.py
@@ -197,20 +197,22 @@ def get_sample_name(df_seq=None, sample=None):
     return entries[int(sample)]
 
 
-def resolve_col_imp_for_sample(df_feat=None, name=None, col_imp=None):
-    """Resolve the 'feat_impact_<name>' column for a sample-level SHAP plot.
+def resolve_col_imp_for_sample(df_feat=None, name=None):
+    """Resolve the 'feat_impact_<name>' column in ``df_feat`` for a sample-level SHAP plot.
 
-    If ``col_imp`` is already explicitly given it is returned unchanged; otherwise the
-    ``feat_impact_<name>`` column is selected from ``df_feat``.
+    Picks the ``feat_impact_<name>`` column matching the resolved sample name. If that exact
+    column is absent but exactly one ``feat_impact_*`` column exists, that single column is used
+    (covers the case where a custom ``names=`` was passed to :meth:`ShapModel.add_feat_impact`).
     """
-    if col_imp is not None:
-        return col_imp
+    cols_impact = [x for x in df_feat.columns if str(x).startswith(f"{ut.COL_FEAT_IMPACT}_")]
     col_imp = f"{ut.COL_FEAT_IMPACT}_{name}"
-    if col_imp not in df_feat.columns:
-        cols_impact = [x for x in df_feat.columns if str(x).startswith(f"{ut.COL_FEAT_IMPACT}_")]
-        raise ValueError(f"'col_imp' ('{col_imp}') derived for sample '{name}' is not a column in 'df_feat'. "
-                         f"Available feature-impact columns are: {cols_impact}")
-    return col_imp
+    if col_imp in df_feat.columns:
+        return col_imp
+    if len(cols_impact) == 1:
+        return cols_impact[0]
+    raise ValueError(f"'col_imp' could not be resolved for sample '{name}': no '{col_imp}' column in 'df_feat' "
+                     f"and the feature-impact column is ambiguous. Available columns are: {cols_impact}. "
+                     f"Pass 'col_imp' explicitly.")
 
 
 # Check update_seq_size
@@ -770,6 +772,7 @@ class CPPPlot:
                 tmd_len: int = 20,
                 df_seq: Optional[pd.DataFrame] = None,
                 entry: Optional[str] = None,
+                sample: Optional[Union[int, str]] = None,
                 tmd_seq: Optional[str] = None,
                 jmd_n_seq: Optional[str] = None,
                 jmd_c_seq: Optional[str] = None,
@@ -851,7 +854,12 @@ class CPPPlot:
         entry : str, optional
             Protein identifier (accession) from the ``entry`` column of ``df_seq`` for which to derive and
             display the TMD-JMD sequence parts. Requires ``df_seq``; must not be combined with explicit
-            ``tmd_seq``/``jmd_n_seq``/``jmd_c_seq``.
+            ``tmd_seq``/``jmd_n_seq``/``jmd_c_seq`` or with ``sample``.
+        sample : int or str, optional
+            Like ``entry``, but accepting either a row position in ``df_seq`` (int) or an entry name (str).
+            Convenience for sample-level SHAP plots: when given with ``df_seq`` and ``shap_plot=True``, the
+            ``feat_impact_<name>`` column is also resolved internally from ``df_feat`` (so ``col_imp`` need not
+            be passed). Requires ``df_seq``; mutually exclusive with explicit ``*_seq`` parts and with ``entry``.
         tmd_seq : str, optional
             TMD sequence for specific sample.
         jmd_n_seq : str, optional
@@ -930,6 +938,14 @@ class CPPPlot:
         """
         # Check primary input
         ut.check_bool(name="shap_plot", val=shap_plot)
+        # Convenience: merge the per-sample selectors ('entry' str-only, 'sample' int-or-str)
+        if entry is not None and sample is not None:
+            raise ValueError(f"'entry' ({entry}) and 'sample' ({sample}) should not be provided together.")
+        sample = entry if entry is not None else sample
+        name_sample = get_sample_name(df_seq=df_seq, sample=sample) if (sample is not None and df_seq is not None) else None
+        # For sample-level SHAP plots, resolve the 'feat_impact_<name>' column when 'col_imp' is left at default
+        if sample is not None and shap_plot and col_imp == ut.COL_FEAT_IMPORT and isinstance(df_feat, pd.DataFrame):
+            col_imp = resolve_col_imp_for_sample(df_feat=df_feat, name=name_sample)
         if col_imp is None:
             df_feat = ut.check_df_feat(df_feat=df_feat, df_cat=self._df_cat)
         else:
@@ -943,11 +959,11 @@ class CPPPlot:
         ut.check_number_range(name="start", val=start, min_val=0, just_int=True)
         jmd_n_len = ut.check_jmd_n_len(jmd_n_len=self._jmd_n_len)
         jmd_c_len = ut.check_jmd_c_len(jmd_c_len=self._jmd_c_len)
-        # Convenience: derive per-sample sequence parts from df_seq/entry via SequenceFeature (frontend reuse)
-        check_match_sample_seq(sample=entry, tmd_seq=tmd_seq, jmd_n_seq=jmd_n_seq, jmd_c_seq=jmd_c_seq, df_seq=df_seq,
-                               name="entry")
-        if entry is not None:
-            args_seq_sample = get_args_seq_for_sample(df_seq=df_seq, sample=entry,
+        # Convenience: derive per-sample sequence parts from df_seq/entry/sample via SequenceFeature (frontend reuse)
+        check_match_sample_seq(sample=sample, tmd_seq=tmd_seq, jmd_n_seq=jmd_n_seq, jmd_c_seq=jmd_c_seq, df_seq=df_seq,
+                               name="sample")
+        if sample is not None:
+            args_seq_sample = get_args_seq_for_sample(df_seq=df_seq, sample=sample,
                                                       jmd_n_len=jmd_n_len, jmd_c_len=jmd_c_len)
             tmd_seq, jmd_n_seq, jmd_c_seq = (args_seq_sample["tmd_seq"], args_seq_sample["jmd_n_seq"],
                                              args_seq_sample["jmd_c_seq"])
@@ -1280,6 +1296,7 @@ class CPPPlot:
                     tmd_len: int = 20,
                     df_seq: Optional[pd.DataFrame] = None,
                     entry: Optional[str] = None,
+                    sample: Optional[Union[int, str]] = None,
                     tmd_seq: Optional[str] = None,
                     jmd_n_seq: Optional[str] = None,
                     jmd_c_seq: Optional[str] = None,
@@ -1394,7 +1411,13 @@ class CPPPlot:
         entry : str, optional
             Protein identifier (accession) from the ``entry`` column of ``df_seq`` for which to derive and
             display the TMD-JMD sequence parts. Requires ``df_seq``; must not be combined with explicit
-            ``tmd_seq``/``jmd_n_seq``/``jmd_c_seq``.
+            ``tmd_seq``/``jmd_n_seq``/``jmd_c_seq`` or with ``sample``.
+        sample : int or str, optional
+            Like ``entry``, but accepting either a row position in ``df_seq`` (int) or an entry name (str).
+            Convenience for sample-level SHAP plots: when given with ``df_seq`` and ``shap_plot=True``, the
+            ``feat_impact_<name>`` column is resolved internally from ``df_feat`` (so ``col_imp`` need not be
+            passed) and ``name_test`` defaults to the resolved sample name. Requires ``df_seq``; mutually
+            exclusive with explicit ``*_seq`` parts and with ``entry``.
         tmd_seq : str, optional
             TMD sequence for specific sample.
         jmd_n_seq : str, optional
@@ -1497,6 +1520,17 @@ class CPPPlot:
         ut.check_bool(name="shap_plot", val=shap_plot)
         ut.check_str_options(name="col_cat", val=col_cat,
                              list_str_options=[ut.COL_CAT, ut.COL_SUBCAT, ut.COL_SCALE_NAME])
+        # Convenience: merge the per-sample selectors ('entry' str-only, 'sample' int-or-str)
+        if entry is not None and sample is not None:
+            raise ValueError(f"'entry' ({entry}) and 'sample' ({sample}) should not be provided together.")
+        sample = entry if entry is not None else sample
+        name_sample = get_sample_name(df_seq=df_seq, sample=sample) if (sample is not None and df_seq is not None) else None
+        # For sample-level SHAP plots, resolve the 'feat_impact_<name>' column and 'name_test' from the sample
+        if sample is not None and shap_plot and isinstance(df_feat, pd.DataFrame):
+            if col_imp == ut.COL_FEAT_IMPORT:
+                col_imp = resolve_col_imp_for_sample(df_feat=df_feat, name=name_sample)
+            if name_test == "TEST" and name_sample is not None:
+                name_test = str(name_sample)
         col_val = check_col_val(col_val=col_val, shap_plot=shap_plot, sample_mean_dif=True)
         col_imp = check_col_imp(col_imp=col_imp, shap_plot=shap_plot)
         df_feat = ut.check_df_feat(df_feat=df_feat, df_cat=self._df_cat, shap_plot=shap_plot,
@@ -1518,11 +1552,11 @@ class CPPPlot:
         ut.check_number_range(name="start", val=start, min_val=0, just_int=True)
         jmd_n_len = ut.check_jmd_n_len(jmd_n_len=self._jmd_n_len)
         jmd_c_len = ut.check_jmd_c_len(jmd_c_len=self._jmd_c_len)
-        # Convenience: derive per-sample sequence parts from df_seq/entry via SequenceFeature (frontend reuse)
-        check_match_sample_seq(sample=entry, tmd_seq=tmd_seq, jmd_n_seq=jmd_n_seq, jmd_c_seq=jmd_c_seq, df_seq=df_seq,
-                               name="entry")
-        if entry is not None:
-            args_seq_sample = get_args_seq_for_sample(df_seq=df_seq, sample=entry,
+        # Convenience: derive per-sample sequence parts from df_seq/entry/sample via SequenceFeature (frontend reuse)
+        check_match_sample_seq(sample=sample, tmd_seq=tmd_seq, jmd_n_seq=jmd_n_seq, jmd_c_seq=jmd_c_seq, df_seq=df_seq,
+                               name="sample")
+        if sample is not None:
+            args_seq_sample = get_args_seq_for_sample(df_seq=df_seq, sample=sample,
                                                       jmd_n_len=jmd_n_len, jmd_c_len=jmd_c_len)
             tmd_seq, jmd_n_seq, jmd_c_seq = (args_seq_sample["tmd_seq"], args_seq_sample["jmd_n_seq"],
                                              args_seq_sample["jmd_c_seq"])

--- a/aaanalysis/feature_engineering/_cpp_plot.py
+++ b/aaanalysis/feature_engineering/_cpp_plot.py
@@ -8,6 +8,7 @@ import warnings
 
 import aaanalysis.utils as ut
 
+from ._sequence_feature import SequenceFeature
 from ._backend.check_feature import (check_split_kws,
                                      check_parts_len,
                                      check_match_features_seq_parts,
@@ -165,6 +166,51 @@ def check_imp_tuples(name="imp_th", imp_tuples=None):
         raise ValueError(f"'{name}' ({imp_tuples}) should contain 3 numbers in ascending order")
     if th1 <= 0:
         raise ValueError(f"Minium of '{name}' ({imp_tuples[0]}) should be > 0")
+
+
+# Resolve per-sample sequence parts and feature-impact column (df_seq / entry / sample convenience)
+def check_match_sample_seq(sample=None, tmd_seq=None, jmd_n_seq=None, jmd_c_seq=None, df_seq=None, name="sample"):
+    """Check the df_seq/sample convenience input against explicitly given sequence parts."""
+    explicit_seq_given = any(x is not None for x in [tmd_seq, jmd_n_seq, jmd_c_seq])
+    if sample is not None:
+        if explicit_seq_given:
+            raise ValueError(f"'{name}' ({sample}) and explicit sequence parts "
+                             f"('tmd_seq', 'jmd_n_seq', 'jmd_c_seq') should not be provided together.")
+        if df_seq is None:
+            raise ValueError(f"'df_seq' should be given (not None) when '{name}' ({sample}) is provided.")
+    elif df_seq is not None:
+        raise ValueError(f"'{name}' should be given (not None) when 'df_seq' is provided.")
+
+
+def get_args_seq_for_sample(df_seq=None, sample=None, jmd_n_len=10, jmd_c_len=10):
+    """Derive the per-part sequence arguments for one protein via SequenceFeature (frontend reuse)."""
+    sf = SequenceFeature(verbose=False)
+    args_seq = sf.get_args_seq(df_seq=df_seq, sample=sample, jmd_n_len=jmd_n_len, jmd_c_len=jmd_c_len)
+    return args_seq
+
+
+def get_sample_name(df_seq=None, sample=None):
+    """Resolve the entry name for a sample given as an entry name (str) or a row position (int)."""
+    if isinstance(sample, str):
+        return sample
+    entries = df_seq[ut.COL_ENTRY].to_list()
+    return entries[int(sample)]
+
+
+def resolve_col_imp_for_sample(df_feat=None, name=None, col_imp=None):
+    """Resolve the 'feat_impact_<name>' column for a sample-level SHAP plot.
+
+    If ``col_imp`` is already explicitly given it is returned unchanged; otherwise the
+    ``feat_impact_<name>`` column is selected from ``df_feat``.
+    """
+    if col_imp is not None:
+        return col_imp
+    col_imp = f"{ut.COL_FEAT_IMPACT}_{name}"
+    if col_imp not in df_feat.columns:
+        cols_impact = [x for x in df_feat.columns if str(x).startswith(f"{ut.COL_FEAT_IMPACT}_")]
+        raise ValueError(f"'col_imp' ('{col_imp}') derived for sample '{name}' is not a column in 'df_feat'. "
+                         f"Available feature-impact columns are: {cols_impact}")
+    return col_imp
 
 
 # Check update_seq_size
@@ -722,6 +768,8 @@ class CPPPlot:
                 # Appearance of Parts (TMD-JMD)
                 start: int = 1,
                 tmd_len: int = 20,
+                df_seq: Optional[pd.DataFrame] = None,
+                entry: Optional[str] = None,
                 tmd_seq: Optional[str] = None,
                 jmd_n_seq: Optional[str] = None,
                 jmd_c_seq: Optional[str] = None,
@@ -794,6 +842,16 @@ class CPPPlot:
         tmd_len : int, default=20
             Length of target middle domain (TMD) to be depicted (>0). Must match with all feature
             from ``df_feat``.
+        df_seq : pd.DataFrame, shape (n_samples, n_seq_info), optional
+            DataFrame containing an ``entry`` column with unique protein identifiers and sequence information,
+            used together with ``entry`` to derive the per-sample TMD-JMD sequence parts
+            (``tmd_seq``/``jmd_n_seq``/``jmd_c_seq``) internally via :meth:`SequenceFeature.get_df_parts`,
+            honoring the instance ``jmd_n_len``/``jmd_c_len``. Mutually exclusive with explicitly passing the
+            ``*_seq`` parts.
+        entry : str, optional
+            Protein identifier (accession) from the ``entry`` column of ``df_seq`` for which to derive and
+            display the TMD-JMD sequence parts. Requires ``df_seq``; must not be combined with explicit
+            ``tmd_seq``/``jmd_n_seq``/``jmd_c_seq``.
         tmd_seq : str, optional
             TMD sequence for specific sample.
         jmd_n_seq : str, optional
@@ -885,6 +943,14 @@ class CPPPlot:
         ut.check_number_range(name="start", val=start, min_val=0, just_int=True)
         jmd_n_len = ut.check_jmd_n_len(jmd_n_len=self._jmd_n_len)
         jmd_c_len = ut.check_jmd_c_len(jmd_c_len=self._jmd_c_len)
+        # Convenience: derive per-sample sequence parts from df_seq/entry via SequenceFeature (frontend reuse)
+        check_match_sample_seq(sample=entry, tmd_seq=tmd_seq, jmd_n_seq=jmd_n_seq, jmd_c_seq=jmd_c_seq, df_seq=df_seq,
+                               name="entry")
+        if entry is not None:
+            args_seq_sample = get_args_seq_for_sample(df_seq=df_seq, sample=entry,
+                                                      jmd_n_len=jmd_n_len, jmd_c_len=jmd_c_len)
+            tmd_seq, jmd_n_seq, jmd_c_seq = (args_seq_sample["tmd_seq"], args_seq_sample["jmd_n_seq"],
+                                             args_seq_sample["jmd_c_seq"])
         args_len, args_seq = check_parts_len(tmd_len=tmd_len, jmd_n_len=jmd_n_len, jmd_c_len=jmd_c_len,
                                              jmd_n_seq=jmd_n_seq, tmd_seq=tmd_seq, jmd_c_seq=jmd_c_seq,
                                              check_jmd_seq_len_consistent=True)
@@ -1212,6 +1278,8 @@ class CPPPlot:
                     # Appearance of Parts (TMD-JMD)
                     start: int = 1,
                     tmd_len: int = 20,
+                    df_seq: Optional[pd.DataFrame] = None,
+                    entry: Optional[str] = None,
                     tmd_seq: Optional[str] = None,
                     jmd_n_seq: Optional[str] = None,
                     jmd_c_seq: Optional[str] = None,
@@ -1317,6 +1385,16 @@ class CPPPlot:
         tmd_len : int, default=20
             Length of target middle domain (TMD) to be depicted (>0). Must match with all feature
             from ``df_feat``.
+        df_seq : pd.DataFrame, shape (n_samples, n_seq_info), optional
+            DataFrame containing an ``entry`` column with unique protein identifiers and sequence information,
+            used together with ``entry`` to derive the per-sample TMD-JMD sequence parts
+            (``tmd_seq``/``jmd_n_seq``/``jmd_c_seq``) internally via :meth:`SequenceFeature.get_df_parts`,
+            honoring the instance ``jmd_n_len``/``jmd_c_len``. Mutually exclusive with explicitly passing the
+            ``*_seq`` parts.
+        entry : str, optional
+            Protein identifier (accession) from the ``entry`` column of ``df_seq`` for which to derive and
+            display the TMD-JMD sequence parts. Requires ``df_seq``; must not be combined with explicit
+            ``tmd_seq``/``jmd_n_seq``/``jmd_c_seq``.
         tmd_seq : str, optional
             TMD sequence for specific sample.
         jmd_n_seq : str, optional
@@ -1440,6 +1518,14 @@ class CPPPlot:
         ut.check_number_range(name="start", val=start, min_val=0, just_int=True)
         jmd_n_len = ut.check_jmd_n_len(jmd_n_len=self._jmd_n_len)
         jmd_c_len = ut.check_jmd_c_len(jmd_c_len=self._jmd_c_len)
+        # Convenience: derive per-sample sequence parts from df_seq/entry via SequenceFeature (frontend reuse)
+        check_match_sample_seq(sample=entry, tmd_seq=tmd_seq, jmd_n_seq=jmd_n_seq, jmd_c_seq=jmd_c_seq, df_seq=df_seq,
+                               name="entry")
+        if entry is not None:
+            args_seq_sample = get_args_seq_for_sample(df_seq=df_seq, sample=entry,
+                                                      jmd_n_len=jmd_n_len, jmd_c_len=jmd_c_len)
+            tmd_seq, jmd_n_seq, jmd_c_seq = (args_seq_sample["tmd_seq"], args_seq_sample["jmd_n_seq"],
+                                             args_seq_sample["jmd_c_seq"])
         args_len, args_seq = check_parts_len(tmd_len=tmd_len, jmd_n_len=jmd_n_len, jmd_c_len=jmd_c_len,
                                              jmd_n_seq=jmd_n_seq, tmd_seq=tmd_seq, jmd_c_seq=jmd_c_seq,
                                              check_jmd_seq_len_consistent=True)

--- a/tests/unit/cpp_plot_tests/test_cpp_plot_df_seq_entry.py
+++ b/tests/unit/cpp_plot_tests/test_cpp_plot_df_seq_entry.py
@@ -112,7 +112,7 @@ class TestProfileDfSeqEntry:
         df_seq = get_df_seq()
         df_feat = get_df_feat()
         cpp_plot = aa.CPPPlot()
-        with pytest.raises(ValueError, match="entry"):
+        with pytest.raises(ValueError, match="should be given"):
             cpp_plot.profile(df_feat=df_feat, df_seq=df_seq)
 
     def test_error_unknown_entry(self):

--- a/tests/unit/cpp_plot_tests/test_cpp_plot_df_seq_entry.py
+++ b/tests/unit/cpp_plot_tests/test_cpp_plot_df_seq_entry.py
@@ -1,0 +1,214 @@
+"""
+This script tests the df_seq=/entry= convenience input of CPPPlot.profile() and
+CPPPlot.feature_map() (issue #127): deriving the per-sample TMD-JMD sequence parts
+internally must match the explicit **args_seq path, and stay back-compatible.
+"""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from hypothesis import given, settings, strategies as st
+import pytest
+import aaanalysis as aa
+
+aa.options["verbose"] = False
+settings.register_profile("ci", deadline=None)
+settings.load_profile("ci")
+
+
+# Constants and Helper functions
+N_SEQ = 10
+COL_FEAT_IMPACT_TEST = "feat_impact_test"
+
+
+def get_df_seq():
+    aa.options["verbose"] = False
+    return aa.load_dataset(name="DOM_GSEC", n=N_SEQ)
+
+
+def get_args_seq(df_seq, n=0):
+    jmd_n_seq, tmd_seq, jmd_c_seq = df_seq.loc[n, ["jmd_n", "tmd", "jmd_c"]]
+    return dict(jmd_n_seq=jmd_n_seq, tmd_seq=tmd_seq, jmd_c_seq=jmd_c_seq)
+
+
+def get_df_feat(n=10):
+    aa.options["verbose"] = False
+    df_feat = aa.load_features().head(n)
+    df_feat.insert(0, COL_FEAT_IMPACT_TEST, [2] * len(df_feat))
+    return df_feat
+
+
+def xtick_text(ax):
+    """The rendered TMD-JMD sequence (where the per-sample seq parts manifest)."""
+    return [t.get_text() for t in ax.get_xticklabels(which="both")]
+
+
+class TestProfileDfSeqEntry:
+    """Positive + negative cases for profile(df_seq=, entry=)."""
+
+    def test_entry_path_matches_explicit_args_seq(self):
+        df_seq = get_df_seq()
+        entry = df_seq.loc[0, "entry"]
+        args_seq = get_args_seq(df_seq, n=0)
+        df_feat = get_df_feat()
+        cpp_plot = aa.CPPPlot()
+        fig1, ax1 = cpp_plot.profile(df_feat=df_feat, **args_seq)
+        t1 = xtick_text(ax1)
+        plt.close("all")
+        fig2, ax2 = cpp_plot.profile(df_feat=df_feat, df_seq=df_seq, entry=entry)
+        t2 = xtick_text(ax2)
+        plt.close("all")
+        assert t1 == t2
+
+    @settings(max_examples=4, deadline=None)
+    @given(n=st.integers(min_value=0, max_value=N_SEQ - 1))
+    def test_entry_path_matches_per_sample(self, n):
+        df_seq = get_df_seq()
+        entry = df_seq.loc[n, "entry"]
+        args_seq = get_args_seq(df_seq, n=n)
+        df_feat = get_df_feat()
+        cpp_plot = aa.CPPPlot()
+        fig1, ax1 = cpp_plot.profile(df_feat=df_feat, **args_seq)
+        t1 = xtick_text(ax1)
+        plt.close("all")
+        fig2, ax2 = cpp_plot.profile(df_feat=df_feat, df_seq=df_seq, entry=entry)
+        t2 = xtick_text(ax2)
+        plt.close("all")
+        assert t1 == t2
+
+    def test_backcompat_explicit_args_seq_still_works(self):
+        df_seq = get_df_seq()
+        args_seq = get_args_seq(df_seq, n=0)
+        df_feat = get_df_feat()
+        cpp_plot = aa.CPPPlot()
+        fig, ax = cpp_plot.profile(df_feat=df_feat, **args_seq)
+        assert isinstance(fig, plt.Figure) and isinstance(ax, plt.Axes)
+        plt.close("all")
+
+    def test_no_entry_no_df_seq_unchanged(self):
+        df_feat = get_df_feat()
+        cpp_plot = aa.CPPPlot()
+        fig, ax = cpp_plot.profile(df_feat=df_feat)
+        assert isinstance(fig, plt.Figure) and isinstance(ax, plt.Axes)
+        plt.close("all")
+
+    def test_error_entry_and_explicit_seq(self):
+        df_seq = get_df_seq()
+        entry = df_seq.loc[0, "entry"]
+        args_seq = get_args_seq(df_seq, n=0)
+        df_feat = get_df_feat()
+        cpp_plot = aa.CPPPlot()
+        with pytest.raises(ValueError, match="should not be provided together"):
+            cpp_plot.profile(df_feat=df_feat, df_seq=df_seq, entry=entry, **args_seq)
+
+    def test_error_entry_without_df_seq(self):
+        df_seq = get_df_seq()
+        entry = df_seq.loc[0, "entry"]
+        df_feat = get_df_feat()
+        cpp_plot = aa.CPPPlot()
+        with pytest.raises(ValueError, match="df_seq"):
+            cpp_plot.profile(df_feat=df_feat, entry=entry)
+
+    def test_error_df_seq_without_entry(self):
+        df_seq = get_df_seq()
+        df_feat = get_df_feat()
+        cpp_plot = aa.CPPPlot()
+        with pytest.raises(ValueError, match="entry"):
+            cpp_plot.profile(df_feat=df_feat, df_seq=df_seq)
+
+    def test_error_unknown_entry(self):
+        df_seq = get_df_seq()
+        df_feat = get_df_feat()
+        cpp_plot = aa.CPPPlot()
+        with pytest.raises(ValueError):
+            cpp_plot.profile(df_feat=df_feat, df_seq=df_seq, entry="NOT_AN_ENTRY")
+
+
+class TestFeatureMapDfSeqEntry:
+    """Positive + negative cases for feature_map(df_seq=, entry=)."""
+
+    def test_entry_path_matches_explicit_args_seq(self):
+        df_seq = get_df_seq()
+        entry = df_seq.loc[0, "entry"]
+        args_seq = get_args_seq(df_seq, n=0)
+        df_feat = get_df_feat()
+        cpp_plot = aa.CPPPlot()
+        fig1, ax1 = cpp_plot.feature_map(df_feat=df_feat, **args_seq)
+        t1 = xtick_text(ax1)
+        plt.close("all")
+        fig2, ax2 = cpp_plot.feature_map(df_feat=df_feat, df_seq=df_seq, entry=entry)
+        t2 = xtick_text(ax2)
+        plt.close("all")
+        assert t1 == t2
+
+    @settings(max_examples=4, deadline=None)
+    @given(n=st.integers(min_value=0, max_value=N_SEQ - 1))
+    def test_entry_path_matches_per_sample(self, n):
+        df_seq = get_df_seq()
+        entry = df_seq.loc[n, "entry"]
+        args_seq = get_args_seq(df_seq, n=n)
+        df_feat = get_df_feat()
+        cpp_plot = aa.CPPPlot()
+        fig1, ax1 = cpp_plot.feature_map(df_feat=df_feat, **args_seq)
+        t1 = xtick_text(ax1)
+        plt.close("all")
+        fig2, ax2 = cpp_plot.feature_map(df_feat=df_feat, df_seq=df_seq, entry=entry)
+        t2 = xtick_text(ax2)
+        plt.close("all")
+        assert t1 == t2
+
+    def test_backcompat_explicit_args_seq_still_works(self):
+        df_seq = get_df_seq()
+        args_seq = get_args_seq(df_seq, n=0)
+        df_feat = get_df_feat()
+        cpp_plot = aa.CPPPlot()
+        fig, ax = cpp_plot.feature_map(df_feat=df_feat, **args_seq)
+        assert isinstance(fig, plt.Figure) and isinstance(ax, plt.Axes)
+        plt.close("all")
+
+    def test_no_entry_no_df_seq_unchanged(self):
+        df_feat = get_df_feat()
+        cpp_plot = aa.CPPPlot()
+        fig, ax = cpp_plot.feature_map(df_feat=df_feat)
+        assert isinstance(fig, plt.Figure) and isinstance(ax, plt.Axes)
+        plt.close("all")
+
+    def test_error_entry_and_explicit_seq(self):
+        df_seq = get_df_seq()
+        entry = df_seq.loc[0, "entry"]
+        args_seq = get_args_seq(df_seq, n=0)
+        df_feat = get_df_feat()
+        cpp_plot = aa.CPPPlot()
+        with pytest.raises(ValueError, match="should not be provided together"):
+            cpp_plot.feature_map(df_feat=df_feat, df_seq=df_seq, entry=entry, **args_seq)
+
+    def test_error_entry_without_df_seq(self):
+        df_seq = get_df_seq()
+        entry = df_seq.loc[0, "entry"]
+        df_feat = get_df_feat()
+        cpp_plot = aa.CPPPlot()
+        with pytest.raises(ValueError, match="df_seq"):
+            cpp_plot.feature_map(df_feat=df_feat, entry=entry)
+
+    def test_error_unknown_entry(self):
+        df_seq = get_df_seq()
+        df_feat = get_df_feat()
+        cpp_plot = aa.CPPPlot()
+        with pytest.raises(ValueError):
+            cpp_plot.feature_map(df_feat=df_feat, df_seq=df_seq, entry="NOT_AN_ENTRY")
+
+    def test_entry_honors_jmd_len(self):
+        """Derived parts must honor the instance jmd_n_len/jmd_c_len, matching get_args_seq."""
+        df_seq = get_df_seq()
+        entry = df_seq.loc[0, "entry"]
+        df_feat = get_df_feat()
+        sf = aa.SequenceFeature(verbose=False)
+        # Explicit parts computed with the SAME jmd lengths as the instance
+        args_seq = sf.get_args_seq(df_seq=df_seq, sample=entry, jmd_n_len=5, jmd_c_len=5)
+        cpp_plot = aa.CPPPlot(jmd_n_len=5, jmd_c_len=5)
+        fig1, ax1 = cpp_plot.feature_map(df_feat=df_feat, **args_seq)
+        t1 = xtick_text(ax1)
+        plt.close("all")
+        fig2, ax2 = cpp_plot.feature_map(df_feat=df_feat, df_seq=df_seq, entry=entry)
+        t2 = xtick_text(ax2)
+        plt.close("all")
+        assert t1 == t2

--- a/tests/unit/cpp_plot_tests/test_cpp_plot_sample_shap.py
+++ b/tests/unit/cpp_plot_tests/test_cpp_plot_sample_shap.py
@@ -1,0 +1,197 @@
+"""
+This script tests the sample= / df_seq= SHAP convenience of CPPPlot.profile() and
+CPPPlot.feature_map() (issue #214): with shap_plot=True, the feat_impact_<name>
+column and the per-sample TMD-JMD parts are resolved internally, and name_test is
+auto-resolved (feature_map). The explicit col_imp=/**args_seq path stays working.
+"""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from hypothesis import given, settings, strategies as st
+import pytest
+import aaanalysis as aa
+
+aa.options["verbose"] = False
+settings.register_profile("ci", deadline=None)
+settings.load_profile("ci")
+
+
+# Constants and Helper functions
+N_SEQ = 10
+N_FEAT = 10
+
+
+def get_df_seq():
+    aa.options["verbose"] = False
+    return aa.load_dataset(name="DOM_GSEC", n=N_SEQ)
+
+
+def get_args_seq(df_seq, sample):
+    sf = aa.SequenceFeature(verbose=False)
+    return sf.get_args_seq(df_seq=df_seq, sample=sample)
+
+
+def get_df_feat_impact(name):
+    """Feature table carrying a single signed feat_impact_<name> column."""
+    aa.options["verbose"] = False
+    df_feat = aa.load_features().head(N_FEAT).reset_index(drop=True)
+    signs = [1 if i % 2 == 0 else -1 for i in range(len(df_feat))]
+    df_feat[f"feat_impact_{name}"] = [s * (1 + i) for i, s in enumerate(signs)]
+    return df_feat
+
+
+def xtick_text(ax):
+    return [t.get_text() for t in ax.get_xticklabels(which="both")]
+
+
+class TestProfileSampleShap:
+    """profile(sample=, df_seq=, shap_plot=True) resolves col_imp + seq parts."""
+
+    def test_sample_matches_explicit_col_imp_and_args_seq(self):
+        df_seq = get_df_seq()
+        entry = df_seq.loc[0, "entry"]
+        df_feat = get_df_feat_impact(entry)
+        args_seq = get_args_seq(df_seq, entry)
+        cpp_plot = aa.CPPPlot()
+        fig1, ax1 = cpp_plot.profile(df_feat=df_feat, shap_plot=True,
+                                     col_imp=f"feat_impact_{entry}", **args_seq)
+        t1 = xtick_text(ax1)
+        plt.close("all")
+        fig2, ax2 = cpp_plot.profile(df_feat=df_feat, shap_plot=True, df_seq=df_seq, sample=entry)
+        t2 = xtick_text(ax2)
+        plt.close("all")
+        assert t1 == t2
+
+    @settings(max_examples=4, deadline=None)
+    @given(n=st.integers(min_value=0, max_value=N_SEQ - 1))
+    def test_int_sample_matches_entry(self, n):
+        df_seq = get_df_seq()
+        entry = df_seq.loc[n, "entry"]
+        df_feat = get_df_feat_impact(entry)
+        cpp_plot = aa.CPPPlot()
+        fig1, ax1 = cpp_plot.profile(df_feat=df_feat, shap_plot=True, df_seq=df_seq, sample=entry)
+        t1 = xtick_text(ax1)
+        plt.close("all")
+        fig2, ax2 = cpp_plot.profile(df_feat=df_feat, shap_plot=True, df_seq=df_seq, sample=n)
+        t2 = xtick_text(ax2)
+        plt.close("all")
+        assert t1 == t2
+
+    def test_custom_name_single_impact_col_resolves(self):
+        """name != accession: the single feat_impact_* column is still resolved."""
+        df_seq = get_df_seq()
+        entry = df_seq.loc[0, "entry"]
+        df_feat = get_df_feat_impact("APP")  # custom name, accession differs
+        cpp_plot = aa.CPPPlot()
+        fig, ax = cpp_plot.profile(df_feat=df_feat, shap_plot=True, df_seq=df_seq, sample=entry)
+        assert isinstance(fig, plt.Figure)
+        plt.close("all")
+
+    def test_backcompat_explicit_col_imp_args_seq(self):
+        df_seq = get_df_seq()
+        entry = df_seq.loc[0, "entry"]
+        df_feat = get_df_feat_impact(entry)
+        args_seq = get_args_seq(df_seq, entry)
+        cpp_plot = aa.CPPPlot()
+        fig, ax = cpp_plot.profile(df_feat=df_feat, shap_plot=True,
+                                   col_imp=f"feat_impact_{entry}", **args_seq)
+        assert isinstance(fig, plt.Figure) and isinstance(ax, plt.Axes)
+        plt.close("all")
+
+    def test_explicit_col_imp_wins_over_sample(self):
+        df_seq = get_df_seq()
+        entry = df_seq.loc[0, "entry"]
+        df_feat = get_df_feat_impact(entry)
+        cpp_plot = aa.CPPPlot()
+        fig, ax = cpp_plot.profile(df_feat=df_feat, shap_plot=True, df_seq=df_seq, sample=entry,
+                                   col_imp=f"feat_impact_{entry}")
+        assert isinstance(fig, plt.Figure)
+        plt.close("all")
+
+    def test_error_entry_and_sample(self):
+        df_seq = get_df_seq()
+        entry = df_seq.loc[0, "entry"]
+        df_feat = get_df_feat_impact(entry)
+        cpp_plot = aa.CPPPlot()
+        with pytest.raises(ValueError, match="should not be provided together"):
+            cpp_plot.profile(df_feat=df_feat, shap_plot=True, df_seq=df_seq, entry=entry, sample=0)
+
+    def test_error_ambiguous_impact_columns(self):
+        """Multiple feat_impact_* columns and no exact match -> clear error."""
+        df_seq = get_df_seq()
+        entry = df_seq.loc[0, "entry"]
+        df_feat = get_df_feat_impact("APP")
+        df_feat["feat_impact_OTHER"] = 1.0
+        cpp_plot = aa.CPPPlot()
+        with pytest.raises(ValueError, match="col_imp"):
+            cpp_plot.profile(df_feat=df_feat, shap_plot=True, df_seq=df_seq, sample=entry)
+
+
+class TestFeatureMapSampleShap:
+    """feature_map(sample=, df_seq=, shap_plot=True) resolves col_imp + seq + name_test."""
+
+    def test_sample_matches_explicit_path(self):
+        df_seq = get_df_seq()
+        entry = df_seq.loc[0, "entry"]
+        df_feat = get_df_feat_impact(entry)
+        args_seq = get_args_seq(df_seq, entry)
+        col = f"feat_impact_{entry}"
+        cpp_plot = aa.CPPPlot()
+        fig1, ax1 = cpp_plot.feature_map(df_feat=df_feat, shap_plot=True, col_imp=col, col_val=col,
+                                         name_test=entry, **args_seq)
+        t1 = xtick_text(ax1)
+        plt.close("all")
+        fig2, ax2 = cpp_plot.feature_map(df_feat=df_feat, shap_plot=True, df_seq=df_seq, sample=entry,
+                                         col_val=col)
+        t2 = xtick_text(ax2)
+        plt.close("all")
+        assert t1 == t2
+
+    def test_name_test_auto_resolves_to_sample(self):
+        """name_test defaults to the sample name (shown in the colorbar label)."""
+        df_seq = get_df_seq()
+        entry = df_seq.loc[0, "entry"]
+        df_feat = get_df_feat_impact(entry)
+        # mean_dif_<name> col_val -> colorbar label reads "<name_test> - <name_ref>"
+        df_feat[f"mean_dif_{entry}"] = df_feat["mean_dif"]
+        cpp_plot = aa.CPPPlot()
+        fig, ax = cpp_plot.feature_map(df_feat=df_feat, shap_plot=True, df_seq=df_seq, sample=entry,
+                                       col_val=f"mean_dif_{entry}")
+        labels = [axx.get_ylabel() for axx in fig.axes]
+        labels += [axx.get_xlabel() for axx in fig.axes]
+        labels += [t.get_text() for axx in fig.axes for t in axx.texts]
+        assert any(entry in (s or "") for s in labels)
+        plt.close("all")
+
+    def test_int_sample_runs(self):
+        df_seq = get_df_seq()
+        entry = df_seq.loc[2, "entry"]
+        df_feat = get_df_feat_impact(entry)
+        col = f"feat_impact_{entry}"
+        cpp_plot = aa.CPPPlot()
+        fig, ax = cpp_plot.feature_map(df_feat=df_feat, shap_plot=True, df_seq=df_seq, sample=2,
+                                       col_val=col)
+        assert isinstance(fig, plt.Figure)
+        plt.close("all")
+
+    def test_backcompat_explicit_path(self):
+        df_seq = get_df_seq()
+        entry = df_seq.loc[0, "entry"]
+        df_feat = get_df_feat_impact(entry)
+        args_seq = get_args_seq(df_seq, entry)
+        col = f"feat_impact_{entry}"
+        cpp_plot = aa.CPPPlot()
+        fig, ax = cpp_plot.feature_map(df_feat=df_feat, shap_plot=True, col_imp=col, col_val=col,
+                                       name_test=entry, **args_seq)
+        assert isinstance(fig, plt.Figure) and isinstance(ax, plt.Axes)
+        plt.close("all")
+
+    def test_error_entry_and_sample(self):
+        df_seq = get_df_seq()
+        entry = df_seq.loc[0, "entry"]
+        df_feat = get_df_feat_impact(entry)
+        col = f"feat_impact_{entry}"
+        cpp_plot = aa.CPPPlot()
+        with pytest.raises(ValueError, match="should not be provided together"):
+            cpp_plot.feature_map(df_feat=df_feat, shap_plot=True, df_seq=df_seq, entry=entry, sample=0,
+                                 col_val=col)


### PR DESCRIPTION
Adds one-call per-protein / per-sample plotting to `CPPPlot.profile` and `CPPPlot.feature_map` (issues #127 and #214), run as an overnight session lane. Both issues edit the same file, so they were developed serially in one branch.

## #127 — `df_seq=` + `entry=`
- New params `df_seq`, `entry` on both methods
- TMD-JMD parts (`tmd_seq`/`jmd_n_seq`/`jmd_c_seq`) derived **through the frontend** via `SequenceFeature.get_args_seq` (honors instance `jmd_n_len`/`jmd_c_len`)
- Clear `ValueError` when `entry` is combined with explicit `*_seq`, or `entry`/`df_seq` given without the other, or `entry` not in `df_seq`
- Regression test: `entry` path yields identical rendered TMD-JMD x-ticks to the explicit `**args_seq` path (16 tests)

## #214 — `sample=` for SHAP plots
- New param `sample` (int row-pos or str accession) on both methods
- With `shap_plot=True`: seq parts via the same resolver; `feat_impact_<name>` column resolved from `df_feat` (exact match, else the single `feat_impact_*` col; ambiguous → `ValueError`); `feature_map` auto-resolves `name_test`
- `entry` (#127) and `sample` (#214) unified into one mutually-exclusive selector; explicit `col_imp=`/`name_test=`/`**args_seq` still wins (back-compat regression, incl. int==accession equivalence; 12 tests)

## Verification
369 passed (cpp_plot + hygiene + param-coverage); 494 in cpp_tests; docstring/drift 0 defects. No `__init__.py` change.

## Follow-up (deferred)
Notebook/cheat-sheet refresh for these new params was **not** done — it needs the pro (shap) env re-executed, judged too risky to do unattended (stale-output drift). Code + regression KPIs are met.

Closes #127
Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)
