### PR TITLE
Add agent-readiness-audit skill (front-door + ADR + module-map checkers)

### DIFF
--- a/.claude/skills/agent-readiness-audit/REFERENCE.md
+++ b/.claude/skills/agent-readiness-audit/REFERENCE.md
@@ -1,0 +1,165 @@
+# agent-readiness-audit — reference (portable methodology)
+
+Rubric, front-door template, and apply discipline. **Repo-agnostic** — every fact
+about *this* codebase (subpackage list, won't-flag ledger, doc pointers, worked
+example, per-repo status) lives in
+[aaanalysis_conventions.md](aaanalysis_conventions.md). The deterministic half is
+`scripts/check_agentic_docs.py`; this file is the *judgment* half a checker can't see.
+
+---
+
+## 1. Agent-friendliness rubric
+
+What makes a package legible to an agent, by leverage. **Only B and C are
+tool-backed**; A, D, F are reviewed by hand — report them as judgment, never as a
+script result. The per-repo ✓/⚠/🔒 status snapshot lives in the conventions file.
+
+- **A. Root navigational map (mental model)** — does a root doc state what each
+  subpackage does *and how they connect* (the inter-module call/data-flow graph)?
+  Plus a glossary, decision log (ADRs), and auto-loading per-area rules. The
+  **dataflow map** (`docs/module_map.md`) is curated (semantic flow can't be derived
+  from imports — frontends are decoupled through the `utils` barrel); its *coverage*
+  is tool-backed (`check_module_map.py`: `MAP-MISSING`, `MAP-MISSING-SUBPKG`,
+  `MAP-STALE-SUBPKG`), its *correctness* is judgment.
+  - **A′. Decision-log hygiene** — ADR status lines well-formed, cross-refs resolve,
+    supersession reciprocal, no ADR referenced from code, and the overview table
+    current. *Tool: `check_adrs.py` (`ADR-NO-STATUS`, `ADR-BAD-STATUS`,
+    `ADR-XREF-DANGLING`, `ADR-IN-CODE`, `ADR-INDEX-MISSING/STALE`,
+    `ADR-SUPERSEDED`).* Whether an ADR's *content* is outdated is judgment; ADRs are
+    **append-only** (supersede, never delete — deletion needs explicit go-ahead).
+- **B. Per-subpackage front-door** — a module docstring in every public
+  `__init__.py`: one-line purpose · key public objects · sibling relationship ·
+  pointers. *Tool: `PKG-NO-DOCSTRING`.*
+- **C. Public-API contract** — `__all__` present, equals the relative re-exports
+  (0 missing / 0 stale), no `_private` leak; top-level `__all__` reconciles with the
+  union of subpackage `__all__`s + any dynamic `append` stubs. *Tool: `ALL-MISSING`,
+  `ALL-EXPORT-MISMATCH`, `PRIVATE-LEAK`, `TOPLEVEL-ALL-DRIFT`.* Public-API deltas are
+  semver-relevant — surface, don't silently apply.
+- **D. Type legibility** — every public parameter + return annotated;
+  `Optional[...]` for `None`-defaults. Presence lets an agent reason without
+  executing. *Judgment (grep public signatures); running mypy/ruff is out of scope.*
+- **E. Docstrings as contract** — owned by the `docstrings` skill (numpydoc, named
+  `Returns`, per-method `Examples`, doc-vs-signature drift). Cross-reference, don't
+  re-specify.
+- **F. Tight feedback loops** — single-test/module run path, a documented
+  **sub-minute smoke path** (verify without a full pipeline), and errors that teach
+  (a precise message → one-step self-correct). *Judgment.*
+- **G–J (verify, don't churn)** — one-way module boundaries / no tangled
+  cross-imports (G); a predictable skeleton and file/naming convention (H);
+  golden-path runnable examples (I); a reproducibility/seed contract (J).
+
+## 2. Checker codes
+
+| Code | Severity | Meaning |
+|---|---|---|
+| `PKG-NO-DOCSTRING` | Defect | package `__init__.py` has no module docstring |
+| `ALL-MISSING` | Defect | no `__all__` |
+| `ALL-EXPORT-MISMATCH` | Defect | `__all__` ≠ relative re-exports (lists missing + stale) |
+| `PRIVATE-LEAK` | Defect | a `_`-prefixed name in `__all__` |
+| `TOPLEVEL-ALL-DRIFT` | Advisory | root `__all__` ≠ union(subpackage `__all__`) + appends |
+| `MAP-MISSING` | Defect | `docs/module_map.md` (dataflow map) absent |
+| `MAP-MISSING-SUBPKG` | Defect | a public subpackage is not covered by the map |
+| `MAP-STALE-SUBPKG` | Defect | the map roster names a removed subpackage |
+
+`0 defects` = the front-door contract holds. The checker is `ast`-based and
+**import-free**, so it runs without the package's optional extras installed.
+
+## 3. Front-door docstring template
+
+A package `__init__` docstring is **not** a feature-module docstring. The
+repo-specific opener convention, carve-out, and a worked example are in the
+conventions file (§5). Generic shape:
+
+```
+"""
+<Subpackage one-liner>.
+
+Public objects: <names — must equal this subpackage's __all__>.
+<How it connects to siblings — what it consumes / feeds>.
+
+See <conventions/rules> for conventions, <glossary> for domain terms, <ADR> for decisions.
+"""
+```
+
+"Public objects" must equal `__all__` (the checker enforces `__all__` ↔ re-exports;
+keep the prose list in step).
+
+## 4. Apply-mode discipline (generic)
+
+- A package `__init__.py` is a sensitive surface — show the diff, get explicit
+  per-file approval, never a blind multi-file write. (Repo's exact CONFIRM-FIRST
+  list: conventions file §6.)
+- A public-API (`__all__`) change carries semver weight — adding a symbol is a minor
+  bump; rename/remove needs a deprecation path. Touch `__all__` only to fix a genuine
+  `ALL-EXPORT-MISMATCH`; surface deltas separately.
+- After writing docstrings, the docs build is the final gate the checker can't see —
+  run it and confirm it still succeeds.
+- Defer docstring *prose* quality to the `docstrings` skill; this skill owns
+  *existence + `__all__` sync + navigability*.
+
+## 5. Audit-report template (use verbatim for a consistent output)
+
+Every audit ends with this shape, so results are comparable across runs:
+
+```markdown
+# Agent-readiness audit — <repo> @ <commit>
+
+**Structural (deterministic):** check_agentic_docs <N defects>; check_adrs <M defects>.
+> 0 defects = structural integrity (front-door exists + `__all__` synced + ADR hygiene),
+> NOT prose/semantic correctness — docstring quality is the `docstrings` skill's job.
+
+## Per-subpackage scorecard
+| subpackage | front-door (B) | __all__ (C) | type hints (D, judgment) | pointers |
+|---|---|---|---|---|
+| <name> | ✅/❌ PKG-NO-DOCSTRING | ✅/❌ | ✅/⚠/— | ✅/⚠ |
+
+## Repo-level (judgment)
+- A. Mental-model map: <present / ⚠ missing edges / drift>
+- F. Sub-minute smoke path: <documented? where?>
+
+## Deliberate — NOT flagged (won't-flag ledger)
+<list the sharp edges encountered, each marked "deliberate — see sharp-edges.md">
+
+## Prioritized fixes
+1. <issue> — <leverage> — <judgment | apply-mode (CONFIRM-FIRST)>
+```
+
+## 6. Bootstrapping a new repo (design settled; build at promotion)
+
+The conventions file (`aaanalysis_conventions.md` here) is the *only* repo-specific
+file. When this skill is taken to another package, create that repo's conventions by
+the **hybrid** path — derive what's derivable, interview the rest:
+
+1. **Derive (skill):** run `check_agentic_docs.py <pkg>` to enumerate the public
+   subpackages; scan for the repo's doc homes (`CLAUDE.md`/`AGENTS.md`, `docs/adr/`,
+   `CONTEXT.md`, a docstring guide); detect the ADR status format. These fill the
+   pointer table, subpackage list, and ADR-conventions section.
+2. **Interview (grill-with-docs):** settle the *judgment* parts — the won't-flag
+   ledger (what is a *deliberate* sharp edge in this repo?), the front-door voice /
+   template, and the dataflow map.
+
+**Status: design only.** Under the current project-scoped model this is moot for
+aaanalysis. Build a generic `conventions.template.md` + this workflow the first time
+the skill runs on a real second repo — not speculatively. (At that point the
+hard-coded `aaanalysis_conventions.md` references also become a generic discovered
+path; see the scoping note — promote to a global skill only once proven here.)
+
+## 7. Known coverage gaps (honest limits)
+
+- **Structural, not semantic.** A subpackage can pass every code while carrying a
+  *misleading* docstring — the checker proves the front-door exists and `__all__` is
+  synced, nothing about whether the prose is true. Always state this in the report.
+- **Prose `Public objects:` line drift — `PUBLIC-OBJECTS-PROSE-DRIFT` (decided: always-on
+  defect; build with the first front-door).** §3 requires the human-read
+  `Public objects:` line to equal `__all__`; today only `__all__` ↔ re-exports is
+  enforced, so the prose could drift. Decision: add this as an **always-run defect** in
+  `check_agentic_docs.py` (parse the `Public objects:` line, expand `X(+Plot)` →
+  `X, XPlot`, set-compare to `__all__`) — built alongside the first front-door (the
+  `metrics` pilot) so every audit thereafter guards it. The front-door's *other* claims
+  (purpose, siblings, pointers) stay judgment, not regex.
+- **Inter-module map (A) is curated, coverage-checked only.** `docs/module_map.md`
+  holds the dataflow map; `check_module_map.py` proves every public subpackage is
+  covered (and the roster has no dead entry) but **cannot verify the edges are
+  correct** — that stays human judgment. An import-graph generator was deliberately
+  *not* built: this repo's frontends are decoupled through the `utils` barrel (≈3
+  cross-subpackage edges total), so a derived import graph would miss the real flow.

