### PR TITLE
refactor(dpulearn): group fit params + allow negative label markers

### DIFF
--- a/aaanalysis/pu_learning/_dpulearn.py
+++ b/aaanalysis/pu_learning/_dpulearn.py
@@ -33,9 +33,10 @@ def check_n_to_identify(labels=None, n_to_identify=None, label_unl=None):
 
 def check_match_labels_markers(label_pos=None, label_unl=None, label_neg=None):
     """Validate the positive/unlabeled/negative marker values used to encode the input labels."""
-    ut.check_number_range(name="label_pos", val=label_pos, min_val=0, just_int=True)
-    ut.check_number_range(name="label_unl", val=label_unl, min_val=0, just_int=True)
-    ut.check_number_range(name="label_neg", val=label_neg, min_val=0, just_int=True, accept_none=True)
+    # Markers may be any integer (e.g. -1), they only need to be distinct and match the labels.
+    ut.check_number_val(name="label_pos", val=label_pos, just_int=True)
+    ut.check_number_val(name="label_unl", val=label_unl, just_int=True)
+    ut.check_number_val(name="label_neg", val=label_neg, just_int=True, accept_none=True)
     markers = {"label_pos": label_pos, "label_unl": label_unl}
     if label_neg is not None:
         markers["label_neg"] = label_neg
