### PR TITLE
doc(subpackages): add per-subpackage front-door module docstrings (#69)

### DIFF
--- a/aaanalysis/data_handling/__init__.py
+++ b/aaanalysis/data_handling/__init__.py
@@ -1,3 +1,17 @@
+"""
+Data loading and sequence/embedding preprocessing — the package's data entry point.
+
+Public objects: load_dataset, load_scales, load_features, read_fasta, to_fasta,
+SequencePreprocessor, EmbeddingPreprocessor, combine_dict_nums.
+Produces the core data objects the rest of the pipeline consumes: ``load_dataset``
+yields ``df_seq``, ``load_scales`` yields ``df_scales`` (fed to
+``feature_engineering.AAclust`` / ``CPP``), ``load_features`` yields a reference
+``df_feat``; ``SequencePreprocessor`` and ``EmbeddingPreprocessor`` turn raw sequences
+into windows / numerical embeddings, and ``read_fasta`` / ``to_fasta`` handle FASTA I/O.
+
+See ``.claude/rules/code-conventions.md`` and ``frontend-backend.md`` for conventions,
+``CONTEXT.md`` for domain terms (df_seq, scale set, embedding-based feature engineering).
+"""
 from ._load_dataset import load_dataset
 from ._load_scales import load_scales
 from ._load_features import load_features

--- a/aaanalysis/data_handling/__init__.py
+++ b/aaanalysis/data_handling/__init__.py
@@ -6,8 +6,10 @@ SequencePreprocessor, EmbeddingPreprocessor, combine_dict_nums.
 Produces the core data objects the rest of the pipeline consumes: ``load_dataset``
 yields ``df_seq``, ``load_scales`` yields ``df_scales`` (fed to
 ``feature_engineering.AAclust`` / ``CPP``), ``load_features`` yields a reference
-``df_feat``; ``SequencePreprocessor`` and ``EmbeddingPreprocessor`` turn raw sequences
-into windows / numerical embeddings, and ``read_fasta`` / ``to_fasta`` handle FASTA I/O.
+``df_feat``, and ``read_fasta`` / ``to_fasta`` handle FASTA I/O. ``SequencePreprocessor``
+turns raw sequences into windows / numeric encodings; ``EmbeddingPreprocessor`` normalizes
+protein-language-model embeddings into the per-residue ``dict_num`` consumed by
+``CPP.run_num`` (``combine_dict_nums`` stacks such tensors).
 
 See ``.claude/rules/code-conventions.md`` and ``frontend-backend.md`` for conventions,
 ``CONTEXT.md`` for domain terms (df_seq, scale set, embedding-based feature engineering).

--- a/aaanalysis/data_handling_pro/__init__.py
+++ b/aaanalysis/data_handling_pro/__init__.py
@@ -2,11 +2,13 @@
 Pro data handling: structure- and annotation-based preprocessing (``pro`` extra).
 
 Public objects: StructurePreprocessor, AnnotationPreprocessor.
-Gated behind the ``pro`` extra — ``StructurePreprocessor`` needs DSSP + biopython,
-``AnnotationPreprocessor`` fetches UniProt annotations via ``requests``. Off the core
-``load → CPP → model`` flow; both enrich ``df_seq`` with structure / annotation columns.
-Imported lazily from the top-level ``aaanalysis`` package and replaced by an
-install-hint stub when the extra is absent.
+Gated behind the ``pro`` extra — ``StructurePreprocessor`` reads PDB / CIF / AlphaFold
+structure files (DSSP geometry, PAE, domains) and ``AnnotationPreprocessor`` fetches
+UniProt PTM / functional-site annotations via ``requests``. Both follow an instance-based
+``encode_*`` pattern that yields the ``[0, 1]``-normalized per-residue ``dict_num``
+consumed by ``CPP.run_num`` (stackable via ``combine_dict_nums``); off the core
+``load → CPP → model`` flow. Imported lazily from the top-level ``aaanalysis`` package
+and replaced by an install-hint stub when the extra is absent.
 
 See ``.claude/rules/pro-core-boundary.md`` for the pro/core boundary, ``CONTEXT.md``
 for domain terms (structure-/annotation-based feature engineering).

--- a/aaanalysis/data_handling_pro/__init__.py
+++ b/aaanalysis/data_handling_pro/__init__.py
@@ -1,3 +1,16 @@
+"""
+Pro data handling: structure- and annotation-based preprocessing (``pro`` extra).
+
+Public objects: StructurePreprocessor, AnnotationPreprocessor.
+Gated behind the ``pro`` extra — ``StructurePreprocessor`` needs DSSP + biopython,
+``AnnotationPreprocessor`` fetches UniProt annotations via ``requests``. Off the core
+``load → CPP → model`` flow; both enrich ``df_seq`` with structure / annotation columns.
+Imported lazily from the top-level ``aaanalysis`` package and replaced by an
+install-hint stub when the extra is absent.
+
+See ``.claude/rules/pro-core-boundary.md`` for the pro/core boundary, ``CONTEXT.md``
+for domain terms (structure-/annotation-based feature engineering).
+"""
 from ._struct_preproc import StructurePreprocessor
 from ._annot_preproc import AnnotationPreprocessor
 

--- a/aaanalysis/explainable_ai/__init__.py
+++ b/aaanalysis/explainable_ai/__init__.py
@@ -1,3 +1,15 @@
+"""
+Explainable AI: interpretable tree-based prediction over CPP features.
+
+Public objects: TreeModel.
+Consumes a CPP feature matrix (``df_feat``) from ``feature_engineering.CPP`` plus labels
+(e.g. reliable negatives from ``pu_learning.dPULearn``) or embeddings ``X`` from
+``data_handling.EmbeddingPreprocessor``; produces a fitted model whose outputs feed
+``explainable_ai_pro.ShapModel``.
+
+See ``.claude/rules/code-conventions.md`` for conventions, ``reproducibility.md`` for the
+``random_state`` contract, ``CONTEXT.md`` for domain terms (explainability vocabulary).
+"""
 from ._tree_model import TreeModel
 
 __all__ = [

--- a/aaanalysis/explainable_ai_pro/__init__.py
+++ b/aaanalysis/explainable_ai_pro/__init__.py
@@ -1,3 +1,15 @@
+"""
+Pro explainable AI: CPP-SHAP feature explanations (``pro`` extra).
+
+Public objects: ShapModel.
+Gated behind the ``pro`` extra (needs ``shap``). Wraps a fitted model (typically
+``explainable_ai.TreeModel``) to compute SHAP values, which ``feature_engineering.CPPPlot``
+renders as per-feature impact. Imported lazily from the top-level package and replaced
+by an install-hint stub when ``shap`` is absent.
+
+See ``.claude/rules/pro-core-boundary.md`` for the pro/core boundary, ``CONTEXT.md``
+for domain terms (explainability (CPP-SHAP) vocabulary).
+"""
 from ._shap_model import ShapModel
 
 __all__ = [

--- a/aaanalysis/feature_engineering/__init__.py
+++ b/aaanalysis/feature_engineering/__init__.py
@@ -1,3 +1,15 @@
+"""
+Feature engineering: scale-based amino-acid features for interpretable prediction.
+
+Public objects: AAclust(+Plot), SequenceFeature, NumericalFeature, CPP, CPPGrid, CPPPlot.
+``AAclust`` reduces a scale set (``df_scales`` from ``data_handling.load_scales``);
+``SequenceFeature`` / ``NumericalFeature`` build ``df_parts``; ``CPP`` / ``CPPGrid`` derive
+the interpretable feature matrix ``df_feat``, which feeds ``explainable_ai.TreeModel``,
+``protein_design``, and the paired ``CPPPlot``.
+
+See ``.claude/rules/code-conventions.md`` / ``frontend-backend.md`` for conventions,
+``CONTEXT.md`` for domain terms (df_parts, part, split, scale; CPP split vocabulary).
+"""
 # DEV NOTE:
 # Suppress matplotlib tight_layout warning caused by manual colorbar axes (fig.add_axes).
 # This is intentional for precise layout control in CPPPlot and related visualizations.

--- a/aaanalysis/metrics/__init__.py
+++ b/aaanalysis/metrics/__init__.py
@@ -1,3 +1,15 @@
+"""
+Metrics: scoring helpers for clustering, ranking, and site-localization quality.
+
+Public objects: comp_auc_adjusted, comp_bic_score, comp_kld, comp_per_protein_ap,
+comp_detection_metrics, comp_bootstrap_ci, comp_smooth_scores.
+A cross-cutting subpackage (not a pipeline stage): the ``comp_*`` functions score the
+outputs of ``feature_engineering.AAclust`` (BIC), model rankings from ``explainable_ai``,
+and per-protein site detection.
+
+See ``.claude/rules/code-conventions.md`` for conventions, ``CONTEXT.md`` for domain
+terms (scoring vocabulary, site-localization metrics vocabulary).
+"""
 from ._metrics import (comp_auc_adjusted, comp_bic_score, comp_kld,
                        comp_per_protein_ap, comp_detection_metrics,
                        comp_bootstrap_ci, comp_smooth_scores)

--- a/aaanalysis/plotting/__init__.py
+++ b/aaanalysis/plotting/__init__.py
@@ -1,3 +1,16 @@
+"""
+Plotting utilities: shared styling, colors, and legends for every ``*Plot`` class.
+
+Public objects: plot_get_clist, plot_get_cmap, plot_get_cdict, plot_settings,
+plot_legend, plot_gcfs, plot_rank.
+A cross-cutting subpackage (not a pipeline stage): ``plot_settings`` sets the house
+rcParams, the ``plot_get_*`` helpers supply the color list / map / dict, and
+``plot_legend`` / ``plot_gcfs`` / ``plot_rank`` are reused by the paired plot classes
+(``CPPPlot``, ``AAclustPlot``, …). Library plot code never calls ``plt.show()``.
+
+See ``.claude/rules/plotting.md`` for the plotting conventions, ``CONTEXT.md`` for
+domain terms.
+"""
 from ._plot_get_clist import plot_get_clist
 from ._plot_get_cmap import plot_get_cmap
 from ._plot_get_cdict import plot_get_cdict

--- a/aaanalysis/protein_design/__init__.py
+++ b/aaanalysis/protein_design/__init__.py
@@ -1,3 +1,14 @@
+"""
+Protein design: per-mutation and per-sequence ΔCPP feature-impact analysis.
+
+Public objects: AAMut(+Plot), SeqMut(+Plot).
+Consumes CPP feature impact from ``feature_engineering`` to score amino-acid mutations
+(``AAMut``) and whole-sequence variants (``SeqMut``); each is paired with a plot class
+for visualization.
+
+See ``.claude/rules/code-conventions.md`` for conventions, ``CONTEXT.md`` for domain
+terms (protein-design (mutation / ΔCPP) vocabulary).
+"""
 from ._aamut import AAMut
 from ._aamut_plot import AAMutPlot
 from ._seqmut import SeqMut

--- a/aaanalysis/pu_learning/__init__.py
+++ b/aaanalysis/pu_learning/__init__.py
@@ -1,3 +1,14 @@
+"""
+Positive-unlabeled learning: identify reliable negatives from unlabeled data.
+
+Public objects: dPULearn(+Plot).
+``dPULearn`` (deterministic PU learning) labels reliable negatives in a dataset that has
+only positives and unlabeled samples; those labels feed ``explainable_ai.TreeModel``.
+Paired with ``dPULearnPlot`` for visualization.
+
+See ``.claude/rules/code-conventions.md`` for conventions, ``reproducibility.md`` for the
+``random_state`` contract, ``CONTEXT.md`` for domain terms (prediction-task taxonomy).
+"""
 from ._dpulearn import dPULearn
 from ._dpulearn_plot import dPULearnPlot
 

--- a/aaanalysis/seq_analysis/__init__.py
+++ b/aaanalysis/seq_analysis/__init__.py
@@ -1,3 +1,14 @@
+"""
+Sequence analysis: window sampling and amino-acid sequence logos.
+
+Public objects: AAlogo(+Plot), AAWindowSampler.
+``AAWindowSampler`` turns ``df_seq`` (from ``data_handling.load_dataset``) into
+fixed-length windows / labels for ``feature_engineering.SequenceFeature``; ``AAlogo``
+(+ ``AAlogoPlot``) renders position-specific sequence logos.
+
+See ``.claude/rules/code-conventions.md`` for conventions, ``reproducibility.md`` for the
+``seed`` contract, ``CONTEXT.md`` for domain terms (window sampling vocabulary).
+"""
 from ._aalogo import AAlogo
 from ._aalogo_plot import AAlogoPlot
 from ._aa_window_sampler import AAWindowSampler

--- a/aaanalysis/seq_analysis_pro/__init__.py
+++ b/aaanalysis/seq_analysis_pro/__init__.py
@@ -1,3 +1,17 @@
+"""
+Pro sequence analysis: similarity, filtering, and motif scanning (``pro`` extra).
+
+Public objects: comp_seq_sim, filter_seq, scan_motif.
+Gated behind the ``pro`` extra — ``comp_seq_sim`` / ``filter_seq`` need biopython and
+``scan_motif`` wraps the MEME suite (FIMO). Complements core ``seq_analysis``:
+``scan_motif`` selects motif-matched windows by FIMO p-value where
+``AAWindowSampler.sample_motif_matched`` uses a pure-Python PWM-sum threshold (a
+genuinely different selection, not a re-scored mimic). Imported lazily and replaced by
+install-hint stubs when the extra is absent.
+
+See ``.claude/rules/pro-core-boundary.md`` for the pro/core boundary, ``CONTEXT.md``
+for domain terms.
+"""
 from ._comp_seq_sim import comp_seq_sim
 from ._filter_seq import filter_seq
 from ._scan_motif import scan_motif

--- a/aaanalysis/show_html/__init__.py
+++ b/aaanalysis/show_html/__init__.py
@@ -1,3 +1,15 @@
+"""
+Notebook display helper (``dev`` extra).
+
+Public objects: display_df.
+``display_df`` renders a DataFrame as a clean, width-bounded HTML table with its shape —
+the house presentation for every example / tutorial notebook. Gated behind the ``dev``
+extra (needs ``IPython``); imported lazily from the top-level package and replaced by an
+install-hint stub when absent.
+
+See ``.claude/rules/notebooks.md`` for the notebook presentation rule, ``CONTEXT.md``
+for domain terms.
+"""
 from ._display_df import display_df
 
 


### PR DESCRIPTION
## What & why

Adds a **front-door module docstring** to every public subpackage `__init__.py` — the highest-leverage agent-legibility fix from the `agent-readiness-audit` skill, and the deliverable of #69 (retitled from "READMEs" to "module-docstring front-door").

Before: the front-door checker (`check_agentic_docs.py`) flagged **12 `PKG-NO-DOCSTRING`** — every subpackage `__init__.py` was an empty front-door. After: **0 defects** across all 12 subpackages.

Each front-door follows the skill's template:
- one-line purpose (in the package voice),
- a `Public objects:` line mirroring the subpackage's `__all__`,
- the sibling dataflow — what it consumes / feeds, per `docs/module_map.md`,
- pointers to the relevant `.claude/rules/*.md` and the `CONTEXT.md` glossary terms it owns.

## Scope notes

- **Purely additive docstrings — no public-API/semver change.** Every `__all__` was already in sync with its re-exports (no `ALL-MISSING` / `ALL-EXPORT-MISMATCH` / `PRIVATE-LEAK`), so no `__all__` was touched. No functional code changed.
- Covers all **12** subpackages the checker scans (the 8 core + the 3 `*_pro` siblings + `show_html`), matching the retitled issue's "every public subpackage" + checker-green close criterion — broader than the body's original 8-README list.
- **No ADR references in source** (house hard rule) — rationale is stated in plain language, overriding the skill template's `ADR-NNNN` placeholder.
- **Deferred:** the skill's optional carve-out note for `.claude/rules/code-conventions.md` (clarifying that the `"""This is a script for ..."""` opener does not apply to `__init__.py` front-doors) was **not** applied — the auto-mode classifier declined the agent-config edit. It is harmless to defer: the opener is not tool-enforced, so there is no automated conflict today. Worth a follow-up if a future agent "corrects" a front-door.

## Verification (local)

- `check_agentic_docs.py aaanalysis` → **0 defects** (was 12).
- `check_docstrings.py aaanalysis` → **0 defects** (35 pre-existing advisories unchanged).
- Package imports cleanly from the branch; `aa.__all__` unchanged (47 symbols).

CI on this PR runs the full matrix (the change touches `.py`, so `paths-ignore` does not skip it).

Closes #69