--- a/.claude/skills/agent-readiness-audit/SKILL.md
+++ b/.claude/skills/agent-readiness-audit/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: agent-readiness-audit
+description: Audit and improve a Python package for agent-friendliness, applying the highest-leverage fix — a per-subpackage front-door = the PEP 257 module docstring in __init__.py (purpose, public objects, sibling links, pointers) plus an __all__ that matches its re-exports. Deterministic half is an ast-based checker (scripts/check_agentic_docs.py — PKG-NO-DOCSTRING, ALL-MISSING, ALL-EXPORT-MISMATCH, PRIVATE-LEAK, TOPLEVEL-ALL-DRIFT); the broader rubric (root call/data-flow map, type-hint consistency, feedback loops) is reviewed by hand, NOT scored by a tool. Audit-first: propose diffs, apply only on confirmation; __init__.py / __all__ edits are CONFIRM-FIRST and semver-relevant. All repo-specific facts (subpackage list, won't-flag ledger, doc pointers, front-door template) live in aaanalysis_conventions.md so they can be edited or swapped. Use when the user wants to make the codebase more agent-friendly, add or refresh subpackage front-door / module docstrings, audit __all__ / public-API legibility, build the inter-module mental-model map, or work the module-front-door task (issue #69).
+---
+
+# agent-readiness-audit — make a package legible to agents
+
+An agent-friendly codebase is a *legible* one with *tight feedback loops*. This
+skill audits a package against that bar and applies the highest-leverage fix: a
+per-subpackage **front-door** = the `__init__.py` module docstring + a synced
+`__all__`. It uses docstrings, **not READMEs** (PEP 257; the per-dir agent niche is
+already filled by auto-loading `.claude/rules/`).
+
+> **Two deliberate layers.** The **deterministic** layer is the checker (proves the
+> front-door *exists* and `__all__` is in sync). The **judgment** layer is the
+> [REFERENCE.md](REFERENCE.md) rubric (call-graph, type-hint consistency, feedback
+> loops) — **reviewed by hand, not scored by a script**; don't claim a tool result
+> for it. **All repo-specifics live in [aaanalysis_conventions.md](aaanalysis_conventions.md)**
+> (a swappable pointer file). The `docstrings` skill owns docstring *prose style*.
+
+## Quick start
+
+```bash
+SK=.claude/skills/agent-readiness-audit/scripts
+python3 $SK/check_agentic_docs.py aaanalysis      # front-door: __init__ docstring + __all__
+python3 $SK/check_adrs.py                          # decision-log hygiene (docs/adr/)
+python3 $SK/check_adrs.py --write-index            # (re)generate docs/adr/INDEX.md table
+python3 $SK/check_module_map.py                    # inter-module dataflow map coverage (docs/module_map.md)
+```
+
+`0 defects` = every public subpackage has a front-door docstring with an `__all__`
+in sync, and the decision log is mechanically clean. Output splits **Defects**
+(exit != 0) from **Advisory** (never fail), mirroring the `docstrings` checker.
+
+**Front-door codes** (`check_agentic_docs.py`):
+- `PKG-NO-DOCSTRING` — package `__init__.py` has no module docstring (empty front-door).
+- `ALL-MISSING` — no `__all__`.
+- `ALL-EXPORT-MISMATCH` — `__all__` ≠ the relative re-exports (0 missing / 0 stale).
+- `PRIVATE-LEAK` — a `_`-prefixed name in `__all__`.
+- `TOPLEVEL-ALL-DRIFT` (advisory) — top-level `__all__` ≠ union of subpackage
+  `__all__`s + the dynamic pro/dev `append` stubs.
+
+**ADR-hygiene codes** (`check_adrs.py`):
+- `ADR-NO-STATUS` / `ADR-BAD-STATUS` — missing/malformed `Status:` line.
+- `ADR-XREF-DANGLING` — an `ADR-NNNN` reference with no such ADR (catches a
+  reference left stale after an ADR is removed).
+- `ADR-IN-CODE` — source code references an ADR (the repo convention forbids it).
+- `ADR-INDEX-MISSING` / `ADR-INDEX-STALE` — the overview table `docs/adr/INDEX.md`
+  is absent or out of date (regenerate with `--write-index`).
+- `ADR-SUPERSEDED` / `ADR-SUPERSEDE-ASYMMETRIC` (advisory) — superseded ADRs surfaced
+  for review; non-reciprocal supersession.
+
+**Module-map codes** (`check_module_map.py` — validates the *curated* dataflow map):
+- `MAP-MISSING` — `docs/module_map.md` absent.
+- `MAP-MISSING-SUBPKG` / `MAP-STALE-SUBPKG` — a public subpackage is missing from the
+  map, or the roster names one that no longer exists (`--write-roster` to resync).
+  The map is **curated by hand** (semantic dataflow can't be auto-derived); the
+  validator only proves coverage, not that the edges are correct.
+
+(`PKG-NO-DOCSTRING` is deliberately distinct from the `docstrings` skill's
+`INIT-NO-DOCSTRING`, which means a class `__init__` *method* lacking a docstring.)
+Whether an ADR's **content** is outdated is judgment (rubric A), not a checker code.
+
+## Three modes
+
+1. **Audit (default, read-only).** Run the checker, then score each subpackage on
+   the deterministic codes and review the judgment rubric by hand. Output a
+   prioritized report and **state the deliberate sharp edges as "not flagged"**
+   (the won't-flag ledger in the conventions file) so the scan reads as honest.
+2. **Apply (CONFIRM-FIRST).** Draft front-door docstrings from the *actual*
+   re-exports + sibling relationships using the conventions-file template; show the
+   diff; edit `__init__.py` **only on explicit per-file confirmation**. Treat any
+   `__all__` change as semver-relevant — surface it separately, never silently.
+   Defer deep docstring prose to the `docstrings` skill.
+3. **Refresh.** Re-run both checkers after code/ADR changes; regenerate any
+   front-door whose public API drifted from `__all__`, and re-run
+   `check_adrs.py --write-index` so the ADR overview table stays current.
+
+## Rules
+
+- **Audit-first, never bulk-overwrite.** A confident-but-stale docstring misleads
+  an agent worse than none.
+- **Honor the won't-flag ledger** (conventions file → derived from
+  `sharp-edges.md`); name deliberate choices, don't "fix" them.
+- **Type hints, map, smoke-path = judgment, not tooling.** Only the front-door /
+  `__all__` codes are deterministic. Don't report an un-tooled dimension as if a
+  script produced it.
+- **Link, don't duplicate** the authoritative homes.
+- **ADRs are append-only.** Flag superseded/contradictory ADRs and fix stale
+  references; never delete an ADR — supersede it (new ADR + flip old status).
+  Deletion needs the maintainer's explicit go-ahead (`docs/adr/README.md` + hard rule).
+- **Verify before asserting.** A claimed gap is a candidate until checked against source.
+
+## See also
+
+- [REFERENCE.md](REFERENCE.md) — portable rubric, front-door template, apply discipline.
+- [aaanalysis_conventions.md](aaanalysis_conventions.md) — all repo-specifics (swappable).
+- `docstrings` skill — docstring prose + numpydoc + doc-vs-signature drift.
+- Issue **#69** (module front-door) and **#126** (inter-module mental model).

--- a/.claude/skills/agent-readiness-audit/aaanalysis_conventions.md
+++ b/.claude/skills/agent-readiness-audit/aaanalysis_conventions.md
@@ -1,0 +1,136 @@
+# AAanalysis conventions (for `agent-readiness-audit`)
+
+**This is the only repo-specific file in the skill.** [SKILL.md](SKILL.md) and
+[REFERENCE.md](REFERENCE.md) are portable methodology; everything that ties the
+skill to *this* codebase lives here, and it is mostly **pointers to the
+authoritative docs** (so they stay the single source of truth). To retarget the
+skill at another package, replace this file.
+
+> Rule of thumb: if a fact about the repo could change, it belongs here as a
+> pointer — never hard-coded into SKILL.md / REFERENCE.md / the checker.
+
+---
+
+## 1. Authoritative docs (pointers — do not duplicate, link)
+
+| Topic | Source of truth |
+|---|---|
+| Scope, hard rules, CONFIRM-FIRST surfaces | `CLAUDE.md` |
+| Repo tree, class templates, extras | `.claude/rules/repo-layout.md` |
+| Accepted sharp edges (the won't-flag basis) | `.claude/rules/sharp-edges.md` |
+| Code conventions, type hints, module skeleton | `.claude/rules/code-conventions.md` |
+| Frontend/backend split, validation | `.claude/rules/frontend-backend.md` |
+| Pro/core boundary, `missing_feature_stub` | `.claude/rules/pro-core-boundary.md` |
+| Public-API stability / semver | `.claude/rules/api-stability.md` |
+| Errors / warnings / logging | `.claude/rules/errors-warnings-logging.md` |
+| Reproducibility (`random_state`/`seed`) | `.claude/rules/reproducibility.md` |
+| Domain glossary | `CONTEXT.md` |
+| Architecture decisions | `docs/adr/` (0001–0033) |
+| Internal dataflow map (curated Mermaid) | `docs/module_map.md` (GitHub; RTD version via #106) |
+| Docstring prose style | `docs/source/index/docstring_guide.rst` (+ the `docstrings` skill) |
+
+## 2. Public subpackages the checker scans
+
+`feature_engineering`, `data_handling`, `seq_analysis`, `pu_learning`,
+`explainable_ai`, `plotting`, `metrics`, `protein_design`, and the `*_pro` /
+dev siblings `data_handling_pro`, `seq_analysis_pro`, `explainable_ai_pro`,
+`show_html`. Internal dirs (`_utils/`, `_backend/`, `_data/`) are skipped by the
+leading-underscore rule. The top-level `aaanalysis/__init__.py` appends the 7
+pro/dev symbols via `__all__.append(...)` inside `try/except ImportError`; the
+`TOPLEVEL-ALL-DRIFT` check parses those.
+
+## 3. Won't-flag ledger (deliberate sharp edges — name, never "fix")
+
+**Source of truth: `.claude/rules/sharp-edges.md` + the root hard rules.** The audit
+must name these as deliberate and never propose fixing them — this is what keeps the
+scan honest. Distilled:
+
+- `utils.py` ~1500-line god-module (v2 refactor).
+- No CI type checker / `ruff` / `pre-commit` / mypy config (out until v2).
+- Bare `ValueError`/`RuntimeError`; no `AAanalysisError` base.
+- Positional-list backend rows (no NamedTuple/dataclass until v2).
+- `[project]` + `[tool.poetry]` duality in `pyproject.toml`.
+- No `SECURITY.md`.
+- The rejected perf optimizations (ADR-0032 / ADR-0033).
+
+Out of scope here, owned elsewhere: docstring prose (`docstrings` skill),
+refactoring (`improve-codebase-architecture`), issue triage (`github-issues`).
+
+## 4. Per-repo rubric status (snapshot — re-check on audit)
+
+Against the REFERENCE rubric: **A** root map ✓ except the inter-module call/data-flow
+graph ⚠ (the #126 mental-model); **B** front-doors ⚠ (all 12 `__init__.py` empty
+today); **C** `__all__` ✓ but unguarded → the checker guards it; **D** type hints —
+convention exists, presence is hand-reviewed (no tool); **E** docstrings ✓ (owned by
+`docstrings`); **F** ⚠ a documented sub-minute smoke path; **G–J** ✓ strong (verify,
+don't churn).
+
+## 5. Front-door template + the carve-out
+
+A package `__init__` docstring is **not** a feature-module docstring, so it does
+**not** open with `"""This is a script for ..."""` (that skeleton in
+`code-conventions.md` is for `_<feature>.py`). **Known tension:** `code-conventions.md`
+states the opener applies to "every module" with no carve-out — an agent could
+"correct" a front-door to the script opener. Apply-mode should add a one-line
+exemption to `code-conventions.md` (or `docstring_guide.rst`) when it first writes
+front-doors. The opener is **not** tool-enforced (`check_docstrings.py` does not check
+module-docstring openers), so there is no automated conflict today.
+
+Template (defer prose to `docstring_guide.rst`):
+
+```
+"""
+<Subpackage one-liner, in the package's voice>.
+
+Public objects: <Class>(+Plot), <func>, ...   # must equal this subpackage's __all__.
+<How it connects to siblings — what it consumes / feeds>.
+
+See ``.claude/rules/<relevant>.md`` for conventions, ``CONTEXT.md`` for domain terms
+(<the glossary terms this subpackage owns>), ADR-<NNNN> for <the decision>.
+"""
+```
+
+Worked example (`feature_engineering`):
+
+```
+"""
+Feature engineering: scale-based amino-acid features for interpretable prediction.
+
+Public objects: AAclust(+Plot), SequenceFeature, NumericalFeature, CPP, CPPGrid, CPPPlot.
+Consumes scale sets from ``data_handling.load_scales``; CPP features (``df_feat``)
+feed ``explainable_ai.TreeModel`` and ``protein_design``.
+
+See ``.claude/rules/code-conventions.md`` / ``frontend-backend.md`` for conventions,
+``CONTEXT.md`` for domain terms (df_parts, part, split, scale), ADR-0001 for the CPP backend.
+"""
+```
+
+For a `*_pro` subpackage, name the gating dependency and cross-link its core sibling
+(`pro-core-boundary.md`).
+
+## 6. ADR (decision-log) conventions
+
+Source of truth: `docs/adr/README.md`. Enforced by `scripts/check_adrs.py`.
+
+- **Status line** (line ~3, inline, never YAML): `Status: Accepted — YYYY-MM-DD` or
+  `Status: Superseded by ADR-MMMM`; partial supersession noted in a parenthetical.
+- **Append-only / immutable once Accepted.** Reverse a decision with a *new* ADR and
+  flip the old status — do **not** edit a decision in place. **Delete only when fully
+  obsolete and only with the maintainer's explicit go-ahead** (repo hard rule). The
+  checker surfaces superseded ADRs as *advisory* (visibility), never auto-deletes.
+- **Code must never reference an ADR** — put rationale inline in the comment. The
+  checker's `ADR-IN-CODE` enforces this (currently 4 known violations:
+  `utils.py:204,383`, `_get_feature_matrix_fast.py:79,98` — fix on touch; the two in
+  `_get_feature_matrix_fast.py` are inside docstrings, which the house style also forbids).
+- **Overview table:** `docs/adr/INDEX.md` (a separate file from `README.md`) holds the
+  auto-generated table between `ADR-INDEX:START/END` markers. Regenerate with
+  `check_adrs.py --write-index`; `ADR-INDEX-STALE` fires if it drifts. README stays the
+  prose conventions doc; INDEX is the machine-maintained roster.
+
+## 7. Apply-mode: CONFIRM-FIRST + semver here
+
+`aaanalysis/__init__.py` and every subpackage `__init__.py` are CONFIRM-FIRST
+(CLAUDE.md §2). An `__all__` change is semver-relevant (`api-stability.md`): adding a
+symbol = minor bump; rename/remove needs a deprecation shim. Touch `__all__` only to
+fix a genuine `ALL-EXPORT-MISMATCH`; surface any delta separately. Final gate after
+writing docstrings: `cd docs && make html` must still succeed.

--- a/.claude/skills/agent-readiness-audit/scripts/check_adrs.py
+++ b/.claude/skills/agent-readiness-audit/scripts/check_adrs.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""ADR-hygiene checker + overview-table generator for ``agent-readiness-audit``.
+
+The decision log (``docs/adr/``) is part of an agent's mental model: a stale or
+contradictory ADR misleads exactly like a stale README. This proves the
+*structural* half of ADR hygiene — status lines well-formed, cross-references
+resolve, supersession targets exist, the repo convention "code must never
+reference an ADR" holds, and the auto-generated overview table (``INDEX.md``) is
+present and current. Whether an ADR's *content* is outdated is judgment a
+reviewer makes; this script only flags mechanical defects.
+
+It does **not** delete anything. Per ``docs/adr/README.md`` the log is append-only:
+reverse a decision by writing a new ADR that supersedes it and flipping the old
+status — delete only when fully obsolete and only with the maintainer's explicit
+go-ahead (repo hard rule). Superseded ADRs are surfaced as advisory, not defects.
+
+Output mirrors ``check_agentic_docs.py``: Defects (exit != 0) vs Advisory.
+
+Usage:
+    python .../check_adrs.py [--adr-dir docs/adr] [--src aaanalysis]
+    python .../check_adrs.py --write-index      # (re)generate docs/adr/INDEX.md
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+
+ADR_FILE_RE = re.compile(r"^(\d{4})-.*\.md$")
+ADR_TOKEN_RE = re.compile(r"ADR-(\d{3,4})")
+STATUS_RE = re.compile(r"^Status:\s*(.+)$", re.MULTILINE)
+TITLE_RE = re.compile(r"^#\s*ADR-\d{3,4}\s*[—\-–:]\s*(.+?)\s*$", re.MULTILINE)
+SUPERSEDE_RE = re.compile(r"[Ss]uperseded by ADR-(\d{3,4})")
+STATUS_PARTS_RE = re.compile(
+    r"^(?P<word>\w+)\s*[—\-–]?\s*(?P<date>\d{4}-\d{2}-\d{2})?\s*(?:\((?P<note>.*)\))?")
+
+INDEX_FILE = "INDEX.md"
+INDEX_START = "<!-- ADR-INDEX:START — auto-generated; regenerate with check_adrs.py --write-index -->"
+INDEX_END = "<!-- ADR-INDEX:END -->"
+INDEX_HEADER = """# ADR index
+
+Auto-generated overview of every Architecture Decision Record. The conventions
+(when to write one, the template, status rules) live in [README.md](README.md).
+
+Regenerate this table with:
+`python .claude/skills/agent-readiness-audit/scripts/check_adrs.py --write-index`
+
+"""
+
+ADVISORY_CODES = {"ADR-SUPERSEDED", "ADR-SUPERSEDE-ASYMMETRIC"}
+
+
+class Finding:
+    __slots__ = ("where", "code", "detail")
+
+    def __init__(self, where: str, code: str, detail: str) -> None:
+        self.where, self.code, self.detail = where, code, detail
+
+    @property
+    def is_defect(self) -> bool:
+        return self.code not in ADVISORY_CODES
+
+
+# --------------------------------------------------------------------------- #
+# I Helper Functions
+# --------------------------------------------------------------------------- #
+def _adr_files(adr_dir: str):
+    out = {}
+    for name in sorted(os.listdir(adr_dir)):
+        m = ADR_FILE_RE.match(name)
+        if m:
+            out[int(m.group(1))] = os.path.join(adr_dir, name)
+    return out
+
+
+def _read(path: str) -> str:
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _status(text: str):
+    m = STATUS_RE.search(text)
+    return m.group(1).strip() if m else None
+
+
+def _title(text: str):
+    m = TITLE_RE.search(text)
+    return m.group(1).strip() if m else "(no title)"
+
+
+def _parse_status(status: str):
+    """Return (word, date, note) from a Status: line value."""
+    if not status:
+        return ("", "", "")
+    m = STATUS_PARTS_RE.match(status)
+    if not m:
+        return (status, "", "")
+    return (m.group("word") or "", m.group("date") or "", (m.group("note") or "").strip())
+
+
+def _build_index_region(adrs) -> str:
+    rows = ["| ADR | Title | Status | Date | Notes |", "|----:|-------|--------|------|-------|"]
+    for num in sorted(adrs):
+        text = _read(adrs[num])
+        word, date, note = _parse_status(_status(text) or "")
+        link = f"[{num:04d}]({os.path.basename(adrs[num])})"
+        rows.append(f"| {link} | {_title(text)} | {word} | {date} | {note} |")
+    return f"{INDEX_START}\n" + "\n".join(rows) + f"\n{INDEX_END}\n"
+
+
+def _extract_region(text: str):
+    if INDEX_START in text and INDEX_END in text:
+        i = text.index(INDEX_START)
+        j = text.index(INDEX_END) + len(INDEX_END)
+        return text[i:j].strip() + "\n"
+    return None
+
+
+def _render_full(existing: str, region: str) -> str:
+    if existing and INDEX_START in existing and INDEX_END in existing:
+        pre = existing[:existing.index(INDEX_START)]
+        post = existing[existing.index(INDEX_END) + len(INDEX_END):]
+        return pre + region.rstrip("\n") + post
+    return INDEX_HEADER + region
+
+
+def _check_one(num, path, text, existing, files):
+    findings = []
+    name = os.path.basename(path)
+    status = _status(text)
+    if status is None:
+        findings.append(Finding(name, "ADR-NO-STATUS", "no 'Status:' line"))
+    else:
+        if not re.match(r"(Accepted|Superseded|Proposed|Deprecated)", status):
+            findings.append(Finding(name, "ADR-BAD-STATUS",
+                                    f"status not Accepted/Superseded/...: {status!r}"))
+        if re.search(r"[Ss]uperseded", status):
+            findings.append(Finding(name, "ADR-SUPERSEDED", f"status: {status!r}"))
+        for target in (int(t) for t in SUPERSEDE_RE.findall(status)):
+            if target in existing:
+                back = _read(files[target])
+                if f"ADR-{num:04d}" not in back and f"ADR-{num}" not in back:
+                    findings.append(Finding(name, "ADR-SUPERSEDE-ASYMMETRIC",
+                                            f"ADR-{target:04d} does not reference back to ADR-{num:04d}"))
+    for tok in sorted(set(int(t) for t in ADR_TOKEN_RE.findall(text))):
+        if tok != num and tok not in existing:
+            findings.append(Finding(name, "ADR-XREF-DANGLING",
+                                    f"references ADR-{tok:04d} (no such ADR)"))
+    return findings
+
+
+def _check_code_refs(src: str):
+    """Convention (docs/adr/README.md): code must never reference an ADR."""
+    findings = []
+    if not os.path.isdir(src):
+        return findings
+    for root, dirs, files in os.walk(src):
+        dirs[:] = [d for d in dirs if d != "__pycache__"]
+        for fn in sorted(files):
+            if not fn.endswith(".py"):
+                continue
+            p = os.path.join(root, fn)
+            for i, line in enumerate(_read(p).splitlines(), 1):
+                m = ADR_TOKEN_RE.search(line)
+                if m:
+                    findings.append(Finding(f"{p}:{i}", "ADR-IN-CODE",
+                                            f"code references ADR-{int(m.group(1)):04d} "
+                                            f"(put the rationale inline instead)"))
+    return findings
+
+
+def _check_index(adr_dir, adrs):
+    region = _build_index_region(adrs)
+    path = os.path.join(adr_dir, INDEX_FILE)
+    if not os.path.isfile(path):
+        return [Finding(INDEX_FILE, "ADR-INDEX-MISSING",
+                        "no overview table (run --write-index)")]
+    have = _extract_region(_read(path))
+    if have is None:
+        return [Finding(INDEX_FILE, "ADR-INDEX-MISSING",
+                        "INDEX.md has no ADR-INDEX markers (run --write-index)")]
+    if have.strip() != region.strip():
+        return [Finding(INDEX_FILE, "ADR-INDEX-STALE",
+                        "overview table out of date (run --write-index)")]
+    return []
+
+
+# --------------------------------------------------------------------------- #
+# II Main Functions
+# --------------------------------------------------------------------------- #
+def run(adr_dir: str, src: str, write_index: bool) -> int:
+    if not os.path.isdir(adr_dir):
+        print(f"error: ADR dir '{adr_dir}' not found")
+        return 2
+    adrs = _adr_files(adr_dir)
+    existing = set(adrs)
+
+    if write_index:
+        path = os.path.join(adr_dir, INDEX_FILE)
+        prev = _read(path) if os.path.isfile(path) else ""
+        full = _render_full(prev, _build_index_region(adrs))
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(full)
+        print(f"wrote {path} ({len(adrs)} ADRs)")
+        return 0
+
+    findings = []
+    for num, path in adrs.items():
+        findings.extend(_check_one(num, path, _read(path), existing, adrs))
+    findings.extend(_check_code_refs(src))
+    findings.extend(_check_index(adr_dir, adrs))
+
+    defects = [f for f in findings if f.is_defect]
+    advisory = [f for f in findings if not f.is_defect]
+
+    print(f"agent-readiness-audit — ADR-hygiene check on {adr_dir}")
+    print(f"  scanned {len(adrs)} ADR(s); code-ref scan in {src}/\n")
+    if defects:
+        print("Defects:")
+        for f in defects:
+            print(f"  [{f.code}] {f.where}: {f.detail}")
+    else:
+        print("Defects: none — status lines well-formed, cross-refs resolve, "
+              "no ADR referenced from code, overview table current.")
+    if advisory:
+        print("\nAdvisory:")
+        for f in advisory:
+            print(f"  [{f.code}] {f.where}: {f.detail}")
+    print(f"\nSummary: {len(defects)} defect(s), {len(advisory)} advisory.")
+    return 1 if defects else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="ADR-hygiene checker + overview generator.")
+    ap.add_argument("--adr-dir", default="docs/adr", help="ADR directory (default: docs/adr)")
+    ap.add_argument("--src", default="aaanalysis", help="source tree to scan for ADR refs")
+    ap.add_argument("--write-index", action="store_true",
+                    help="(re)generate the overview table at <adr-dir>/INDEX.md")
+    args = ap.parse_args()
+    return run(args.adr_dir, args.src, args.write_index)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/agent-readiness-audit/scripts/check_agentic_docs.py
+++ b/.claude/skills/agent-readiness-audit/scripts/check_agentic_docs.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Deterministic front-door checker for the ``agent-readiness-audit`` skill.
+
+Proves the *structural* half of agent-friendliness: every public subpackage has a
+module-level ``__init__.py`` docstring (the local entry point), an ``__all__`` that
+matches its actual re-exports (0 missing / 0 stale), no private leak, and a
+top-level ``aaanalysis.__all__`` that equals the union of the subpackage surfaces.
+
+Static + ``ast``-based: it never imports the package, so it is safe to run without
+the optional ``pro`` / ``embed`` / ``dev`` dependencies installed (the very deps
+that make a live import fail). Output mirrors ``docstrings/scripts/check_docstrings.py``:
+**Defects** (exit != 0) vs **Advisory** (never fail).
+
+Usage:
+    python .claude/skills/agent-readiness-audit/scripts/check_agentic_docs.py [PATH]
+
+PATH defaults to ``aaanalysis`` (the package root, i.e. the dir holding the
+top-level ``__init__.py``). A single subpackage dir also works.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import sys
+
+# Dirs that are deliberately internal — no public front-door expected (see
+# .claude/rules/repo-layout.md). A leading underscore already marks the rest.
+SKIP_DIRS = {"_utils", "_backend", "_data", "__pycache__"}
+
+# Defect codes fail the run; advisory codes never do (mirror check_docstrings.py).
+ADVISORY_CODES = {"TOPLEVEL-ALL-DRIFT"}
+
+
+class Finding:
+    __slots__ = ("path", "code", "detail")
+
+    def __init__(self, path: str, code: str, detail: str) -> None:
+        self.path = path
+        self.code = code
+        self.detail = detail
+
+    @property
+    def is_defect(self) -> bool:
+        return self.code not in ADVISORY_CODES
+
+
+# ----------------------------------------------------------------------------- #
+# I Helper Functions
+# ----------------------------------------------------------------------------- #
+def _parse(init_path: str) -> ast.Module:
+    with open(init_path, encoding="utf-8") as fh:
+        return ast.parse(fh.read(), filename=init_path)
+
+
+def _all_list(tree: ast.Module):
+    """Return the literal value assigned to ``__all__`` (a list[str]), or None."""
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "__all__" for t in node.targets
+        ):
+            try:
+                return list(ast.literal_eval(node.value))
+            except (ValueError, SyntaxError):
+                return None
+    return None
+
+
+def _appended_names(tree: ast.Module):
+    """Names added via ``__all__.append("X")`` (the top-level pro/dev stubs)."""
+    out = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "append"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "__all__"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+        ):
+            out.append(node.args[0].value)
+    return out
+
+
+def _relative_reexports(tree: ast.Module):
+    """Public names bound by a *relative* ``from .x import Y`` (the re-exports).
+
+    Relative-only filtering cleanly drops absolute/stdlib imports (``import
+    warnings``, ``from importlib.metadata import version``); underscore filtering
+    drops private helpers.
+    """
+    names = set()
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom) and (node.level or 0) > 0:
+            for alias in node.names:
+                bound = alias.asname or alias.name
+                if not bound.startswith("_"):
+                    names.add(bound)
+    return names
+
+
+def _public_subpackages(pkg_root: str):
+    """Yield (name, init_path) for every public subpackage under pkg_root."""
+    for name in sorted(os.listdir(pkg_root)):
+        if name.startswith("_") or name in SKIP_DIRS:
+            continue
+        sub = os.path.join(pkg_root, name)
+        init_path = os.path.join(sub, "__init__.py")
+        if os.path.isdir(sub) and os.path.isfile(init_path):
+            yield name, init_path
+
+
+def _check_subpackage(name: str, init_path: str):
+    findings = []
+    rel = os.path.join(name, "__init__.py")
+    tree = _parse(init_path)
+
+    if ast.get_docstring(tree) is None:
+        # PKG-NO-DOCSTRING (not INIT-NO-DOCSTRING): this is the *package module*
+        # docstring. The docstrings skill's INIT-NO-DOCSTRING means a class
+        # __init__ *method* without a docstring — a different thing.
+        findings.append(Finding(rel, "PKG-NO-DOCSTRING",
+                                "no module docstring (the front-door is empty)"))
+
+    all_list = _all_list(tree)
+    if all_list is None:
+        findings.append(Finding(rel, "ALL-MISSING", "no __all__ defined"))
+        return findings  # nothing more to compare against
+
+    private = [x for x in all_list if x.startswith("_")]
+    if private:
+        findings.append(Finding(rel, "PRIVATE-LEAK",
+                                f"private name(s) in __all__: {sorted(private)}"))
+
+    reexports = _relative_reexports(tree)
+    declared = set(all_list)
+    missing = reexports - declared          # re-exported but not in __all__
+    stale = declared - reexports - set(private)  # in __all__ but not re-exported
+    if missing or stale:
+        bits = []
+        if missing:
+            bits.append(f"missing from __all__: {sorted(missing)}")
+        if stale:
+            bits.append(f"stale in __all__ (not re-exported): {sorted(stale)}")
+        findings.append(Finding(rel, "ALL-EXPORT-MISMATCH", "; ".join(bits)))
+
+    return findings
+
+
+def _check_toplevel(pkg_root: str, sub_all):
+    """Advisory: top-level __all__ (static + appended) == union(subpackages) + options."""
+    init_path = os.path.join(pkg_root, "__init__.py")
+    if not os.path.isfile(init_path):
+        return []
+    tree = _parse(init_path)
+    static = _all_list(tree) or []
+    appended = _appended_names(tree)
+    top = set(static) | set(appended)
+
+    expected = set().union(*sub_all.values()) if sub_all else set()
+    expected.add("options")  # re-exported from .config, not a subpackage
+
+    missing = expected - top
+    extra = top - expected
+    findings = []
+    if missing or extra:
+        bits = []
+        if missing:
+            bits.append(f"subpackage symbols absent from aaanalysis.__all__: {sorted(missing)}")
+        if extra:
+            bits.append(f"in aaanalysis.__all__ but no subpackage exports it: {sorted(extra)}")
+        findings.append(Finding("__init__.py", "TOPLEVEL-ALL-DRIFT", "; ".join(bits)))
+    return findings
+
+
+# ----------------------------------------------------------------------------- #
+# II Main Functions
+# ----------------------------------------------------------------------------- #
+def run(path: str) -> int:
+    path = os.path.abspath(path)
+    # Resolve to a package root (a dir holding __init__.py).
+    if os.path.isfile(path):
+        path = os.path.dirname(path)
+    if not os.path.isfile(os.path.join(path, "__init__.py")):
+        print(f"error: '{path}' is not a Python package (no __init__.py)", file=sys.stderr)
+        return 2
+
+    findings = []
+    subpkgs = list(_public_subpackages(path))
+
+    if subpkgs:
+        # ``path`` is a package root (e.g. aaanalysis): check every child
+        # subpackage and reconcile the top-level __all__ union.
+        sub_all = {}
+        for name, init_path in subpkgs:
+            findings.extend(_check_subpackage(name, init_path))
+            sub_all[name] = set(_all_list(_parse(init_path)) or [])
+        findings.extend(_check_toplevel(path, sub_all))
+        scanned = len(sub_all)
+    else:
+        # ``path`` is a single leaf subpackage (e.g. aaanalysis/metrics): check
+        # just its own front-door — the union check applies only at the root.
+        findings.extend(_check_subpackage(os.path.basename(path),
+                                          os.path.join(path, "__init__.py")))
+        scanned = 1
+
+    defects = [f for f in findings if f.is_defect]
+    advisory = [f for f in findings if not f.is_defect]
+
+    print(f"agent-readiness-audit — front-door check on {path}")
+    print(f"  scanned {scanned} public subpackage(s)\n")
+
+    if defects:
+        print("Defects:")
+        for f in defects:
+            print(f"  [{f.code}] {f.path}: {f.detail}")
+    else:
+        print("Defects: none — every public subpackage has a front-door docstring "
+              "and an __all__ in sync with its re-exports.")
+
+    if advisory:
+        print("\nAdvisory:")
+        for f in advisory:
+            print(f"  [{f.code}] {f.path}: {f.detail}")
+
+    print(f"\nSummary: {len(defects)} defect(s), {len(advisory)} advisory.")
+    print("Note: 0 defects = structural front-door integrity (docstring exists + __all__ "
+          "in sync), NOT prose/semantic quality — that is the docstrings skill's job.")
+    return 1 if defects else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Front-door (__init__ docstring + __all__) checker.")
+    ap.add_argument("path", nargs="?", default="aaanalysis",
+                    help="package root or a subpackage dir (default: aaanalysis)")
+    args = ap.parse_args()
+    return run(args.path)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/agent-readiness-audit/scripts/check_module_map.py
+++ b/.claude/skills/agent-readiness-audit/scripts/check_module_map.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Module-map validator for the ``agent-readiness-audit`` skill.
+
+Checks the curated internal-dataflow map (default ``docs/module_map.md``) stays in
+step with the package. It is a **validator, not a generator**: the diagram/prose is
+curated by hand because a *semantic* dataflow (which DataFrame flows where) cannot
+be reliably derived from imports — in this repo the frontends are decoupled and
+route through the ``utils`` barrel, so an import graph would miss the real flow.
+
+What it proves (deterministic, text-based):
+  MAP-MISSING        — the map file does not exist.
+  MAP-MISSING-SUBPKG — a current public subpackage is absent from the map.
+  MAP-STALE-SUBPKG   — the map's roster names a subpackage that no longer exists.
+What it cannot prove: that the curated edges/data objects are *correct* — that is a
+human judgment (rubric A).
+
+Usage:
+    python .../check_module_map.py [--map docs/module_map.md] [--pkg aaanalysis]
+    python .../check_module_map.py --write-roster      # regenerate the roster block
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+
+SKIP_DIRS = {"_utils", "_backend", "_data", "__pycache__"}
+ROSTER_START = "<!-- MAP-SUBPKGS:START — roster checked by check_module_map.py; regenerate with --write-roster -->"
+ROSTER_END = "<!-- MAP-SUBPKGS:END -->"
+ADVISORY_CODES: set = set()
+
+
+class Finding:
+    __slots__ = ("where", "code", "detail")
+
+    def __init__(self, where, code, detail):
+        self.where, self.code, self.detail = where, code, detail
+
+    @property
+    def is_defect(self):
+        return self.code not in ADVISORY_CODES
+
+
+# --------------------------------------------------------------------------- #
+# I Helper Functions
+# --------------------------------------------------------------------------- #
+def _public_subpackages(pkg_root):
+    out = []
+    for name in sorted(os.listdir(pkg_root)):
+        if name.startswith("_") or name in SKIP_DIRS:
+            continue
+        if os.path.isfile(os.path.join(pkg_root, name, "__init__.py")):
+            out.append(name)
+    return out
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _roster(text):
+    if ROSTER_START in text and ROSTER_END in text:
+        block = text[text.index(ROSTER_START) + len(ROSTER_START): text.index(ROSTER_END)]
+        return [m.group(1) for m in re.finditer(r"^\s*-\s*(\S+)", block, re.MULTILINE)]
+    return None
+
+
+def _render_roster(subpkgs):
+    lines = "\n".join(f"- {s}" for s in sorted(subpkgs))
+    return f"{ROSTER_START}\n{lines}\n{ROSTER_END}"
+
+
+# --------------------------------------------------------------------------- #
+# II Main Functions
+# --------------------------------------------------------------------------- #
+def run(map_path, pkg_root, write_roster):
+    if not os.path.isfile(os.path.join(pkg_root, "__init__.py")):
+        print(f"error: '{pkg_root}' is not a package")
+        return 2
+    live = _public_subpackages(pkg_root)
+
+    if write_roster:
+        if not os.path.isfile(map_path):
+            print(f"error: map '{map_path}' not found — create it first")
+            return 2
+        text = _read(map_path)
+        if ROSTER_START not in text:
+            print(f"error: no roster markers in {map_path}")
+            return 2
+        new = text[:text.index(ROSTER_START)] + _render_roster(live) + text[text.index(ROSTER_END) + len(ROSTER_END):]
+        with open(map_path, "w", encoding="utf-8") as fh:
+            fh.write(new)
+        print(f"wrote roster ({len(live)} subpackages) to {map_path}")
+        return 0
+
+    findings = []
+    if not os.path.isfile(map_path):
+        findings.append(Finding(map_path, "MAP-MISSING", "no module map (the inter-module mental model is absent)"))
+    else:
+        text = _read(map_path)
+        for sub in live:                                    # coverage: live ⊆ map text
+            if not re.search(rf"\b{re.escape(sub)}\b", text):
+                findings.append(Finding(os.path.basename(map_path), "MAP-MISSING-SUBPKG",
+                                        f"public subpackage '{sub}' not mentioned in the map"))
+        roster = _roster(text)
+        if roster is not None:                              # staleness: roster ⊆ live
+            for sub in roster:
+                if sub not in live:
+                    findings.append(Finding(os.path.basename(map_path), "MAP-STALE-SUBPKG",
+                                            f"roster names '{sub}' which is no longer a public subpackage"))
+
+    defects = [f for f in findings if f.is_defect]
+    print(f"agent-readiness-audit — module-map check on {map_path}")
+    print(f"  {len(live)} live public subpackage(s)\n")
+    if defects:
+        print("Defects:")
+        for f in defects:
+            print(f"  [{f.code}] {f.where}: {f.detail}")
+    else:
+        print("Defects: none — the map exists and covers every public subpackage.")
+    print(f"\nSummary: {len(defects)} defect(s).")
+    print("Note: this validates coverage only — whether the curated edges/data objects "
+          "are CORRECT is human judgment (rubric A), not a checker result.")
+    return 1 if defects else 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Module-map (internal dataflow) validator.")
+    ap.add_argument("--map", default="docs/module_map.md", help="map file (default: docs/module_map.md)")
+    ap.add_argument("--pkg", default="aaanalysis", help="package root (default: aaanalysis)")
+    ap.add_argument("--write-roster", action="store_true", help="regenerate the roster block from live subpackages")
+    args = ap.parse_args()
+    return run(args.map, args.pkg, args.write_roster)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -1,0 +1,45 @@
+# ADR index
+
+Auto-generated overview of every Architecture Decision Record. The conventions
+(when to write one, the template, status rules) live in [README.md](README.md).
+
+Regenerate this table with:
+`python .claude/skills/agent-readiness-audit/scripts/check_adrs.py --write-index`
+
+<!-- ADR-INDEX:START — auto-generated; regenerate with check_adrs.py --write-index -->
+| ADR | Title | Status | Date | Notes |
+|----:|-------|--------|------|-------|
+| [0001](0001-cpp-backend-architecture.md) | CPP backend architecture: unified numerical pipeline + Cython acceleration | Accepted | 2026-05-25 |  |
+| [0002](0002-structure-preprocessor-alphafold-features.md) | StructurePreprocessor: AlphaFold per-residue features (feature-set rev 1.1) | Accepted | 2026-05-25 |  |
+| [0003](0003-residue-annotation-layer.md) | Residue-level annotation layer (AnnotationPreprocessor) | Accepted | 2026-05-25 |  |
+| [0004](0004-domain-segmentation-wrapper.md) | Domain segmentation: wrap ChainSaw + AFragmenter; Merizo stays BYO | Accepted | 2026-05-25 |  |
+| [0005](0005-feature-preprocessor-family.md) | Feature-preprocessor family: consolidate into `data_handling_pro`, unify the protocol | Accepted | 2026-05-29 | partially superseded by ADR-0011, 2026-06-01 |
+| [0006](0006-standalone-rank-plot.md) | Per-protein rank plot ships as a standalone `aa.plot_rank`, not a `*Plot` method | Accepted | 2026-05-31 |  |
+| [0007](0007-cppgrid-across-configs.md) | `CPPGrid`: a class that sweeps across configurations on a threads-default backend | Accepted | 2026-05-31 |  |
+| [0008](0008-n-jobs-semantics.md) | Unified `n_jobs` contract: `None` means optimized | Accepted | 2026-05-31 |  |
+| [0009](0009-discard-cppstate-for-lru.md) | Reuse scale tensors via an internal content-hash LRU, not a public `CPPState` | Accepted | 2026-05-31 | D2 superseded by ADR-0014, 2026-06-03 |
+| [0010](0010-package-version-1.1.0.md) | Next package release is v1.1.0, not v1.0.4 | Accepted | 2026-06-01 |  |
+| [0011](0011-embedding-encode-and-builder-naming.md) | EmbeddingPreprocessor gains `encode`; unify builder names to `build_scales` / `build_cat` | Accepted | 2026-06-01 |  |
+| [0012](0012-defer-comp-seq-cons.md) | Defer `comp_seq_cons`: neither test nor integrate the orphaned conservation module | Accepted | 2026-06-02 |  |
+| [0013](0013-wire-sample-batched-cpp-run.md) | Wire `cpp_run_sample_batched` to a public `CPP.run(n_sample_batches=)` | Accepted | 2026-06-03 |  |
+| [0014](0014-clear-cache-internal-not-public.md) | Demote cache eviction to an internal utility; drop public `CPP.clear_cache()` | Accepted | 2026-06-03 |  |
+| [0015](0015-cpp-regression-anchor.md) | Exact-value CPP regression anchor, pinned to one canonical CI cell | Accepted | 2026-06-03 |  |
+| [0016](0016-coverage-measurement-and-gates.md) | Measure coverage on the package only; ratchet module gates | Accepted | 2026-06-03 |  |
+| [0017](0017-alphafold-fetch-and-acquisition-verbs.md) | `StructurePreprocessor.fetch_alphafold` + the preprocessor verb taxonomy | Accepted | 2026-06-04 |  |
+| [0018](0018-options-override-only-scales-cache.md) | `options['df_scales'|'df_cat']` are override-only; default memoization is internal | Accepted | 2026-06-05 |  |
+| [0019](0019-fimo-source-build-in-ci.md) | Build FIMO from source on the Linux CI matrix to gate `scan_motif` end-to-end | Accepted | 2026-06-05 |  |
+| [0020](0020-negative-sampler-subsumed-by-aawindowsampler.md) | Issue #66 `NegativeSampler` is subsumed by `AAWindowSampler` | Accepted | 2026-06-05 |  |
+| [0021](0021-scan-motif-fimo-significance.md) | `scan_motif` is a true FIMO significance scanner, not a parity twin | Accepted | 2026-06-05 |  |
+| [0022](0022-prediction-task-level-taxonomy.md) | Prediction-task taxonomy: residue / domain / protein, by unit-of-comparison | Accepted | 2026-06-06 |  |
+| [0023](0023-tree-model-select-features.md) | `TreeModel.select_features` is a post-fit method, not a new selector class | Accepted | 2026-06-06 |  |
+| [0024](0024-feature-map-shap-via-shap-plot.md) | `feature_map` gains SHAP support via the `shap_plot` toggle, not issue #63's `stack_by` / `df_imp` | Accepted | 2026-06-06 |  |
+| [0025](0025-interpretability-tiered-explainable-scale-sets.md) | Interpretability-tiered "explainable" scale sets in `load_scales` | Accepted | 2026-06-06 |  |
+| [0026](0026-feature-pruning-empirical-not-scale-correlation.md) | Feature pruning is empirical (sample-level), df_feat-in/out methods on `SequenceFeature` | Accepted | 2026-06-11 |  |
+| [0027](0027-protein-design-mutation-deltacpp-scope.md) | Protein design (AAMut/SeqMut): scope boundary and model-free ΔCPP | Accepted | 2026-06-11 |  |
+| [0028](0028-cppstructureplot-structureview-return-wrapper.md) | `CPPStructurePlot` returns a `StructureView` wrapper, not a matplotlib `Axes` | Accepted | 2026-06-11 |  |
+| [0029](0029-fetch-embeddings.md) | EmbeddingPreprocessor.fetch_embeddings + fetch_* covers model-weight acquisition | Accepted | 2026-06-12 |  |
+| [0030](0030-changelog-and-deprecation-policy.md) | Strict-semver deprecation policy, `deprecated` decorator, and a two-file changelog | Accepted | 2026-06-13 |  |
+| [0031](0031-integration-e2e-test-policy.md) | Integration & e2e test tiers: scope, taxonomy, and merge-gating | Accepted | 2026-06-13 |  |
+| [0032](0032-numerical-equivalence-tolerance-policy.md) | Numerical-equivalence tolerance policy for output-affecting optimizations | Accepted | 2026-06-13 |  |
+| [0033](0033-performance-audit-outcomes.md) | Whole-library performance audit: accepted wins and rejected optimizations | Accepted | 2026-06-13 |  |
+<!-- ADR-INDEX:END -->