@@ -211,13 +212,13 @@ class dPULearn:
     def fit(self,
             X: ut.ArrayLike2D,
             labels: ut.ArrayLike1D = None,
-            n_neg: int = None,
-            metric: Optional[Literal["euclidean", "manhattan", "cosine"]] = None,
-            n_components: Union[float, int] = 0.80,
             label_pos: int = 1,
             label_unl: int = 2,
             label_neg: Optional[int] = None,
+            n_neg: int = None,
             n_unl_to_neg: int = None,
+            metric: Optional[Literal["euclidean", "manhattan", "cosine"]] = None,
+            n_components: Union[float, int] = 0.80,
             ) -> "dPULearn":
         """
         Fit the dPULearn model to identify reliable negative samples (labeled by 0) from unlabeled samples (2)
@@ -244,12 +245,28 @@ class dPULearn:
             unlabeled marker (``label_unl``); pre-labeled negatives (``label_neg``) are optional. By
             default positives are ``1`` and unlabeled are ``2``; set ``label_unl=0`` to pass the standard
             ``{0, 1}`` encoding directly (``0`` = unlabeled, ``1`` = positive).
+        label_pos : int, default=1
+            Value marking positive samples in ``labels``. Must be present.
+        label_unl : int, default=2
+            Value marking unlabeled samples in ``labels`` (the candidate pool). Must be present. Set
+            ``label_unl=0`` to pass the standard ``{0, 1}`` encoding (``0`` = unlabeled, ``1`` =
+            positive) without re-encoding.
+        label_neg : int or None, default=None
+            Value marking pre-labeled (already known) negatives in ``labels``. When given, those
+            samples are kept as negatives and never re-selected, and dPULearn only identifies the
+            remaining (``n_neg`` minus pre-labeled) negatives from the unlabeled pool. ``None`` means
+            ``labels`` contains no pre-labeled negatives. Must differ from ``label_pos`` / ``label_unl``.
         n_neg : int, optional
             **Total** number of negatives (0) wanted in the output: any pre-labeled negatives
             (``label_neg``) plus the newly identified reliable negatives add up to ``n_neg``. So
             dPULearn identifies ``n_neg`` minus the pre-labeled negatives (with no pre-labeled
             negatives it identifies exactly ``n_neg``). It must exceed the number of pre-labeled
             negatives. Provide **exactly one** of ``n_neg`` or ``n_unl_to_neg``.
+        n_unl_to_neg : int, optional
+            Number of reliable negatives to identify **directly from the unlabeled pool** — direct
+            control over how many unlabeled samples are reclassified, independent of any pre-labeled
+            negatives (final negatives = pre-labeled + ``n_unl_to_neg``). Provide **exactly one** of
+            ``n_neg`` or ``n_unl_to_neg``. With no pre-labeled negatives the two are equivalent.
         metric : str or None, optional
             The distance metric to use. If ``None``, Principal Component Analysis (PCA)-based
             identification is performed. For distance-based identification one of the following
@@ -264,23 +281,6 @@ class dPULearn:
 
             * In case (a): it should be an integer >= 1.
             * In case (b): it should be a float with  0.0 < ``n_components`` < 1.0.
-
-        label_pos : int, default=1
-            Value marking positive samples in ``labels``. Must be present.
-        label_unl : int, default=2
-            Value marking unlabeled samples in ``labels`` (the candidate pool). Must be present. Set
-            ``label_unl=0`` to pass the standard ``{0, 1}`` encoding (``0`` = unlabeled, ``1`` =
-            positive) without re-encoding.
-        label_neg : int or None, default=None
-            Value marking pre-labeled (already known) negatives in ``labels``. When given, those
-            samples are kept as negatives and never re-selected, and dPULearn only identifies the
-            remaining (``n_neg`` minus pre-labeled) negatives from the unlabeled pool. ``None`` means
-            ``labels`` contains no pre-labeled negatives. Must differ from ``label_pos`` / ``label_unl``.
-        n_unl_to_neg : int, optional
-            Number of reliable negatives to identify **directly from the unlabeled pool** — direct
-            control over how many unlabeled samples are reclassified, independent of any pre-labeled
-            negatives (final negatives = pre-labeled + ``n_unl_to_neg``). Provide **exactly one** of
-            ``n_neg`` or ``n_unl_to_neg``. With no pre-labeled negatives the two are equivalent.
 
         Returns
         -------

--- a/tests/unit/dpulearn_tests/test_dpulearn_fit.py
+++ b/tests/unit/dpulearn_tests/test_dpulearn_fit.py
@@ -258,6 +258,16 @@ class TestdPULearnFitLabelEncoding:
         assert isinstance(df_pu, pd.DataFrame)
         assert np.sum(dpul.labels_ == 0) == 5
 
+    def test_negative_marker_values(self):
+        """Markers may be negative integers (e.g. label_unl=-1)."""
+        X, labels_pu = self._det_data()
+        labels_neg_marker = np.where(labels_pu == 2, -1, 1)  # 1 = positive, -1 = unlabeled
+        dpul = aa.dPULearn(random_state=42)
+        df_pu = dpul.fit(X, labels_neg_marker, label_unl=-1, n_neg=5).df_pu_
+        assert isinstance(df_pu, pd.DataFrame)
+        # output stays canonical (0 = negative, 1 = positive, 2 = unlabeled)
+        assert np.sum(dpul.labels_ == 0) == 5
+
     def test_equivalence_1_0_vs_1_2(self):
         """1/0 + n_neg yields byte-identical labels_/df_pu_ to the 1/2 + n_neg path."""
         X, labels_pu = self._det_data()


### PR DESCRIPTION
Polish on the unreleased v1.1.0 `dPULearn.fit` label-handling feature (#157). Two changes, no behavior change to existing keyword calls.

## 1. Parameter reorder
`fit` parameters are regrouped so they read in logical order — encoding → count → algorithm:

```python
fit(self, X, labels=None,
    label_pos=1, label_unl=2, label_neg=None,   # encoding
    n_neg=None, n_unl_to_neg=None,               # count — exactly one
    metric=None, n_components=0.80)              # algorithm
```

Docstring `Parameters` reordered to match. Signature-only; every call site (tests, examples) uses keywords, and the feature is unreleased — so no deprecation.

## 2. Allow negative label markers
`check_match_labels_markers` now validates marker **type** via `ut.check_number_val` (any int) instead of `check_number_range` (which forced `min_val=0`). So `label_unl=-1` (etc.) works. Markers must still be distinct and match the labels; **output stays canonical** (`0` = negative, `1` = positive, `2` = unlabeled). New negative-marker test added.

## Verified
Full fast suite **4598 passed / 14 skipped**; `test_param_coverage` ✓; docstring checker 0 defects / 0 drift. No CHANGELOG change (polish on the unreleased feature; existing entry already says "arbitrary positive/unlabeled/negative encoding").

🤖 Generated with [Claude Code](https://claude.com/claude-code)