--- a/docs/module_map.md
+++ b/docs/module_map.md
@@ -1,0 +1,88 @@
+# AAanalysis module map (internal dataflow)
+
+How the public subpackages **connect at runtime** — the canonical pipeline
+`load → parts → CPP → model → explain → plot`. This is a **dataflow/composition**
+map, **not an import graph**: the frontends are deliberately decoupled (only a
+handful of cross-subpackage imports; everything shares the `aaanalysis.utils`
+barrel and backend isolation is test-gated), so the connections below happen in
+**user code passing DataFrames**, not in module imports.
+
+Scope: this is the *internal* mental model. The *external* ecosystem (AAanalysis ↔
+sklearn / SHAP / biopython / upstream descriptors) is a separate diagram
+(README + Introduction, issue #210). A user-facing rendered version of this map is
+owned by the docs-architecture epic **#106**; this file is the GitHub/agent source.
+
+```mermaid
+flowchart LR
+  subgraph DH["data_handling"]
+    LD["load_dataset"]
+    LS["load_scales"]
+    LF["load_features"]
+    EP["EmbeddingPreprocessor"]
+  end
+  subgraph SA["seq_analysis"]
+    AWS["AAWindowSampler"]
+    AL["AAlogo"]
+  end
+  subgraph FE["feature_engineering"]
+    AAC["AAclust"]
+    SF["SequenceFeature / NumericalFeature"]
+    CPP["CPP / CPPGrid"]
+    CPPP["CPPPlot"]
+  end
+  subgraph PU["pu_learning"]
+    DPU["dPULearn"]
+  end
+  subgraph XAI["explainable_ai (+_pro)"]
+    TM["TreeModel"]
+    SM["ShapModel (pro)"]
+  end
+  subgraph PD["protein_design"]
+    AAM["AAMut / SeqMut"]
+  end
+
+  LD -->|df_seq| SF
+  LD -->|df_seq| AWS
+  AWS -->|windows / labels| SF
+  LS -->|df_scales| AAC
+  AAC -->|reduced scale set| CPP
+  LS -->|df_scales| CPP
+  SF -->|df_parts| CPP
+  CPP -->|df_feat| TM
+  CPP -->|df_feat| CPPP
+  LF -->|df_feat ref| CPPP
+  DPU -->|labels| TM
+  EP -->|embeddings X| TM
+  TM -->|fitted model| SM
+  SM -->|SHAP values| CPPP
+  CPP -->|feature impact| AAM
+  AL -.->|sequence logos| CPPP
+```
+
+**Cross-cutting (used by many, not a pipeline stage):** `plotting`
+(`plot_settings`/colors/`plot_legend`/`plot_rank`) styles every `*Plot`; `metrics`
+(`comp_*`) scores model/clustering outputs.
+
+**Pro / utility subpackages (off the core flow):** `data_handling_pro`
+(StructurePreprocessor, AnnotationPreprocessor), `seq_analysis_pro`
+(comp_seq_sim, filter_seq, scan_motif), `explainable_ai_pro` (ShapModel),
+`show_html` (display_df, dev).
+
+<!-- MAP-SUBPKGS:START — roster checked by check_module_map.py; regenerate with --write-roster -->
+- data_handling
+- data_handling_pro
+- explainable_ai
+- explainable_ai_pro
+- feature_engineering
+- metrics
+- plotting
+- protein_design
+- pu_learning
+- seq_analysis
+- seq_analysis_pro
+- show_html
+<!-- MAP-SUBPKGS:END -->
+
+_Validated by `agent-readiness-audit` (`scripts/check_module_map.py`): every public
+subpackage must appear above; the diagram/prose is curated by hand (semantic
+dataflow can't be auto-derived)._


### PR DESCRIPTION
## What

A new project skill **`agent-readiness-audit`** under `.claude/skills/`, plus its two generated artifacts. Audits the package for *agent-friendliness* and applies the highest-leverage fix: a per-subpackage **front-door** (PEP 257 module docstring in each `__init__.py`).

Bundles three deterministic, `ast`-based, import-free checkers:
- `check_agentic_docs.py` — front-door docstring presence + `__all__` ↔ re-export sync (`PKG-NO-DOCSTRING`, `ALL-MISSING`, `ALL-EXPORT-MISMATCH`, `PRIVATE-LEAK`, `TOPLEVEL-ALL-DRIFT`).
- `check_adrs.py` — ADR hygiene (status lines, dangling xrefs, `ADR-IN-CODE`) + generates/validates `docs/adr/INDEX.md`.
- `check_module_map.py` — coverage check for the curated dataflow map `docs/module_map.md`.

Adds the generated artifacts: **`docs/adr/INDEX.md`** (ADR overview table) and **`docs/module_map.md`** (curated Mermaid internal-dataflow map).

## Scope — deliberately additive only

This PR adds **only new files** (the skill + the two docs). To avoid clobbering work currently in flight in other sessions/worktrees on shared files, three follow-ups are **deferred**:
- the `github-issue-handoff` → `github-issues` skill rename,
- the `agentic-engineering` SKILL/REFERENCE progressive-disclosure refactor,
- a `repo-layout.md` pointer to the module map.

## Not closing #69

The actual #69 work — writing the 12 subpackage front-door docstrings — is a **follow-up** that runs this skill's apply-mode (audit-first, each `__init__.py` is CONFIRM-FIRST). Intentionally **no `Closes #69`** so the issue stays open until the front-doors land and the checker is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)