### PR TITLE
feat(types): ship py.typed + advisory pyright + honest public signatures (ADR-0035/0036)

### DIFF
--- a/.claude/rules/sharp-edges.md
+++ b/.claude/rules/sharp-edges.md
@@ -9,7 +9,9 @@ limitations — do not "fix" them opportunistically.
   `_plotting_glue.py`, `_data_io.py` is a v2 refactor.
 - **`config.py` is documented as untested.** Adding unit tests when
   touching it is welcomed.
-- **No type checker, no pre-commit, no ruff.** Out of scope until v2.
+- **No pre-commit, no ruff** — out of scope until v2. **Type checking is NOT deferred:**
+  the package ships `py.typed` and `pyright` runs **non-blocking (advisory)** in CI,
+  public-API-first (`_backend` excluded for now); mypy is not used. See ADR-0036.
 - **`pyproject.toml` carries both `[project]` and `[tool.poetry]` blocks.**
   Edit `[project]` only.
 - **MEME format alphabet quirk** (relevant only for `aa.scan_motif`): the
@@ -22,6 +24,13 @@ limitations — do not "fix" them opportunistically.
   config** — these are explicitly out of scope for now.
 - **Don't create `AAanalysisError`** or any custom exception base — bare
   `ValueError` / `RuntimeError` is the rule.
+- **Don't add Pydantic / pandera or any schema-validation framework** — not in
+  v1 and not planned for v2. Input validation is the hand-rolled `ut.check_*`
+  family (sklearn-style Validate block); the `df_feat` output contract is a
+  documented, test-guarded **data dictionary** (`ut.LIST_COLS_FEAT` /
+  `sort_cols_feat`), not a typed model. Agent-facing typed I/O contracts
+  (Pydantic `CPPRequest`/`CPPResult`, JSON/MCP tool schemas) live downstream in
+  **ProtXplain**, never in this package. See ADR-0035.
 - **Don't re-attempt the rejected performance optimizations.** A whole-library
   perf audit already tried and dropped many candidates — FASTA `iterrows`,
   TreeModel CV parallelization, `encode_pae` loops, AAclust binary-search `k`

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -1,0 +1,47 @@
+name: Type Check (advisory)
+
+# pyright runs ADVISORY only — public-API-first (pyrightconfig.json excludes
+# aaanalysis/**/_backend). The check step carries continue-on-error so the job is
+# always green and never gates a merge; the report is in the step log. The
+# method-body Optional burn-down proceeds without blocking. Type hints are the
+# read-time contract; py.typed ships the annotations downstream.
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '**/*.rst'
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '**/*.rst'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+  pyright:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install package + pyright
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[pro]
+          pip install pyright
+
+      - name: Run pyright (advisory — never fails the build)
+        continue-on-error: true
+        run: pyright

--- a/aaanalysis/data_handling/_combine_dict_nums.py
+++ b/aaanalysis/data_handling/_combine_dict_nums.py
@@ -8,6 +8,7 @@ along the D axis per entry. The result feeds
 from typing import Dict, List
 
 import numpy as np
+from typing import Optional  # noqa: E402
 
 
 # I Helper Functions
@@ -70,7 +71,7 @@ def _check_arrays_shape_per_entry(
 
 # II Main Functions
 def combine_dict_nums(
-    dict_nums: List[Dict[str, np.ndarray]] = None,
+    dict_nums: Optional[List[Dict[str, np.ndarray]]] = None,
 ) -> Dict[str, np.ndarray]:
     """Concatenate multiple per-residue ``dict_num`` inputs along the D axis.
 

--- a/aaanalysis/data_handling/_embed_preproc.py
+++ b/aaanalysis/data_handling/_embed_preproc.py
@@ -133,8 +133,8 @@ class EmbeddingPreprocessor:
 
     def encode(
         self,
-        df_seq: pd.DataFrame = None,
-        embeddings: Dict[str, np.ndarray] = None,
+        df_seq: Optional[pd.DataFrame] = None,
+        embeddings: Optional[Dict[str, np.ndarray]] = None,
         method: Literal["minmax", "quantile", "sigmoid"] = "minmax",
         clip: Tuple[float, float] = (1.0, 99.0),
         return_df: bool = False,
@@ -229,8 +229,8 @@ class EmbeddingPreprocessor:
 
     def build_scales(
         self,
-        df_seq: pd.DataFrame = None,
-        dict_num: Dict[str, np.ndarray] = None,
+        df_seq: Optional[pd.DataFrame] = None,
+        dict_num: Optional[Dict[str, np.ndarray]] = None,
         return_std: bool = False,
     ) -> Union[pd.DataFrame, Tuple[pd.DataFrame, pd.DataFrame]]:
         """
@@ -325,8 +325,8 @@ class EmbeddingPreprocessor:
 
     def build_cat(
         self,
-        df_scales: pd.DataFrame = None,
-        df_stds: pd.DataFrame = None,
+        df_scales: Optional[pd.DataFrame] = None,
+        df_stds: Optional[pd.DataFrame] = None,
         cat_min_th: float = 0.5,
         subcat_min_th: float = 0.7,
         metric: Literal["correlation", "cosine"] = "correlation",
@@ -440,7 +440,7 @@ class EmbeddingPreprocessor:
 
     def fetch_embeddings(
         self,
-        df_seq: pd.DataFrame = None,
+        df_seq: Optional[pd.DataFrame] = None,
         mode: Literal["protein", "residue"] = "protein",
         model: Literal["esm2_t6_8M", "esm2_t12_35M", "esm2_t30_150M",
                        "esm2_t33_650M", "esm2_t36_3B", "esm1b",
@@ -681,9 +681,9 @@ class EmbeddingPreprocessor:
 
     def pool_embeddings(
         self,
-        embeddings: Dict[str, np.ndarray] = None,
+        embeddings: Optional[Dict[str, np.ndarray]] = None,
         pooling: Literal["mean", "max"] = "mean",
-        df_seq: pd.DataFrame = None,
+        df_seq: Optional[pd.DataFrame] = None,
     ) -> Union[Dict[str, np.ndarray], np.ndarray]:
         """
         Pool per-residue embeddings into one vector per protein.

--- a/aaanalysis/data_handling/_load_dataset.py
+++ b/aaanalysis/data_handling/_load_dataset.py
@@ -19,7 +19,7 @@ LIST_CLEAVAGE_SITE_DATA = ["AA_CASPASE3", "AA_FURIN", "AA_MMP2"]
 
 # I Helper Functions
 # Check functions
-def check_name_of_dataset(name="Overview", folder_in=None):
+def check_name_of_dataset(name="Overview", folder_in=None) -> None:
     """Check if name of dataset is valid"""
     if name == "Overview":
         return
@@ -35,7 +35,7 @@ def check_name_of_dataset(name="Overview", folder_in=None):
                          f"\n Domain datasets: {list_dom}")
 
 
-def check_min_max_val(min_len=None, max_len=None):
+def check_min_max_val(min_len=None, max_len=None) -> None:
     """Check if min_val and max_val are valid and match"""
     ut.check_number_range(name="min_len", val=min_len, min_val=1, accept_none=True, just_int=True)
     ut.check_number_range(name="max_len", val=max_len, min_val=1, accept_none=True, just_int=True)
@@ -45,7 +45,7 @@ def check_min_max_val(min_len=None, max_len=None):
         raise ValueError(f"'min_len' ({min_len}) should not be smaller than 'max_len' ({max_len})")
 
 
-def check_aa_window_size(aa_window_size=None, is_cs_dataset=False):
+def check_aa_window_size(aa_window_size=None, is_cs_dataset=False) -> None:
     """Check if aa_window size is a positive odd integer"""
     if aa_window_size is None:
         return
@@ -55,7 +55,7 @@ def check_aa_window_size(aa_window_size=None, is_cs_dataset=False):
                          f"Only the following cleavage site datasets can have odd or even sizes: {LIST_CLEAVAGE_SITE_DATA}")
 
 
-def post_check_df_seq(df_seq=None, n=None, name=None):
+def post_check_df_seq(df_seq=None, n=None, name=None) -> None:
     """Check if length of df_seq is valid"""
     max_n = df_seq[ut.COL_LABEL].value_counts().min()
     warning_message = f"'n' ({n}) is too high since the smaller class for '{name}' contains {max_n} samples." \

--- a/aaanalysis/data_handling/_load_features.py
+++ b/aaanalysis/data_handling/_load_features.py
@@ -4,6 +4,8 @@ This is a script for filtering scales from df_scales, such as using correlation 
 
 from typing import Literal
 
+import pandas as pd
+
 import aaanalysis.utils as ut
 
 LIST_DATASETS_WITH_FEATURES = ["DOM_GSEC"]
@@ -11,14 +13,14 @@ FOLDER_FEATURES = ut.FOLDER_DATA + "features" + ut.SEP
 
 
 # I Helper Functions
-def check_name(name=None):
+def check_name(name=None) -> None:
     """Check provided names of dataset"""
     if name not in LIST_DATASETS_WITH_FEATURES:
         raise ValueError(f"'name' should be one of: {LIST_DATASETS_WITH_FEATURES}")
 
 
 # II Main Functions
-def load_features(name: Literal["DOM_GSEC"] = "DOM_GSEC"):
+def load_features(name: Literal["DOM_GSEC"] = "DOM_GSEC") -> pd.DataFrame:
     """
     Load feature sets for protein benchmarking datasets.
 

--- a/aaanalysis/data_handling/_load_scales.py
+++ b/aaanalysis/data_handling/_load_scales.py
@@ -9,7 +9,7 @@ from aaanalysis import utils as ut
 
 
 # Check functions for load_scales
-def check_name_of_scale(name=None):
+def check_name_of_scale(name=None) -> None:
     # Check if the provided scale name is valid
     if name not in ut.NAMES_SCALE_SETS:
         raise ValueError(f"'name' ('{name}') is not valid. Choose one of following: {ut.NAMES_SCALE_SETS}")
@@ -31,7 +31,7 @@ def check_top60_n(name=None, top60_n=None):
     return top60_n
 
 
-def check_top_explain(name=None, top_explain_n=None, top_explain_min_th=None, top60_n=None):
+def check_top_explain(name=None, top_explain_n=None, top_explain_min_th=None, top60_n=None) -> None:
     """Validate the interpretability-tier selector (top_explain_n / top_explain_min_th)."""
     if top_explain_n is None:
         if top_explain_min_th is not None:

--- a/aaanalysis/data_handling/_read_fasta.py
+++ b/aaanalysis/data_handling/_read_fasta.py
@@ -12,7 +12,7 @@ import aaanalysis.utils as ut
 
 # I Helper Functions
 # Post check functions
-def post_check_unique_entries(list_entries=None, col_id=None):
+def post_check_unique_entries(list_entries=None, col_id=None) -> None:
     """Check if entries are unique"""
     list_duplicates = list(set([x for x in list_entries if list_entries.count(x) > 1]))
     if len(list_duplicates) > 0:
@@ -21,7 +21,7 @@ def post_check_unique_entries(list_entries=None, col_id=None):
         warnings.warn(str_warning)
 
 
-def post_check_col_db(df_seq=None, col_db=None, sep="|"):
+def post_check_col_db(df_seq=None, col_db=None, sep="|") -> None:
     """Check if database column is in DataFrame"""
     columns = list(df_seq)
     if col_db is not None and col_db not in columns:

--- a/aaanalysis/data_handling/_seq_preproc.py
+++ b/aaanalysis/data_handling/_seq_preproc.py
@@ -13,7 +13,7 @@ from ._backend.seq_preproc.get_sliding_aa_window import get_sliding_aa_window
 
 
 # I Helper Functions
-def check_gap(gap="_"):
+def check_gap(gap="_") -> None:
     """Check if string of length one"""
     ut.check_str(name="gap", val=gap, accept_none=False)
     if len(gap) != 1:
@@ -21,7 +21,7 @@ def check_gap(gap="_"):
 
 
 # Encoding check functions
-def check_match_list_seq_alphabet(list_seq=None, alphabet=None, gap="-"):
+def check_match_list_seq_alphabet(list_seq=None, alphabet=None, gap="-") -> None:
     """Validate if all characters in the sequences are within the given alphabet"""
     all_chars = set(''.join(list_seq))
     if not all_chars.issubset(set(alphabet + gap)):
@@ -29,7 +29,7 @@ def check_match_list_seq_alphabet(list_seq=None, alphabet=None, gap="-"):
         raise ValueError(f"Following amino acid(s) from 'list_seq' are not in 'alphabet': {invalid_chars}")
 
 
-def check_match_gap_alphabet(gap="_", alphabet=None):
+def check_match_gap_alphabet(gap="_", alphabet=None) -> None:
     """Check that gap is not in alphabet"""
     if gap in alphabet:
         raise ValueError(f"'gap' ('{gap}') should not be contained in the 'alphabet' ('{alphabet}')")
@@ -45,13 +45,13 @@ def adjust_positions(start=None, stop=None, index1=False):
     return start, stop
 
 
-def check_match_pos_start_pos_stop(pos_start=None, pos_stop=None):
+def check_match_pos_start_pos_stop(pos_start=None, pos_stop=None) -> None:
     """Check if start position smaller than stop position"""
     if pos_stop is not None and pos_start > pos_stop:
         raise ValueError(f"'pos_start' ({pos_start}) should be smaller than 'pos_stop' ({pos_stop})")
 
 
-def check_match_pos_stop_window_size(pos_stop=None, window_size=None):
+def check_match_pos_stop_window_size(pos_stop=None, window_size=None) -> None:
     """Check if one is given"""
     if pos_stop is None and window_size is None:
         raise ValueError("Either 'pos_end' or 'window_size' must be specified. Both are 'None'.")
@@ -60,7 +60,7 @@ def check_match_pos_stop_window_size(pos_stop=None, window_size=None):
                          f" Both are given.")
 
 
-def check_match_seq_pos(seq=None, pos_start=None, pos_stop=None):
+def check_match_seq_pos(seq=None, pos_start=None, pos_stop=None) -> None:
     """Check if pos_start matches length of sequence"""
     seq_len = len(seq)
     if pos_start >= seq_len:
@@ -69,7 +69,7 @@ def check_match_seq_pos(seq=None, pos_start=None, pos_stop=None):
         raise ValueError(f"'pos_stop' ({pos_stop}) must be smaller than the sequence length ({seq_len})")
 
 
-def check_match_seq_pos_start_window_size(seq=None, pos_start=None, window_size=None):
+def check_match_seq_pos_start_window_size(seq=None, pos_start=None, window_size=None) -> None:
     """Check if start position and window size do not extend the sequence length"""
     if window_size is not None:
         seq_len = len(seq)
@@ -80,13 +80,13 @@ def check_match_seq_pos_start_window_size(seq=None, pos_start=None, window_size=
 
 
 # Sliding window check functions
-def check_match_slide_start_slide_stop(slide_start=None, slide_stop=None):
+def check_match_slide_start_slide_stop(slide_start=None, slide_stop=None) -> None:
     """Check if start sliding position smaller than stop position"""
     if slide_stop is not None and slide_start > slide_stop:
         raise ValueError(f"'slide_start' ({slide_start}) should be smaller than 'slide_stop' ({slide_stop})")
 
 
-def check_match_slide_start_slide_stop_window_size(slide_start=None, slide_stop=None, window_size=None):
+def check_match_slide_start_slide_stop_window_size(slide_start=None, slide_stop=None, window_size=None) -> None:
     """Check if one is given"""
     if slide_stop is not None:
         min_window_size = slide_stop - slide_stop
@@ -95,7 +95,7 @@ def check_match_slide_start_slide_stop_window_size(slide_start=None, slide_stop=
                              f" between 'slide_start' ('{slide_start}') and 'slide_stop' ({slide_stop}).")
 
 
-def check_match_seq_slide(seq=None, slide_start=None, slide_stop=None):
+def check_match_seq_slide(seq=None, slide_start=None, slide_stop=None) -> None:
     """Check if slide_start matches length of sequence"""
     seq_len = len(seq)
     if slide_start >= seq_len:
@@ -104,7 +104,7 @@ def check_match_seq_slide(seq=None, slide_start=None, slide_stop=None):
         raise ValueError(f"'slide_stop' ({slide_stop}) must be smaller than the sequence length ({seq_len})")
 
 
-def check_match_seq_slide_start_window_size(seq=None, slide_start=None, window_size=None):
+def check_match_seq_slide_start_window_size(seq=None, slide_start=None, window_size=None) -> None:
     """Check if start position and window size do not extend the sequence length"""
     seq_len = len(seq)
     slide_stop = slide_start + window_size
@@ -132,7 +132,7 @@ class SequencePreprocessor:
 
     # Sequence encoding
     @staticmethod
-    def encode_one_hot(list_seq: Union[List[str], str] = None,
+    def encode_one_hot(list_seq: Optional[Union[List[str], str]] = None,
                        alphabet: str = "ACDEFGHIKLMNPQRSTVWY",
                        gap: str = "-",
                        pad_at: Literal["C", "N"] = "C",
@@ -187,7 +187,7 @@ class SequencePreprocessor:
         return X, features
 
     @staticmethod
-    def encode_integer(list_seq: Union[List[str], str] = None,
+    def encode_integer(list_seq: Optional[Union[List[str], str]] = None,
                        alphabet: str = "ACDEFGHIKLMNPQRSTVWY",
                        gap: str = "-",
                        pad_at: Literal["C", "N"] = "C",
@@ -240,7 +240,7 @@ class SequencePreprocessor:
         return X, features
 
     @staticmethod
-    def get_aa_window(seq: str = None,
+    def get_aa_window(seq: Optional[str] = None,
                       pos_start: int = 0,
                       pos_stop: Optional[int] = None,
                       window_size: Optional[int] = None,
@@ -313,7 +313,7 @@ class SequencePreprocessor:
         return window
 
     @staticmethod
-    def get_sliding_aa_window(seq: str = None,
+    def get_sliding_aa_window(seq: Optional[str] = None,
                               slide_start: int = 0,
                               slide_stop: Optional[int] = None,
                               window_size: int = 5,

--- a/aaanalysis/data_handling/_to_fasta.py
+++ b/aaanalysis/data_handling/_to_fasta.py
@@ -13,8 +13,8 @@ from ._backend.parse_fasta import save_entries_to_fasta
 
 
 # II Main Functions
-def to_fasta(df_seq: pd.DataFrame = None,
-             file_path: str = None,
+def to_fasta(df_seq: Optional[pd.DataFrame] = None,
+             file_path: Optional[str] = None,
              col_id: str = "entry",
              col_seq: str = "sequence",
              sep: str = "|",

--- a/aaanalysis/data_handling_pro/_annot_preproc.py
+++ b/aaanalysis/data_handling_pro/_annot_preproc.py
@@ -164,7 +164,7 @@ class AnnotationPreprocessor:
     # ------------------------------------------------------------------
     def fetch_uniprot(
         self,
-        df_seq: pd.DataFrame = None,
+        df_seq: Optional[pd.DataFrame] = None,
         features: Optional[List[str]] = None,
         evidence: Literal["experimental", "manual", "all"] = "manual",
         timeout: float = 30.0,
@@ -252,7 +252,7 @@ class AnnotationPreprocessor:
     # ------------------------------------------------------------------
     # ingest
     # ------------------------------------------------------------------
-    def ingest(self, df_user: pd.DataFrame = None) -> pd.DataFrame:
+    def ingest(self, df_user: Optional[pd.DataFrame] = None) -> pd.DataFrame:
         """Ingest a user / predictor annotation table into ``df_annot``.
 
         Every ingested ``feature_type`` is treated as a ``'Functional sites'``
@@ -348,7 +348,7 @@ class AnnotationPreprocessor:
     # ------------------------------------------------------------------
     def register_feature(
         self,
-        key: str = None,
+        key: Optional[str] = None,
         subcategory: Optional[str] = None,
         normalization: Optional[Callable] = None,
     ) -> None:
@@ -399,9 +399,9 @@ class AnnotationPreprocessor:
     # ------------------------------------------------------------------
     def encode(
         self,
-        df_seq: pd.DataFrame = None,
-        df_annot: pd.DataFrame = None,
-        features: List[str] = None,
+        df_seq: Optional[pd.DataFrame] = None,
+        df_annot: Optional[pd.DataFrame] = None,
+        features: Optional[List[str]] = None,
         on_mismatch: Literal["raise", "drop", "warn"] = "raise",
         return_df: bool = False,
     ) -> Union[Dict[str, np.ndarray], Tuple[Dict[str, np.ndarray], pd.DataFrame]]:
@@ -545,9 +545,9 @@ class AnnotationPreprocessor:
     # ------------------------------------------------------------------
     def build_scales(
         self,
-        df_seq: pd.DataFrame = None,
-        dict_num: Dict[str, np.ndarray] = None,
-        features: List[str] = None,
+        df_seq: Optional[pd.DataFrame] = None,
+        dict_num: Optional[Dict[str, np.ndarray]] = None,
+        features: Optional[List[str]] = None,
         return_std: bool = False,
         dim_names_override: Optional[List[str]] = None,
     ) -> Union[pd.DataFrame, Tuple[pd.DataFrame, pd.DataFrame]]:
@@ -689,7 +689,7 @@ class AnnotationPreprocessor:
     # ------------------------------------------------------------------
     def build_cat(
         self,
-        features: List[str] = None,
+        features: Optional[List[str]] = None,
         dim_names_override: Optional[List[str]] = None,
     ) -> pd.DataFrame:
         """Build the ``df_cat`` metadata frame for ``features`` (corpus-free).
@@ -745,12 +745,12 @@ class AnnotationPreprocessor:
     # ------------------------------------------------------------------
     def to_df_seq(
         self,
-        df_seq: pd.DataFrame = None,
-        df_annot: pd.DataFrame = None,
-        feature_type: str = None,
+        df_seq: Optional[pd.DataFrame] = None,
+        df_annot: Optional[pd.DataFrame] = None,
+        feature_type: Optional[str] = None,
         match_residue_type: bool = True,
         exclude_other_annotations: bool = True,
-        pos_col: str = None,
+        pos_col: Optional[str] = None,
         aa_context_col: str = "aa_context",
     ) -> pd.DataFrame:
         """Project annotations onto ``df_seq`` for AAWindowSampler negative sampling.

--- a/aaanalysis/data_handling_pro/_struct_preproc.py
+++ b/aaanalysis/data_handling_pro/_struct_preproc.py
@@ -459,8 +459,8 @@ class StructurePreprocessor:
     # ------------------------------------------------------------------
     def fetch_alphafold(
         self,
-        df_seq: pd.DataFrame = None,
-        out_folder: Union[str, Path] = None,
+        df_seq: Optional[pd.DataFrame] = None,
+        out_folder: Optional[Union[str, Path]] = None,
         file_format: Literal["pdb", "cif"] = "pdb",
         timeout: float = 30.0,
         skip_existing: bool = True,
@@ -605,9 +605,9 @@ class StructurePreprocessor:
     # ------------------------------------------------------------------
     def get_dssp(
         self,
-        df_seq: pd.DataFrame = None,
-        pdb_folder: Union[str, Path] = None,
-        features: List[str] = None,
+        df_seq: Optional[pd.DataFrame] = None,
+        pdb_folder: Optional[Union[str, Path]] = None,
+        features: Optional[List[str]] = None,
         ss_mode: Literal["ss3", "ss8"] = "ss3",
         gap_handling: Literal["pad", "omit"] = "pad",
     ) -> pd.DataFrame:
@@ -695,9 +695,9 @@ class StructurePreprocessor:
     # ------------------------------------------------------------------
     def encode_dssp(
         self,
-        df_seq: pd.DataFrame = None,
-        pdb_folder: Union[str, Path] = None,
-        features: List[str] = None,
+        df_seq: Optional[pd.DataFrame] = None,
+        pdb_folder: Optional[Union[str, Path]] = None,
+        features: Optional[List[str]] = None,
         ss_mode: Literal["ss3", "ss8"] = "ss3",
         gap_handling: Literal["pad", "omit"] = "pad",
         on_failure: Literal["nan", "drop", "raise"] = "nan",
@@ -901,9 +901,9 @@ class StructurePreprocessor:
     # ------------------------------------------------------------------
     def encode_pdb(
         self,
-        df_seq: pd.DataFrame = None,
-        pdb_folder: Union[str, Path] = None,
-        features: List[str] = None,
+        df_seq: Optional[pd.DataFrame] = None,
+        pdb_folder: Optional[Union[str, Path]] = None,
+        features: Optional[List[str]] = None,
         plddt_disorder_threshold: float = 70.0,
         on_failure: Literal["nan", "drop", "raise"] = "nan",
         return_df: bool = False,
@@ -1150,9 +1150,9 @@ class StructurePreprocessor:
     # ------------------------------------------------------------------
     def encode_pae(
         self,
-        df_seq: pd.DataFrame = None,
-        pae_folder: Union[str, Path] = None,
-        features: List[str] = None,
+        df_seq: Optional[pd.DataFrame] = None,
+        pae_folder: Optional[Union[str, Path]] = None,
+        features: Optional[List[str]] = None,
         local_window: int = 5,
         pae_band_edges: Tuple[int, int] = (5, 15),
         on_failure: Literal["nan", "drop", "raise"] = "nan",
@@ -1355,9 +1355,9 @@ class StructurePreprocessor:
     # ------------------------------------------------------------------
     def get_domains(
         self,
-        df_seq: pd.DataFrame = None,
-        pdb_folder: Union[str, Path] = None,
-        pae_folder: Union[str, Path] = None,
+        df_seq: Optional[pd.DataFrame] = None,
+        pdb_folder: Optional[Union[str, Path]] = None,
+        pae_folder: Optional[Union[str, Path]] = None,
         tool: Literal["chainsaw", "afragmenter"] = "afragmenter",
         chainsaw_path: Optional[Union[str, Path]] = None,
         resolution: float = 0.7,
@@ -1539,9 +1539,9 @@ class StructurePreprocessor:
     # ------------------------------------------------------------------
     def encode_domains(
         self,
-        df_seq: pd.DataFrame = None,
-        domain_folder: Union[str, Path] = None,
-        features: List[str] = None,
+        df_seq: Optional[pd.DataFrame] = None,
+        domain_folder: Optional[Union[str, Path]] = None,
+        features: Optional[List[str]] = None,
         on_failure: Literal["nan", "drop", "raise"] = "nan",
         return_df: bool = False,
     ) -> Union[Dict[str, np.ndarray], Tuple[Dict[str, np.ndarray], pd.DataFrame]]:
@@ -1765,9 +1765,9 @@ class StructurePreprocessor:
     # ------------------------------------------------------------------
     def build_scales(
         self,
-        df_seq: pd.DataFrame = None,
-        dict_num: Dict[str, np.ndarray] = None,
-        features: List[str] = None,
+        df_seq: Optional[pd.DataFrame] = None,
+        dict_num: Optional[Dict[str, np.ndarray]] = None,
+        features: Optional[List[str]] = None,
         return_std: bool = False,
         dim_names_override: Optional[List[str]] = None,
     ) -> Union[pd.DataFrame, Tuple[pd.DataFrame, pd.DataFrame]]:
@@ -1919,7 +1919,7 @@ class StructurePreprocessor:
 
     def build_cat(
         self,
-        features: List[str] = None,
+        features: Optional[List[str]] = None,
         dim_names_override: Optional[List[str]] = None,
     ) -> pd.DataFrame:
         """Build the ``df_cat`` metadata frame for ``features``.

--- a/aaanalysis/explainable_ai/_tree_model.py
+++ b/aaanalysis/explainable_ai/_tree_model.py
@@ -29,7 +29,7 @@ def check_is_preselected(is_preselected=None):
     return is_preselected
 
 
-def check_n_feat_min_n_feat_max(n_feat_min=None, n_feat_max=None):
+def check_n_feat_min_n_feat_max(n_feat_min=None, n_feat_max=None) -> None:
     """Check if vmin and vmax are valid numbers and vmin is less than vmax."""
     ut.check_number_range(name="n_feat_min", val=n_feat_min, min_val=1, just_int=True, accept_none=False)
     ut.check_number_range(name="n_feat_max", val=n_feat_max, min_val=1, just_int=True, accept_none=False)
@@ -37,7 +37,7 @@ def check_n_feat_min_n_feat_max(n_feat_min=None, n_feat_max=None):
         raise ValueError(f"'n_feat_min' ({n_feat_min}) >= 'n_feat_max' ({n_feat_max}) not fulfilled.")
 
 
-def check_n_cv(n_cv=None, labels=None):
+def check_n_cv(n_cv=None, labels=None) -> None:
     """Check if n_cv is valid"""
     ut.check_number_range(name="n_cv", val=n_cv, min_val=2, just_int=True)
     # Check if smaller than smaller class
@@ -48,7 +48,7 @@ def check_n_cv(n_cv=None, labels=None):
         raise ValueError(f"'n_cv' should not be greater than the smallest class count ({min_class_count}), got {n_cv}.")
 
 
-def check_metrics(name="list_eval_sores", metrics=None):
+def check_metrics(name="list_eval_sores", metrics=None) -> None:
     """Check if evaluation metrics are valid"""
     valid_metrics = ["accuracy", "balanced_accuracy", "precision", "recall", "f1", "roc_auc"]
     if metrics is None:
@@ -91,7 +91,7 @@ def check_list_is_selected(list_is_selected=None, X=None, convert_1d_to_2d=False
     return list_is_selected
 
 
-def check_match_df_feat_importance_arrays(df_feat=None, feat_importance=None, feat_importance_std=None, drop=False):
+def check_match_df_feat_importance_arrays(df_feat=None, feat_importance=None, feat_importance_std=None, drop=False) -> None:
     """Check if df_feat matches with importance values"""
     if feat_importance is None:
         raise ValueError(f"'feat_importance' is None. Please fit TreeModel before adding feature importance.")
@@ -112,7 +112,7 @@ def check_match_df_feat_importance_arrays(df_feat=None, feat_importance=None, fe
             raise ValueError(f"'{ut.COL_FEAT_IMPORT_STD}' already in 'df_feat' columns. To override, set 'drop=True'.")
 
 
-def check_param_matches_strategy(strategy=None, param=None, n_feat=None):
+def check_param_matches_strategy(strategy=None, param=None, n_feat=None) -> None:
     """Check that the polymorphic ``param`` has the type/range the strategy requires."""
     if strategy == ut.STRATEGY_TOP_K:
         ut.check_number_range(name="param", val=param, min_val=1, max_val=n_feat, just_int=True)
@@ -128,7 +128,7 @@ def check_param_matches_strategy(strategy=None, param=None, n_feat=None):
             raise ValueError(f"'param' (0) should be > 0 for 'strategy'='{ut.STRATEGY_FREQUENCY}'.")
 
 
-def check_match_df_feat_feat_importance(df_feat=None, feat_importance=None):
+def check_match_df_feat_feat_importance(df_feat=None, feat_importance=None) -> None:
     """Check that df_feat rows align one-to-one with the fitted feature importance."""
     n_feat = len(df_feat)
     n_feat_imp = len(feat_importance)
@@ -169,7 +169,7 @@ class TreeModel(Wrapper):
         Same order as ``feat_importance``.
     """
     def __init__(self,
-                 list_model_classes: List[Type[Union[ClassifierMixin, BaseEstimator]]] = None,
+                 list_model_classes: Optional[List[Type[Union[ClassifierMixin, BaseEstimator]]]] = None,
                  list_model_kwargs: Optional[List[Dict]] = None,
                  is_preselected: Optional[ut.ArrayLike1D] = None,
                  verbose: bool = True,
@@ -260,7 +260,7 @@ class TreeModel(Wrapper):
 
     def fit(self,
             X: ut.ArrayLike2D,
-            labels: ut.ArrayLike1D = None,
+            labels: Optional[ut.ArrayLike1D] = None,
             n_rounds: int = 5,
             use_rfe: bool = False,
             n_cv: int = 5,
@@ -354,12 +354,12 @@ class TreeModel(Wrapper):
 
     def eval(self,
              X: ut.ArrayLike2D,
-             labels: ut.ArrayLike1D = None,
-             list_is_selected: List[ut.ArrayLike2D] = None,
+             labels: Optional[ut.ArrayLike1D] = None,
+             list_is_selected: Optional[List[ut.ArrayLike2D]] = None,
              convert_1d_to_2d: bool = False,
              names_feature_selections: Optional[List[str]] = None,
              n_cv: int = 5,
-             list_metrics: Union[str, List[str]] = None,
+             list_metrics: Optional[Union[str, List[str]]] = None,
              ) -> pd.DataFrame:
         """
         Evaluate the prediction performance for different feature selections.
@@ -486,7 +486,7 @@ class TreeModel(Wrapper):
         return pred, pred_std
 
     def add_feat_importance(self,
-                            df_feat: pd.DataFrame = None,
+                            df_feat: Optional[pd.DataFrame] = None,
                             drop: bool = False,
                             sort: bool = False,
                             ) -> pd.DataFrame:
@@ -543,9 +543,9 @@ class TreeModel(Wrapper):
         return df_feat
 
     def select_features(self,
-                        df_feat: pd.DataFrame = None,
+                        df_feat: Optional[pd.DataFrame] = None,
                         strategy: Optional[Literal["top_k", "threshold", "frequency"]] = None,
-                        param: Union[int, float, dict] = None,
+                        param: Optional[Union[int, float, dict]] = None,
                         ) -> pd.DataFrame:
         """
         Select a subset of features from a feature DataFrame using tree-based feature importance.

--- a/aaanalysis/explainable_ai_pro/_shap_model.py
+++ b/aaanalysis/explainable_ai_pro/_shap_model.py
@@ -41,7 +41,7 @@ def check_shap_model(explainer_class=None, explainer_kwargs=None):
     return explainer_kwargs
 
 
-def check_match_class_explainer_and_models(explainer_class=None, explainer_kwargs=None, list_model_classes=None):
+def check_match_class_explainer_and_models(explainer_class=None, explainer_kwargs=None, list_model_classes=None) -> None:
     """Check if each model in list_model_class is compatible with the shap explainer class"""
     dummy_data = np.array([[0, 1], [1, 0]])  # Minimal dummy data to initialize explainers
     dummy_label = [0, 1]
@@ -71,7 +71,7 @@ def check_match_class_explainer_and_models(explainer_class=None, explainer_kwarg
 
 
 # Check functions for fit method
-def check_shap_values(shap_values=None):
+def check_shap_values(shap_values=None) -> None:
     """Check if shap values are properly set"""
     if shap_values is None:
         raise ValueError("'shape_values' are None. Use 'ShapModel().fit()' to compute them.")
@@ -109,7 +109,7 @@ def check_is_selected(is_selected=None, n_feat=None):
     return is_selected
 
 
-def check_match_labels_fuzzy_labeling(labels=None, fuzzy_labeling=False, verbose=True):
+def check_match_labels_fuzzy_labeling(labels=None, fuzzy_labeling=False, verbose=True) -> None:
     """Check if only on label is fuzzy labeled and that the remaining sample balanced (best training scenario)"""
     if not fuzzy_labeling:
         return  # Skip check if fuzzy labeling is not enabled
@@ -125,14 +125,14 @@ def check_match_labels_fuzzy_labeling(labels=None, fuzzy_labeling=False, verbose
                       f"\n The 'labels' contain {n_pos} positive (1) and {n_neg} negative (0) samples.")
 
 
-def check_match_labels_target_class_labels(label_target_class=None, labels=None):
+def check_match_labels_target_class_labels(label_target_class=None, labels=None) -> None:
     """Check if class index matches to classes (unique labels) in labels"""
     label_classes = sorted(list(dict.fromkeys([int(x) for x in labels if x == int(x)])))
     if label_target_class not in label_classes:
         raise ValueError(f"'label_target_class' ({label_target_class}) should be from 'labels' classes: {label_classes}")
 
 
-def check_match_n_background_data_X(n_background_data=None, X=None):
+def check_match_n_background_data_X(n_background_data=None, X=None) -> None:
     """Check if n_background_data not >= n_samples"""
     if n_background_data is None:
         return None # Skip test
@@ -141,7 +141,7 @@ def check_match_n_background_data_X(n_background_data=None, X=None):
         raise ValueError(f"'n_background_data' ({n_background_data}) must be < 'n_samples' ({n_samples}) from 'X'.")
 
 
-def check_match_df_seq_X(df_seq=None, X=None):
+def check_match_df_seq_X(df_seq=None, X=None) -> None:
     """Verify 'df_seq' has a unique 'entry' column and is row-aligned to 'X'."""
     if not isinstance(df_seq, pd.DataFrame):
         raise ValueError(f"'df_seq' ({type(df_seq)}) should be a pandas DataFrame.")
@@ -197,7 +197,7 @@ def check_sample_positions(sample_positions=None, n_samples=None):
     return sample_positions
 
 
-def check_names(names=None):
+def check_names(names=None) -> None:
     """Check if name is str ror list of str"""
     if names is None:
         return None     # Skip test
@@ -246,7 +246,7 @@ def check_match_sample_positions_names(sample_positions=None, names=None, group_
     return sample_positions, names
 
 
-def check_match_sample_positions_group_average(sample_positions=None, group_average=False):
+def check_match_sample_positions_group_average(sample_positions=None, group_average=False) -> None:
     """Check if group_average only True if sample_positions is list"""
     if group_average:
         sample_positions = ut.check_list_like(name="sample_positions", val=sample_positions)
@@ -305,7 +305,7 @@ def check_match_samples_df_seq(samples=None, names=None, df_seq=None, n_samples=
     return samples, names
 
 
-def check_match_df_feat_shap_values(df_feat=None, shap_values=None, drop=False, shap_feat_importance=False):
+def check_match_df_feat_shap_values(df_feat=None, shap_values=None, drop=False, shap_feat_importance=False) -> None:
     """Check if df_feat matches with importance values"""
     if shap_values is None:
         raise ValueError(f"'shap_values' is None. Please fit ShapModel before adding feature impact.")
@@ -355,7 +355,7 @@ class ShapModel(Wrapper):
     def __init__(self,
                  explainer_class: Callable = shap.TreeExplainer,
                  explainer_kwargs: Optional[dict] = None,
-                 list_model_classes: List[Type[Union[BaseEstimator]]] = None,
+                 list_model_classes: Optional[List[Type[Union[BaseEstimator]]]] = None,
                  list_model_kwargs: Optional[List[dict]] = None,
                  verbose: bool = True,
                  random_state: Optional[int] = None,
@@ -467,10 +467,10 @@ class ShapModel(Wrapper):
 
     def fit(self,
             X: ut.ArrayLike2D,
-            labels: ut.ArrayLike1D = None,
+            labels: Optional[ut.ArrayLike1D] = None,
             label_target_class: int = 1,
             n_rounds: int = 5,
-            is_selected: ut.ArrayLike2D = None,
+            is_selected: Optional[ut.ArrayLike2D] = None,
             fuzzy_labeling: bool = False,
             n_background_data: Optional[int] = None,
             df_seq: Optional[pd.DataFrame] = None,
@@ -586,7 +586,7 @@ class ShapModel(Wrapper):
         self.exp_value = exp_val
         return self
 
-    def eval(self, shap_values=None, is_selected=None):
+    def eval(self, shap_values=None, is_selected=None) -> None:
         """Evaluate convergence of the Monte Carlo SHAP-value estimates over rounds.
 
         .. note::
@@ -596,7 +596,7 @@ class ShapModel(Wrapper):
         raise NotImplementedError("ShapModel.eval is under construction.")
 
     def add_feat_impact(self,
-                        df_feat: pd.DataFrame = None,
+                        df_feat: Optional[pd.DataFrame] = None,
                         drop: bool = False,
                         samples: Union[int, List[int], str, List[str], None] = None,
                         names: Optional[Union[str, List[str]]] = None,
@@ -733,9 +733,9 @@ class ShapModel(Wrapper):
 
     @staticmethod
     def add_sample_mean_dif(X: ut.ArrayLike2D,
-                            labels: ut.ArrayLike1D = None,
+                            labels: Optional[ut.ArrayLike1D] = None,
                             label_ref: int = 0,
-                            df_feat: pd.DataFrame = None,
+                            df_feat: Optional[pd.DataFrame] = None,
                             drop: bool = False,
                             samples: Union[int, List[int], str, List[str], None] = None,
                             names: Optional[Union[str, List[str]]] = None,

--- a/aaanalysis/feature_engineering/_aaclust.py
+++ b/aaanalysis/feature_engineering/_aaclust.py
@@ -24,7 +24,7 @@ from ._backend.aaclust.aaclust_methods import (compute_centers, compute_medoids,
 
 # I Helper Functions
 # Check parameter matching functions
-def check_match_X_names(X=None, names=None, accept_none=True):
+def check_match_X_names(X=None, names=None, accept_none=True) -> None:
     """Verify that the number of samples in 'X' matches the length of 'names'."""
     if accept_none and names is None:
         return
@@ -33,7 +33,7 @@ def check_match_X_names(X=None, names=None, accept_none=True):
         raise ValueError(f"n_samples does not match for 'X' ({len(X)}) and 'names' ({len(names)}).")
 
 
-def check_match_X_n_clusters(X=None, n_clusters=None, accept_none=True):
+def check_match_X_n_clusters(X=None, n_clusters=None, accept_none=True) -> None:
     """Ensure the number of samples and unique samples in 'X' are greater than or equal to 'n_clusters'."""
     if accept_none and n_clusters is None:
         return
@@ -45,7 +45,7 @@ def check_match_X_n_clusters(X=None, n_clusters=None, accept_none=True):
         raise ValueError(f"'n_clusters' ({n_clusters}) should be >= n_unique_samples={n_unique_samples} (in 'X').")
 
 
-def check_match_df_seq_X(df_seq=None, X=None):
+def check_match_df_seq_X(df_seq=None, X=None) -> None:
     """Verify 'df_seq' has a unique 'entry' column and is row-aligned to 'X'."""
     if not isinstance(df_seq, pd.DataFrame):
         raise ValueError(f"'df_seq' ({type(df_seq)}) should be a pandas DataFrame.")
@@ -59,7 +59,7 @@ def check_match_df_seq_X(df_seq=None, X=None):
         raise ValueError(f"n_proteins does not match for 'df_seq' ({len(df_seq)}) and 'X' ({n_samples} rows).")
 
 
-def check_X_X_ref(X=None, X_ref=None):
+def check_X_X_ref(X=None, X_ref=None) -> None:
     """Check that the number of features in 'X' matches the number of features in 'X_ref'."""
     n_samples, n_features = X.shape
     n_samples_ref, n_features_ref = X_ref.shape
@@ -81,7 +81,7 @@ def check_labels_cor(labels=None, labels_name="labels"):
 
 
 # Post check functions
-def post_check_n_clusters(n_clusters_actual=None, n_clusters=None):
+def post_check_n_clusters(n_clusters_actual=None, n_clusters=None) -> None:
     """Check if n_clusters set properly"""
     if n_clusters is not None and n_clusters_actual < n_clusters:
         warnings.warn(f"'n_clusters' was reduced from {n_clusters} to {n_clusters_actual} "
@@ -89,7 +89,7 @@ def post_check_n_clusters(n_clusters_actual=None, n_clusters=None):
 
 
 # Matching functions for filter_coverage
-def check_match_X_scale_ids(X=None, scale_ids=None, accept_none=True):
+def check_match_X_scale_ids(X=None, scale_ids=None, accept_none=True) -> None:
     """Verify that the number of samples in 'X' matches the length of 'names'."""
     if accept_none and scale_ids is None:
         return
@@ -98,7 +98,7 @@ def check_match_X_scale_ids(X=None, scale_ids=None, accept_none=True):
         raise ValueError(f"n_samples does not match for 'X' ({len(X)}) and 'scale_ids' ({len(scale_ids)}).")
 
 
-def check_match_scale_ids_names(scale_ids=None, names=None, df_cat=None, col_name=None):
+def check_match_scale_ids_names(scale_ids=None, names=None, df_cat=None, col_name=None) -> None:
     """Check scale elements corresponding to scale_ids are superset of names"""
     all_scale_names = df_cat[df_cat[ut.COL_SCALE_ID].isin(scale_ids)][col_name].to_list()
     ut.check_superset_subset(name_superset=f"df_cat ('{col_name}')",
@@ -339,7 +339,7 @@ class AAclust(Wrapper):
 
     def eval(self,
              X: ut.ArrayLike2D,
-             list_labels: ut.ArrayLike2D = None,
+             list_labels: Optional[ut.ArrayLike2D] = None,
              names_datasets: Optional[List[str]] = None,
              ) -> pd.DataFrame:
         """
@@ -414,8 +414,8 @@ class AAclust(Wrapper):
 
     @staticmethod
     def name_clusters(X: ut.ArrayLike2D,
-                      labels: ut.ArrayLike1D = None,
-                      names: List[str] = None,
+                      labels: Optional[ut.ArrayLike1D] = None,
+                      names: Optional[List[str]] = None,
                       shorten_names : bool = True,
                       ) -> List[str]:
         """
@@ -465,7 +465,7 @@ class AAclust(Wrapper):
 
     @staticmethod
     def comp_centers(X: ut.ArrayLike2D,
-                     labels: ut.ArrayLike1D = None
+                     labels: Optional[ut.ArrayLike1D] = None
                      ) -> Tuple[ut.ArrayLike1D, ut.ArrayLike1D]:
         """
         Computes the center of each cluster based on the given labels.
@@ -504,7 +504,7 @@ class AAclust(Wrapper):
 
     @staticmethod
     def comp_medoids(X: ut.ArrayLike2D,
-                     labels: ut.ArrayLike1D = None,
+                     labels: Optional[ut.ArrayLike1D] = None,
                      metric: Literal["correlation", "manhattan", "euclidean", "cosine"] = "correlation"
                      ) -> Tuple[ut.ArrayLike1D, ut.ArrayLike1D]:
         """
@@ -553,7 +553,7 @@ class AAclust(Wrapper):
 
     @staticmethod
     def comp_correlation(X: ut.ArrayLike2D,
-                         labels: ut.ArrayLike1D = None,
+                         labels: Optional[ut.ArrayLike1D] = None,
                          X_ref: Optional[ut.ArrayLike2D] = None,
                          labels_ref: Optional[ut.ArrayLike1D] = None,
                          names: Optional[List[str]] = None,
@@ -624,8 +624,8 @@ class AAclust(Wrapper):
         return df_corr, labels_sorted
 
     @staticmethod
-    def comp_coverage(names: List[str] = None,
-                      names_ref: List[str] = None
+    def comp_coverage(names: Optional[List[str]] = None,
+                      names_ref: Optional[List[str]] = None
                       ) -> float:
         """
         Computes the percentage of unique names from ``names`` that are present in ``names_ref``.
@@ -663,7 +663,7 @@ class AAclust(Wrapper):
         return coverage
 
     def select_scales(self,
-                      df_scales: pd.DataFrame = None,
+                      df_scales: Optional[pd.DataFrame] = None,
                       n_clusters: Optional[int] = None,
                       on_center: bool = True,
                       min_th: float = 0.3,
@@ -731,10 +731,10 @@ class AAclust(Wrapper):
 
     def filter_coverage(self,
                         X: ut.ArrayLike2D,
-                        scale_ids: List[str] = None,
-                        names_ref: List[str] = None,
+                        scale_ids: Optional[List[str]] = None,
+                        names_ref: Optional[List[str]] = None,
                         min_coverage: int = 100,
-                        df_cat: pd.DataFrame = None,
+                        df_cat: Optional[pd.DataFrame] = None,
                         col_name: Literal['category', 'subcategory', 'scale_name'] = "subcategory"
                         ) -> List[str]:
         """

--- a/aaanalysis/feature_engineering/_aaclust_plot.py
+++ b/aaanalysis/feature_engineering/_aaclust_plot.py
@@ -82,14 +82,14 @@ def check_match_df_corr_labels_ref(df_corr=None, labels_ref=None, labels=None, p
     return labels_ref
 
 
-def check_method(method=None):
+def check_method(method=None) -> None:
     """Validate the method parameter against a list of valid hierarchical clustering methods"""
     valid_methods = ["single", "complete", "average", "weighted", "centroid", "median", "ward"]
     if method not in valid_methods:
         raise ValueError(f"'method' ({method}) should be one of: {valid_methods}")
 
 
-def check_match_df_corr_clust_x(df_corr=None, cluster_x=None):
+def check_match_df_corr_clust_x(df_corr=None, cluster_x=None) -> None:
     """Ensure df_corr has variability and no missing values if cluster_x is enabled"""
     all_vals = df_corr.to_numpy().flatten()[1:].tolist()
     if cluster_x:
@@ -191,7 +191,7 @@ class AAclustPlot:
         self._model_kwargs = model_kwargs
 
     @staticmethod
-    def eval(df_eval: pd.DataFrame = None,
+    def eval(df_eval: Optional[pd.DataFrame] = None,
              figsize: Tuple[Union[int, float], Union[int, float]] = (6, 4),
              dict_xlims: Optional[dict] = None,
              ) -> Tuple[plt.Figure, plt.Axes]:
@@ -356,7 +356,7 @@ class AAclustPlot:
 
     def medoids(self,
                 X: Optional[ut.ArrayLike2D] = None,
-                labels: ut.ArrayLike1D = None,
+                labels: Optional[ut.ArrayLike1D] = None,
                 df_scales: Optional[pd.DataFrame] = None,
                 component_x: int = 1,
                 component_y: int = 2,
@@ -465,8 +465,8 @@ class AAclustPlot:
         return ax, df_components
 
     def correlation(self,
-                    df_corr: pd.DataFrame = None,
-                    labels: ut.ArrayLike1D = None,
+                    df_corr: Optional[pd.DataFrame] = None,
+                    labels: Optional[ut.ArrayLike1D] = None,
                     labels_ref: Optional[ut.ArrayLike1D] = None,
                     cluster_x: bool = False,
                     method: str = "average",

--- a/aaanalysis/feature_engineering/_cpp.py
+++ b/aaanalysis/feature_engineering/_cpp.py
@@ -72,7 +72,7 @@ def _finalize_run_output(df_feat=None, return_stats=False):
     return df_feat
 
 
-def check_sample_in_df_seq(sample_name=None, df_seq=None):
+def check_sample_in_df_seq(sample_name=None, df_seq=None) -> None:
     """Check if sample name in df_seq"""
     list_names = list(df_seq[ut.COL_NAME])
     if sample_name not in list_names:
@@ -83,13 +83,13 @@ def check_sample_in_df_seq(sample_name=None, df_seq=None):
         raise ValueError(error)
 
 
-def check_match_list_df_feat_list_df_parts(list_df_feat=None, list_df_parts=None):
+def check_match_list_df_feat_list_df_parts(list_df_feat=None, list_df_parts=None) -> None:
     """Check if all elements in list are valid feature DataFrames"""
     for df_feat, df_parts in zip(list_df_feat, list_df_parts):
         ut.check_df_feat(df_feat=df_feat, list_parts=list(df_parts))
 
 
-def check_ml_cv_labels(ml_cv=None, labels=None):
+def check_ml_cv_labels(ml_cv=None, labels=None) -> None:
     """Validate ``ml_cv`` (>=2, <= smallest class count) for the simplify CV gate."""
     ut.check_number_range(name="ml_cv", val=ml_cv, min_val=2, just_int=True)
     min_class_count = min(pd.Series(labels).value_counts())
@@ -100,7 +100,7 @@ def check_ml_cv_labels(ml_cv=None, labels=None):
         )
 
 
-def check_ml_model(ml_model=None):
+def check_ml_model(ml_model=None) -> None:
     """Validate the simplify CV-gate model: a string preset or a classifier instance."""
     if isinstance(ml_model, str):
         ut.check_str_options(
@@ -115,7 +115,7 @@ def check_ml_model(ml_model=None):
 
 def check_match_list_df_feat_names_feature_sets(
     list_df_feat=None, names_feature_sets=None
-):
+) -> None:
     """Check if length of list_df_feat and names match"""
     if names_feature_sets is None:
         return None  # Skip check
@@ -172,7 +172,7 @@ def _check_dict_num_df_scales_match(dict_num=None, df_scales=None):
 
 def check_match_df_seq_df_parts(
     df_seq=None, df_parts=None, jmd_n_len=None, jmd_c_len=None
-):
+) -> None:
     """Verify ``df_seq`` derives parts equal to ``df_parts`` (CPP.run_num parity guard)."""
     list_parts = list(df_parts)
     try:
@@ -292,7 +292,7 @@ class CPP(Tool):
 
     def __init__(
         self,
-        df_parts: pd.DataFrame = None,
+        df_parts: Optional[pd.DataFrame] = None,
         split_kws: Optional[dict] = None,
         df_scales: Optional[pd.DataFrame] = None,
         df_cat: Optional[pd.DataFrame] = None,
@@ -390,7 +390,7 @@ class CPP(Tool):
     # Main method
     def run(
         self,
-        labels: ut.ArrayLike1D = None,
+        labels: Optional[ut.ArrayLike1D] = None,
         label_test: int = 1,
         label_ref: int = 0,
         n_filter: int = 100,
@@ -689,8 +689,8 @@ class CPP(Tool):
 
     def run_num(
         self,
-        dict_num_parts: Dict[str, np.ndarray] = None,
-        labels: ut.ArrayLike1D = None,
+        dict_num_parts: Optional[Dict[str, np.ndarray]] = None,
+        labels: Optional[ut.ArrayLike1D] = None,
         label_test: int = 1,
         label_ref: int = 0,
         n_filter: int = 100,
@@ -965,8 +965,8 @@ class CPP(Tool):
 
     def eval(
         self,
-        list_df_feat: List[pd.DataFrame] = None,
-        labels: ut.ArrayLike1D = None,
+        list_df_feat: Optional[List[pd.DataFrame]] = None,
+        labels: Optional[ut.ArrayLike1D] = None,
         label_test: int = 1,
         label_ref: int = 0,
         min_th: float = 0.0,
@@ -1104,8 +1104,8 @@ class CPP(Tool):
         return df_eval
     def simplify(
         self,
-        df_feat: pd.DataFrame = None,
-        labels: ut.ArrayLike1D = None,
+        df_feat: Optional[pd.DataFrame] = None,
+        labels: Optional[ut.ArrayLike1D] = None,
         strategy: Literal["greedy", "consolidate", "swap_all"] = "greedy",
         candidate_search: Literal["exact", "fast"] = "exact",
         max_interpret_grade: Optional[int] = None,

--- a/aaanalysis/feature_engineering/_cpp_grid.py
+++ b/aaanalysis/feature_engineering/_cpp_grid.py
@@ -179,8 +179,8 @@ class CPPGrid(Tool):
     """
 
     def __init__(self,
-                 df_seq: pd.DataFrame = None,
-                 labels: ut.ArrayLike1D = None,
+                 df_seq: Optional[pd.DataFrame] = None,
+                 labels: Optional[ut.ArrayLike1D] = None,
                  dict_num: Optional[Dict[str, np.ndarray]] = None,
                  accept_gaps: bool = False,
                  verbose: bool = True,

--- a/aaanalysis/feature_engineering/_cpp_plot.py
+++ b/aaanalysis/feature_engineering/_cpp_plot.py
@@ -50,7 +50,7 @@ def check_match_dict_color_list_cat(dict_color=None, list_cat=None):
     return {cat: dict_color[cat] for cat in list_cat}
 
 
-def check_df_eval(df_eval):
+def check_df_eval(df_eval) -> None:
     """Check if columns in df_eval have valid values"""
     if len(df_eval) <= 1:
         raise ValueError("'df_eval' should contain at least two features sets")
@@ -71,7 +71,7 @@ def check_df_eval(df_eval):
     ut.check_number_range(name=ut.COL_STD_N_FEAT_PER_CLUST, val=std_n_feat_per_clust, just_int=False)
 
 
-def check_match_df_eval_list_cat(df_eval=None, list_cat=None):
+def check_match_df_eval_list_cat(df_eval=None, list_cat=None) -> None:
     """Check if number of features per category in df_eval and list_cat match"""
     names = df_eval[ut.COL_NAME].to_list()
     list_n_feat_sets = [x[1] for x in df_eval[ut.COL_N_FEAT]]
@@ -81,7 +81,7 @@ def check_match_df_eval_list_cat(df_eval=None, list_cat=None):
 
 
 # Checks for feature plot
-def check_match_df_seq_names_to_show(df_seq=None, names_to_show=None):
+def check_match_df_seq_names_to_show(df_seq=None, names_to_show=None) -> None:
     """Check if """
     if names_to_show is None:
         return # Skip check
@@ -95,14 +95,14 @@ def check_match_df_seq_names_to_show(df_seq=None, names_to_show=None):
 
 
 # Checks for main CPP plots (ranking, profile, maps)
-def check_cmap_for_heatmap(cmap=None):
+def check_cmap_for_heatmap(cmap=None) -> None:
     """Check if cmap is valid or 'SHAP'"""
     if cmap in [ut.STR_CMAP_SHAP, ut.STR_CMAP_CPP]:
         return None     # Skip test
     ut.check_cmap(name="cmap", val=cmap, accept_none=True)
 
 
-def check_col_dif(col_dif=None, shap_plot=False):
+def check_col_dif(col_dif=None, shap_plot=False) -> None:
     """Check if col_dif is string and set default"""
     ut.check_str(name="col_dif", val=col_dif, accept_none=False)
     if col_dif is None:
@@ -149,13 +149,13 @@ def check_col_val(col_val=None, shap_plot=False, sample_mean_dif=False):
     return col_val
 
 
-def check_match_shap_plot_add_legend_cat(shap_plot=False, add_legend_cat=False):
+def check_match_shap_plot_add_legend_cat(shap_plot=False, add_legend_cat=False) -> None:
     """Check if not both are True"""
     if shap_plot and add_legend_cat:
         raise ValueError(f"'shap_plot' ({shap_plot}) and 'add_legend_cat' ({add_legend_cat}) can not be both True.")
 
 
-def check_imp_tuples(name="imp_th", imp_tuples=None):
+def check_imp_tuples(name="imp_th", imp_tuples=None) -> None:
     """Check if legend importance thresholds are valid"""
     ut.check_tuple(name=name, val=imp_tuples, n=3,
                    accept_none=False, check_number=True,
@@ -168,7 +168,7 @@ def check_imp_tuples(name="imp_th", imp_tuples=None):
 
 
 # Check update_seq_size
-def check_match_ax_seq_len(ax=None, jmd_n_len=10, jmd_c_len=10):
+def check_match_ax_seq_len(ax=None, jmd_n_len=10, jmd_c_len=10) -> None:
     """Check if ax matches with required length"""
     labels = ax.xaxis.get_ticklabels(which="both")
     f = lambda l: l.get_window_extent(ax.figure.canvas.get_renderer())
@@ -281,7 +281,7 @@ class CPPPlot:
         self._jmd_c_len = jmd_c_len
 
     @staticmethod
-    def eval(df_eval: pd.DataFrame = None,
+    def eval(df_eval: Optional[pd.DataFrame] = None,
              figsize: Tuple[int or float, int or float] = (6, 4),
              dict_xlims: Optional[dict] = None,
              legend: bool = True,
@@ -380,10 +380,10 @@ class CPPPlot:
 
     # Plotting method for single feature
     def feature(self,
-                feature: Union[str, List[str], pd.DataFrame] = None,
+                feature: Optional[Union[str, List[str], pd.DataFrame]] = None,
                 feat_rank: int = 1,
-                df_seq: pd.DataFrame = None,
-                labels: ut.ArrayLike1D = None,
+                df_seq: Optional[pd.DataFrame] = None,
+                labels: Optional[ut.ArrayLike1D] = None,
                 label_test: int = 1,
                 label_ref: int = 0, 
                 ax: Optional[plt.Axes] = None,
@@ -539,7 +539,7 @@ class CPPPlot:
 
     # Plotting methods for multiple features (group and sample level)
     def ranking(self,
-                df_feat: pd.DataFrame = None,
+                df_feat: Optional[pd.DataFrame] = None,
                 shap_plot: bool = False,
                 col_dif: str = "mean_dif",
                 col_imp: str = "feat_importance",
@@ -712,7 +712,7 @@ class CPPPlot:
 
     def profile(self,
                 # Data and Plot Type
-                df_feat: pd.DataFrame = None,
+                df_feat: Optional[pd.DataFrame] = None,
                 shap_plot: bool = False,
                 col_imp: Union[str, None] = "feat_importance",
                 normalize: bool = True,
@@ -729,8 +729,8 @@ class CPPPlot:
                 jmd_color: str = "blue",
                 tmd_seq_color: str = "black",
                 jmd_seq_color: str = "white",
-                seq_size: Union[int, float] = None,
-                fontsize_tmd_jmd: Union[int, float] = None,
+                seq_size: Optional[Union[int, float]] = None,
+                fontsize_tmd_jmd: Optional[Union[int, float]] = None,
                 weight_tmd_jmd: Literal['normal', 'bold'] = "normal",
                 add_xticks_pos: bool = False,
                 highlight_tmd_area: bool = True,
@@ -939,7 +939,7 @@ class CPPPlot:
 
     def heatmap(self,
                 # Data and Plot Type
-                df_feat: pd.DataFrame = None,
+                df_feat: Optional[pd.DataFrame] = None,
                 shap_plot: bool = False,
                 col_cat: Literal['category', 'subcategory', 'scale_name'] = "subcategory",
                 col_val: str = "mean_dif",
@@ -1193,7 +1193,7 @@ class CPPPlot:
 
     def feature_map(self,
                     # Data and Plot Type
-                    df_feat: pd.DataFrame = None,
+                    df_feat: Optional[pd.DataFrame] = None,
                     shap_plot: bool = False,
                     col_cat: Literal['category', 'subcategory', 'scale_name'] = "subcategory",
                     col_val: str = "mean_dif",
@@ -1512,10 +1512,10 @@ class CPPPlot:
         return fig, ax
 
     def update_seq_size(self,
-                        ax: plt.Axes = None,
+                        ax: Optional[plt.Axes] = None,
                         fig: Optional[plt.Figure] = None,
                         max_x_dist: float = 0.1,
-                        fontsize_tmd_jmd: Union[int, float] = None,
+                        fontsize_tmd_jmd: Optional[Union[int, float]] = None,
                         weight_tmd_jmd: Literal['normal', 'bold'] = 'normal',
                         tmd_color: str = "mediumspringgreen",
                         jmd_color: str = "blue",

--- a/aaanalysis/feature_engineering/_numerical_feature.py
+++ b/aaanalysis/feature_engineering/_numerical_feature.py
@@ -16,14 +16,14 @@ from ._backend.cpp._filters._assign import assign_dict_num_to_parts
 
 
 # I Helper Functions
-def check_match_df_scales_letter_new(df_scales=None, letter_new=None):
+def check_match_df_scales_letter_new(df_scales=None, letter_new=None) -> None:
     """Check if new letter not already in df_scales"""
     alphabet = df_scales.index.to_list()
     if letter_new in alphabet:
         raise ValueError(f"Letter '{letter_new}' already exists in alphabet of 'df_scales': {alphabet}")
 
 
-def check_match_df_seq_dict_num(df_seq=None, dict_num=None):
+def check_match_df_seq_dict_num(df_seq=None, dict_num=None) -> None:
     """Validate that ``dict_num`` matches ``df_seq`` (Layer-1 contract for ``get_parts``).
 
     Checks (per entry):
@@ -124,8 +124,8 @@ class NumericalFeature:
         return is_selected
 
     @staticmethod
-    def get_parts(df_seq: pd.DataFrame = None,
-                  dict_num: Dict[str, np.ndarray] = None,
+    def get_parts(df_seq: Optional[pd.DataFrame] = None,
+                  dict_num: Optional[Dict[str, np.ndarray]] = None,
                   list_parts: Optional[List[str]] = None,
                   all_parts: bool = False,
                   jmd_n_len: int = 10,
@@ -278,8 +278,8 @@ class NumericalFeature:
         return df_parts, dict_part_vals
 
     @staticmethod
-    def extend_alphabet(df_scales: pd.DataFrame = None,
-                        new_letter: str = None,
+    def extend_alphabet(df_scales: Optional[pd.DataFrame] = None,
+                        new_letter: Optional[str] = None,
                         value_type: Literal["min", "mean", "median", "max"] = "mean",
                         ) -> pd.DataFrame:
         """

--- a/aaanalysis/feature_engineering/_sequence_feature.py
+++ b/aaanalysis/feature_engineering/_sequence_feature.py
@@ -57,7 +57,7 @@ def check_steps(steps=None, steps_name="steps_pattern", len_min=2, fixed_len=Fal
     return steps
 
 
-def warn_creation_of_feature_matrix(features=None, df_parts=None, name="Feature matrix"):
+def warn_creation_of_feature_matrix(features=None, df_parts=None, name="Feature matrix") -> None:
     """Warn if feature matrix gets too large"""
     n_feat = len(features)
     n_samples = len(df_parts)
@@ -70,7 +70,7 @@ def warn_creation_of_feature_matrix(features=None, df_parts=None, name="Feature 
         warnings.warn(warning)
 
 
-def check_match_labels_label_test_label_ref(labels=None, label_test=1, label_ref=0):
+def check_match_labels_label_test_label_ref(labels=None, label_test=1, label_ref=0) -> None:
     """Check if labels only contains label_test and label_ref"""
     wrong_labels = [x for x in labels if x not in [label_ref, label_test]]
     unique_wrong_labels = list(set(wrong_labels))
@@ -79,7 +79,7 @@ def check_match_labels_label_test_label_ref(labels=None, label_test=1, label_ref
         raise ValueError(f"'labels' contains {n_wrong_labels} wrong labels: {unique_wrong_labels}")
 
 
-def check_match_df_parts_label_test_label_ref(df_parts=None, labels=None, label_test=1, label_ref=0):
+def check_match_df_parts_label_test_label_ref(df_parts=None, labels=None, label_test=1, label_ref=0) -> None:
     """Check if 'jmd_n', 'tmd', and 'jmd_c' in df_parts if amino acid for label_test or label_ref should be retrieved"""
     list_parts = list(df_parts)
     required_parts = ["jmd_n", "tmd", "jmd_c"]
@@ -99,20 +99,20 @@ def check_match_df_parts_label_test_label_ref(df_parts=None, labels=None, label_
                              f"\n Add them to the current parts of 'df_parts': {list_parts}")
 
 
-def check_col_cat(col_cat=None):
+def check_col_cat(col_cat=None) -> None:
     """Check if col_cat valid column from df_feat"""
     if col_cat not in ut.COLS_FEAT_SCALES:
         raise ValueError(f"'col_cat' {col_cat} should be one of: {ut.COLS_FEAT_SCALES}")
 
 
-def check_col_val(col_val=None):
+def check_col_val(col_val=None) -> None:
     """Check if col_val valid column from df_feat"""
     cols_feat = ut.COLS_FEAT_STAT + ut.COLS_FEAT_WEIGHT
     if col_val not in cols_feat:
         raise ValueError(f"'col_val' {col_val} should be one of: {cols_feat}")
 
 
-def check_match_labels_value_sources(labels=None, df_parts=None, dict_num_parts=None, name="labels"):
+def check_match_labels_value_sources(labels=None, df_parts=None, dict_num_parts=None, name="labels") -> None:
     """Check at least one value source is given and each aligns row-wise with labels/targets."""
     if df_parts is None and dict_num_parts is None:
         raise ValueError("Provide at least one of 'df_parts' or 'dict_num_parts' to subset per group.")
@@ -188,7 +188,7 @@ def recover_seq_parts_from_df_parts_row(row=None):
     return jmd_n_seq, tmd_seq, jmd_c_seq
 
 
-def check_match_df_seq_df_parts(df_seq=None, entry=None, jmd_n_seq="", tmd_seq="", jmd_c_seq=""):
+def check_match_df_seq_df_parts(df_seq=None, entry=None, jmd_n_seq="", tmd_seq="", jmd_c_seq="") -> None:
     """Check that the parts recovered from ``df_parts`` are consistent with ``df_seq`` for one protein."""
     mask = df_seq[ut.COL_ENTRY] == entry
     if not mask.any():
@@ -275,7 +275,7 @@ class SequenceFeature:
 
     # Part and Split methods
     def get_df_parts(self,
-                     df_seq: pd.DataFrame = None,
+                     df_seq: Optional[pd.DataFrame] = None,
                      list_parts: Optional[Union[str, List[str]]] = None,
                      all_parts: bool = False,
                      jmd_n_len: Union[int, None] = 10,
@@ -407,9 +407,9 @@ class SequenceFeature:
         return df_parts
 
     def get_seq_kws(self,
-                    df_seq: pd.DataFrame = None,
-                    df_parts: pd.DataFrame = None,
-                    sample: Union[int, str] = None,
+                    df_seq: Optional[pd.DataFrame] = None,
+                    df_parts: Optional[pd.DataFrame] = None,
+                    sample: Optional[Union[int, str]] = None,
                     ) -> dict:
         """
         Get the per-part sequence keyword arguments (``jmd_n_seq``, ``tmd_seq``, ``jmd_c_seq``) for one protein.
@@ -570,9 +570,9 @@ class SequenceFeature:
 
     # Feature methods
     def get_df_feat(self,
-                    features: Union[ut.ArrayLike1D, pd.DataFrame] = None,
-                    df_parts: pd.DataFrame = None,
-                    labels: ut.ArrayLike1D = None,
+                    features: Optional[Union[ut.ArrayLike1D, pd.DataFrame]] = None,
+                    df_parts: Optional[pd.DataFrame] = None,
+                    labels: Optional[ut.ArrayLike1D] = None,
                     label_test: int = 1,
                     label_ref: int = 0,
                     df_scales: Optional[pd.DataFrame] = None,
@@ -697,8 +697,8 @@ class SequenceFeature:
         return df_feat
 
     def feature_matrix(self,
-                       features: Union[ut.ArrayLike1D, pd.DataFrame] = None,
-                       df_parts: Union[pd.DataFrame, List[pd.DataFrame]] = None,
+                       features: Optional[Union[ut.ArrayLike1D, pd.DataFrame]] = None,
+                       df_parts: Optional[Union[pd.DataFrame, List[pd.DataFrame]]] = None,
                        df_scales: Optional[pd.DataFrame] = None,
                        accept_gaps: bool = False,
                        n_jobs: Union[int, None] = 1,
@@ -803,7 +803,7 @@ class SequenceFeature:
         return list_X if batch else list_X[0]
 
     def prune_by_variance(self,
-                          df_feat: pd.DataFrame = None,
+                          df_feat: Optional[pd.DataFrame] = None,
                           df_parts: Optional[pd.DataFrame] = None,
                           df_scales: Optional[pd.DataFrame] = None,
                           threshold: float = 0.0,
@@ -901,7 +901,7 @@ class SequenceFeature:
         return df_feat
 
     def prune_by_correlation(self,
-                             df_feat: pd.DataFrame = None,
+                             df_feat: Optional[pd.DataFrame] = None,
                              df_parts: Optional[pd.DataFrame] = None,
                              df_scales: Optional[pd.DataFrame] = None,
                              max_cor: float = 0.7,
@@ -1076,7 +1076,7 @@ class SequenceFeature:
         return features
 
     @staticmethod
-    def get_feature_names(features: Union[ut.ArrayLike1D, pd.DataFrame] = None,
+    def get_feature_names(features: Optional[Union[ut.ArrayLike1D, pd.DataFrame]] = None,
                           df_cat: Optional[pd.DataFrame] = None,
                           start: int = 1,
                           tmd_len: int = 20,
@@ -1151,7 +1151,7 @@ class SequenceFeature:
         return feat_names
 
     @staticmethod
-    def get_feature_descriptions(features: Union[ut.ArrayLike1D, pd.DataFrame] = None,
+    def get_feature_descriptions(features: Optional[Union[ut.ArrayLike1D, pd.DataFrame]] = None,
                                  df_cat: Optional[pd.DataFrame] = None,
                                  start: int = 1,
                                  tmd_len: int = 20,
@@ -1232,7 +1232,7 @@ class SequenceFeature:
         return feat_descriptions
 
     @staticmethod
-    def get_feature_positions(features: Union[ut.ArrayLike1D, pd.DataFrame] = None,
+    def get_feature_positions(features: Optional[Union[ut.ArrayLike1D, pd.DataFrame]] = None,
                               start: int = 1,
                               tmd_len: int = 20,
                               jmd_n_len: int = 10,
@@ -1308,7 +1308,7 @@ class SequenceFeature:
             return list_pos
 
     @staticmethod
-    def get_df_pos(df_feat: pd.DataFrame = None,
+    def get_df_pos(df_feat: Optional[pd.DataFrame] = None,
                    col_val: str = "mean_dif",
                    col_cat: str = "category",
                    start: int = 1,
@@ -1389,7 +1389,7 @@ class SequenceFeature:
         return df_pos
 
     @staticmethod
-    def get_labels_ovr(labels: ut.ArrayLike1D = None,
+    def get_labels_ovr(labels: Optional[ut.ArrayLike1D] = None,
                        label_test: int = 1,
                        label_ref: int = 0,
                        ) -> Dict[int, np.ndarray]:
@@ -1450,9 +1450,9 @@ class SequenceFeature:
         return get_labels_ovr_(labels=labels, label_test=label_test, label_ref=label_ref)
 
     @staticmethod
-    def get_labels_ovo(labels: ut.ArrayLike1D = None,
-                       df_parts: pd.DataFrame = None,
-                       dict_num_parts: Dict[str, np.ndarray] = None,
+    def get_labels_ovo(labels: Optional[ut.ArrayLike1D] = None,
+                       df_parts: Optional[pd.DataFrame] = None,
+                       dict_num_parts: Optional[Dict[str, np.ndarray]] = None,
                        label_test: int = 1,
                        label_ref: int = 0,
                        ) -> Dict[Tuple[int, int], Tuple[Optional[pd.DataFrame], Optional[Dict[str, np.ndarray]], np.ndarray]]:
@@ -1530,7 +1530,7 @@ class SequenceFeature:
         return dict_labels
 
     @staticmethod
-    def get_labels_quantile(targets: ut.ArrayLike1D = None,
+    def get_labels_quantile(targets: Optional[ut.ArrayLike1D] = None,
                             q: float = 0.5,
                             label_test: int = 1,
                             label_ref: int = 0,
@@ -1598,11 +1598,11 @@ class SequenceFeature:
         return labels
 
     @staticmethod
-    def get_labels_tiered(targets: ut.ArrayLike1D = None,
+    def get_labels_tiered(targets: Optional[ut.ArrayLike1D] = None,
                           q_pos: float = 0.8,
                           list_q_neg: Sequence[float] = (0.8, 0.5, 0.3),
-                          df_parts: pd.DataFrame = None,
-                          dict_num_parts: Dict[str, np.ndarray] = None,
+                          df_parts: Optional[pd.DataFrame] = None,
+                          dict_num_parts: Optional[Dict[str, np.ndarray]] = None,
                           label_test: int = 1,
                           label_ref: int = 0,
                           ) -> Dict[float, Tuple[Optional[pd.DataFrame], Optional[Dict[str, np.ndarray]], np.ndarray]]:
@@ -1696,7 +1696,7 @@ class SequenceFeature:
         return dict_labels
 
     @staticmethod
-    def get_df_parts_from_windows(dict_parts: Dict[str, Union[pd.DataFrame, Sequence[str]]] = None,
+    def get_df_parts_from_windows(dict_parts: Optional[Dict[str, Union[pd.DataFrame, Sequence[str]]]] = None,
                                   ) -> pd.DataFrame:
         """
         Assemble a ``df_parts`` from per-part window sets (e.g. :class:`AAWindowSampler` outputs).

--- a/aaanalysis/metrics/_metrics.py
+++ b/aaanalysis/metrics/_metrics.py
@@ -25,8 +25,8 @@ def _check_n_classes_n_samples(X=None, labels=None):
 
 
 # Adjusted Area Under the Curve (AUC*)
-def comp_auc_adjusted(X: ut.ArrayLike2D = None,
-                      labels: ut.ArrayLike1D = None,
+def comp_auc_adjusted(X: Optional[ut.ArrayLike2D] = None,
+                      labels: Optional[ut.ArrayLike1D] = None,
                       label_test: int = 1,
                       label_ref: int = 0,
                       n_jobs: Optional[int] = None
@@ -81,8 +81,8 @@ def comp_auc_adjusted(X: ut.ArrayLike2D = None,
 
 
 # BIC score
-def comp_bic_score(X: ut.ArrayLike2D = None,
-                   labels: ut.ArrayLike1D = None
+def comp_bic_score(X: Optional[ut.ArrayLike2D] = None,
+                   labels: Optional[ut.ArrayLike1D] = None
                    ) -> float:
     """
     Compute an adjusted Bayesian Information Criterion (BIC) (-∞, ∞) for assessing clustering quality.
@@ -134,8 +134,8 @@ def comp_bic_score(X: ut.ArrayLike2D = None,
 
 
 # Kullback-Leibler Divergence
-def comp_kld(X: ut.ArrayLike2D = None,
-             labels: ut.ArrayLike1D =None,
+def comp_kld(X: Optional[ut.ArrayLike2D] = None,
+             labels: Optional[ut.ArrayLike1D] =None,
              label_test: int = 1,
              label_ref: int = 0
              ) -> ut.ArrayLike1D:
@@ -218,8 +218,8 @@ def _check_list_scores_positions(list_scores=None, list_positions=None):
 
 
 # Per-protein average precision (site localization)
-def comp_per_protein_ap(list_scores: list = None,
-                        list_positions: list = None,
+def comp_per_protein_ap(list_scores: Optional[list] = None,
+                        list_positions: Optional[list] = None,
                         tolerance: int = 0,
                         ) -> ut.ArrayLike1D:
     """
@@ -265,8 +265,8 @@ def comp_per_protein_ap(list_scores: list = None,
 
 
 # Detection metrics at a fixed threshold
-def comp_detection_metrics(list_scores: list = None,
-                           list_positions: list = None,
+def comp_detection_metrics(list_scores: Optional[list] = None,
+                           list_positions: Optional[list] = None,
                            threshold: float = 0.5,
                            tolerance: int = 0,
                            ) -> dict:
@@ -318,7 +318,7 @@ def comp_detection_metrics(list_scores: list = None,
 
 
 # Bootstrap confidence interval
-def comp_bootstrap_ci(values: ut.ArrayLike1D = None,
+def comp_bootstrap_ci(values: Optional[ut.ArrayLike1D] = None,
                       n_rounds: int = 1000,
                       ci: float = 0.95,
                       seed: Optional[int] = None,
@@ -370,7 +370,7 @@ def comp_bootstrap_ci(values: ut.ArrayLike1D = None,
 
 
 # Peak-preserving score smoothing
-def comp_smooth_scores(scores: ut.ArrayLike1D = None,
+def comp_smooth_scores(scores: Optional[ut.ArrayLike1D] = None,
                        method: Literal["triangular", "gaussian"] = "triangular",
                        window: int = 2,
                        sigma: Optional[float] = None,

--- a/aaanalysis/plotting/_plot_legend.py
+++ b/aaanalysis/plotting/_plot_legend.py
@@ -12,7 +12,7 @@ from aaanalysis import utils as ut
 # II Main function
 def plot_legend(ax: Optional[plt.Axes] = None,
                 # Categories and colors
-                dict_color: Dict[str, str] = None,
+                dict_color: Optional[Dict[str, str]] = None,
                 list_cat: Optional[List[str]] = None,
                 labels: Optional[List[str]] = None,
                 # Position and Layout

--- a/aaanalysis/plotting/_plot_rank.py
+++ b/aaanalysis/plotting/_plot_rank.py
@@ -43,7 +43,7 @@ def _resolve_group_colors(group_order=None, dict_color=None):
 
 
 # II Main Functions
-def plot_rank(df_rank: pd.DataFrame = None,
+def plot_rank(df_rank: Optional[pd.DataFrame] = None,
               col_score: str = "score",
               col_group: str = "group",
               group_order: Optional[List[str]] = None,

--- a/aaanalysis/plotting/_plot_settings.py
+++ b/aaanalysis/plotting/_plot_settings.py
@@ -15,7 +15,7 @@ LIST_FONTS = ['Arial', 'Courier New', 'DejaVu Sans', 'Times New Roman', 'Verdana
 
 # I Helper functions
 # Check plot_settings
-def check_font(font="Arial"):
+def check_font(font="Arial") -> None:
     if font not in LIST_FONTS:
         error_message = f"'font' ({font}) not in recommended fonts: {LIST_FONTS}. Set font manually by:" \
                         f"\n\tplt.rcParams['font.sans-serif'] = '{font}'"
@@ -23,7 +23,7 @@ def check_font(font="Arial"):
 
 
 # Helper function
-def set_tick_size(axis=None, major_size=None, minor_size=None):
+def set_tick_size(axis=None, major_size=None, minor_size=None) -> None:
     """Set tick size of the given axis."""
     plt.rcParams[f"{axis}tick.major.size"] = major_size
     plt.rcParams[f"{axis}tick.minor.size"] = minor_size

--- a/aaanalysis/protein_design/_aamut.py
+++ b/aaanalysis/protein_design/_aamut.py
@@ -11,7 +11,7 @@ from ._backend.aamut.aamut import comp_substitution_impact, eval_substitution_im
 
 
 # I Helper Functions
-def check_df_scales_aa(df_scales=None):
+def check_df_scales_aa(df_scales=None) -> None:
     """Check that df_scales is a DataFrame indexed by the canonical amino acids."""
     if not isinstance(df_scales, pd.DataFrame):
         raise ValueError(f"'df_scales' ({type(df_scales)}) should be a pandas DataFrame.")
@@ -133,7 +133,7 @@ class AAMut(Tool):
         return df_impact
 
     def eval(self,
-             df_impact: pd.DataFrame = None,
+             df_impact: Optional[pd.DataFrame] = None,
              ) -> pd.DataFrame:
         """
         Evaluate substitution impact by ranking scales on their mean substitution sensitivity.

--- a/aaanalysis/protein_design/_aamut_plot.py
+++ b/aaanalysis/protein_design/_aamut_plot.py
@@ -11,7 +11,7 @@ import aaanalysis.utils as ut
 
 
 # I Helper Functions
-def check_df_impact(df_impact=None):
+def check_df_impact(df_impact=None) -> None:
     """Check that df_impact is a valid AAMut.run output."""
     ut.check_df(df=df_impact, name="df_impact", cols_required=ut.COLS_AAMUT)
     if len(df_impact) == 0:
@@ -51,7 +51,7 @@ class AAMutPlot:
 
     # Main methods
     def substitution_matrix(self,
-                            df_impact: pd.DataFrame = None,
+                            df_impact: Optional[pd.DataFrame] = None,
                             ax: Optional[plt.Axes] = None,
                             figsize: Tuple[Union[int, float], Union[int, float]] = (7, 6),
                             cmap: str = "viridis",
@@ -96,7 +96,7 @@ class AAMutPlot:
         return ax
 
     def scale_ranking(self,
-                      df_impact: pd.DataFrame = None,
+                      df_impact: Optional[pd.DataFrame] = None,
                       top_n: int = 20,
                       ax: Optional[plt.Axes] = None,
                       figsize: Tuple[Union[int, float], Union[int, float]] = (6, 5),
@@ -145,9 +145,9 @@ class AAMutPlot:
         return ax
 
     def aa_comparison(self,
-                      df_impact: pd.DataFrame = None,
-                      from_aa: str = None,
-                      to_aa: str = None,
+                      df_impact: Optional[pd.DataFrame] = None,
+                      from_aa: Optional[str] = None,
+                      to_aa: Optional[str] = None,
                       top_n: int = 20,
                       ax: Optional[plt.Axes] = None,
                       figsize: Tuple[Union[int, float], Union[int, float]] = (6, 5),

--- a/aaanalysis/protein_design/_seqmut.py
+++ b/aaanalysis/protein_design/_seqmut.py
@@ -12,7 +12,7 @@ from ._backend.seqmut.seqmut import (build_scan_plan, comp_delta_x, comp_scan_sc
 
 
 # I Helper Functions
-def check_match_df_seq_pos_based(df_seq=None):
+def check_match_df_seq_pos_based(df_seq=None) -> None:
     """Check that df_seq is in the position-based format (sequence + tmd_start + tmd_stop)."""
     ut.check_df_seq(df_seq=df_seq)
     missing = [c for c in ut.COLS_SEQ_POS if c not in df_seq.columns]
@@ -131,8 +131,8 @@ class SeqMut:
 
     # Main methods
     def mutate(self,
-               df_seq: pd.DataFrame = None,
-               mutations: pd.DataFrame = None,
+               df_seq: Optional[pd.DataFrame] = None,
+               mutations: Optional[pd.DataFrame] = None,
                df_feat: Optional[pd.DataFrame] = None,
                jmd_n_len: int = 10,
                jmd_c_len: int = 10,
@@ -209,8 +209,8 @@ class SeqMut:
         return df_mut
 
     def scan(self,
-             df_seq: pd.DataFrame = None,
-             df_feat: pd.DataFrame = None,
+             df_seq: Optional[pd.DataFrame] = None,
+             df_feat: Optional[pd.DataFrame] = None,
              region: Optional[Union[str, List[int]]] = None,
              to_aa: Optional[List[str]] = None,
              jmd_n_len: int = 10,
@@ -272,8 +272,8 @@ class SeqMut:
         return df_scan
 
     def suggest(self,
-                df_seq: pd.DataFrame = None,
-                df_feat: pd.DataFrame = None,
+                df_seq: Optional[pd.DataFrame] = None,
+                df_feat: Optional[pd.DataFrame] = None,
                 n: int = 10,
                 region: Optional[Union[str, List[int]]] = None,
                 to_aa: Optional[List[str]] = None,
@@ -340,7 +340,7 @@ class SeqMut:
         return df_suggest
 
     def eval(self,
-             df_scan: pd.DataFrame = None,
+             df_scan: Optional[pd.DataFrame] = None,
              th: Optional[float] = None,
              ) -> pd.DataFrame:
         """

--- a/aaanalysis/protein_design/_seqmut_plot.py
+++ b/aaanalysis/protein_design/_seqmut_plot.py
@@ -11,7 +11,7 @@ import aaanalysis.utils as ut
 
 
 # I Helper Functions
-def check_df_scan(df_scan=None):
+def check_df_scan(df_scan=None) -> None:
     """Check that df_scan is a valid SeqMut.scan output."""
     ut.check_df(df=df_scan, name="df_scan", cols_required=ut.COLS_SEQMUT_SCAN)
     if len(df_scan) == 0:
@@ -56,7 +56,7 @@ class SeqMutPlot:
 
     # Main methods
     def mutation_landscape(self,
-                           df_scan: pd.DataFrame = None,
+                           df_scan: Optional[pd.DataFrame] = None,
                            entry: Optional[str] = None,
                            ax: Optional[plt.Axes] = None,
                            figsize: Tuple[Union[int, float], Union[int, float]] = (10, 5),
@@ -105,9 +105,9 @@ class SeqMutPlot:
         return ax
 
     def residue_mutation_impact(self,
-                                df_scan: pd.DataFrame = None,
+                                df_scan: Optional[pd.DataFrame] = None,
                                 entry: Optional[str] = None,
-                                pos: int = None,
+                                pos: Optional[int] = None,
                                 ax: Optional[plt.Axes] = None,
                                 figsize: Tuple[Union[int, float], Union[int, float]] = (6, 5),
                                 color: Optional[str] = None,

--- a/aaanalysis/pu_learning/_dpulearn.py
+++ b/aaanalysis/pu_learning/_dpulearn.py
@@ -18,13 +18,13 @@ LIST_METRICS = ['euclidean', 'manhattan', 'cosine']
 
 # I Helper Functions
 # Check functions
-def check_metric(metric=None):
+def check_metric(metric=None) -> None:
     """Validate provided metric"""
     if metric is not None and metric not in LIST_METRICS:
         raise ValueError(f"'metric' ({metric}) should be None or one of following: {LIST_METRICS}")
 
 
-def check_n_to_identify(labels=None, n_to_identify=None, label_unl=None):
+def check_n_to_identify(labels=None, n_to_identify=None, label_unl=None) -> None:
     """Validate that there are enough unlabeled samples to identify the requested negatives."""
     n_unl = np.sum(labels == label_unl)
     if n_unl < n_to_identify:
@@ -32,7 +32,7 @@ def check_n_to_identify(labels=None, n_to_identify=None, label_unl=None):
                          f"negatives to identify from them ({n_to_identify}).")
 
 
-def check_match_labels_markers(label_pos=None, label_unl=None, label_neg=None):
+def check_match_labels_markers(label_pos=None, label_unl=None, label_neg=None) -> None:
     """Validate the positive/unlabeled/negative marker values used to encode the input labels."""
     # Markers may be any integer (e.g. -1), they only need to be distinct and match the labels.
     ut.check_number_val(name="label_pos", val=label_pos, just_int=True)
@@ -45,7 +45,7 @@ def check_match_labels_markers(label_pos=None, label_unl=None, label_neg=None):
         raise ValueError(f"Label markers must be distinct, but got {markers}.")
 
 
-def check_match_labels_markers_present(labels=None, label_pos=None, label_unl=None, label_neg=None):
+def check_match_labels_markers_present(labels=None, label_pos=None, label_unl=None, label_neg=None) -> None:
     """Ensure 'labels' contains the required markers and no values outside the marker set."""
     allowed = {label_pos, label_unl} | ({label_neg} if label_neg is not None else set())
     present = set(np.asarray(labels).tolist())
@@ -90,7 +90,7 @@ def resolve_n_to_identify(n_neg=None, n_unl_to_neg=None, n_pre_neg=0):
     return n_to_identify
 
 
-def check_n_components(n_components=1):
+def check_n_components(n_components=1) -> None:
     """Check if n_components valid for sklearn PCA object"""
     try:
         # Check number of PCs
@@ -106,14 +106,14 @@ def check_n_components(n_components=1):
                          f"\n  a float with 0.0 < 'n_components' < 1.0 (percentage of covered variance)")
 
 
-def check_match_X_n_components(X=None, n_components=1):
+def check_match_X_n_components(X=None, n_components=1) -> None:
     """Check if n_components matches to dimensions of X"""
     n_samples, n_features = X.shape
     if min(n_features, n_samples) <= n_components:
         raise ValueError(f"'n_components' ({n_components}) should be < min(n_features, n_samples) from 'X' ({n_features})")
 
 
-def check_match_list_labels_df_seq(list_labels=None, df_seq=None):
+def check_match_list_labels_df_seq(list_labels=None, df_seq=None) -> None:
     """Check if length of labels in list_labels and df_seq matches"""
     if df_seq is None:
         return None # Skip check
@@ -123,7 +123,7 @@ def check_match_list_labels_df_seq(list_labels=None, df_seq=None):
                          f"samples in 'df_seq' (n={len(df_seq)})")
 
 
-def check_match_X_X_neg(X=None, X_neg=None):
+def check_match_X_X_neg(X=None, X_neg=None) -> None:
     """Check if number of features matches in both feature matrices"""
     if X_neg is None:
         return # Skip test
@@ -214,12 +214,12 @@ class dPULearn(Wrapper):
     # Main method
     def fit(self,
             X: ut.ArrayLike2D,
-            labels: ut.ArrayLike1D = None,
+            labels: Optional[ut.ArrayLike1D] = None,
             label_pos: int = 1,
             label_unl: int = 2,
             label_neg: Optional[int] = None,
-            n_neg: int = None,
-            n_unl_to_neg: int = None,
+            n_neg: Optional[int] = None,
+            n_unl_to_neg: Optional[int] = None,
             metric: Optional[Literal["euclidean", "manhattan", "cosine"]] = None,
             n_components: Union[float, int] = 0.80,
             ) -> "dPULearn":
@@ -360,7 +360,7 @@ class dPULearn(Wrapper):
 
     @staticmethod
     def eval(X: ut.ArrayLike2D,
-             list_labels: ut.ArrayLike2D = None,
+             list_labels: Optional[ut.ArrayLike2D] = None,
              names_datasets: Optional[List[str]] = None,
              X_neg: Optional[ut.ArrayLike2D] = None,
              comp_kld: bool = False,
@@ -446,7 +446,7 @@ class dPULearn(Wrapper):
         return df_eval
 
     @staticmethod
-    def compare_sets_negatives(list_labels: ut.ArrayLike1D = None,
+    def compare_sets_negatives(list_labels: Optional[ut.ArrayLike1D] = None,
                                names_datasets: Optional[List[str]] = None,
                                df_seq: Optional[pd.DataFrame] = None,
                                remove_non_neg : bool = True,

--- a/aaanalysis/pu_learning/_dpulearn_plot.py
+++ b/aaanalysis/pu_learning/_dpulearn_plot.py
@@ -47,14 +47,14 @@ def _adjust_plot_args(names=None, colors=None, args_scatter=None, default_names=
 
 
 # Check functions
-def check_match_df_pu_labels(df_pu=None, labels=None):
+def check_match_df_pu_labels(df_pu=None, labels=None) -> None:
     """Check length match df_pu and labels"""
     n_samples = len(df_pu)
     if n_samples != len(labels):
         raise ValueError(f"Number of samples from 'df_pu' (n={n_samples}) does not match with 'labels' (n={len(labels)})")
 
 
-def check_match_names_colors(names=None, colors=None):
+def check_match_names_colors(names=None, colors=None) -> None:
     """Check if length matches of names and colors"""
     if len(names) != len(colors):
         raise ValueError(f"Length of 'names' (n={len(names)}) and 'colors' (n={len(colors)}) does not match.")
@@ -80,7 +80,7 @@ class dPULearnPlot:
         """
 
     @staticmethod
-    def eval(df_eval: pd.DataFrame = None,
+    def eval(df_eval: Optional[pd.DataFrame] = None,
              figsize: Tuple[Union[int, float], Union[int, float]] = (6, 4),
              dict_xlims: Optional[dict] = None,
              legend: bool = True,
@@ -165,7 +165,7 @@ class dPULearnPlot:
         return fig, axes
 
     @staticmethod
-    def pca(df_pu: pd.DataFrame = None,
+    def pca(df_pu: Optional[pd.DataFrame] = None,
             labels=None,
             figsize: Tuple[Union[int, float], Union[int, float]] = (5, 5),
             pc_x: int = 1,

--- a/aaanalysis/seq_analysis/_aa_window_sampler.py
+++ b/aaanalysis/seq_analysis/_aa_window_sampler.py
@@ -31,13 +31,13 @@ def check_similarity_threshold(name, val):
     return float(val)
 
 
-def check_output_mode(output_mode):
+def check_output_mode(output_mode) -> None:
     """Validate ``output_mode`` is one of the allowed modes."""
     ut.check_str_options(name="output_mode", val=output_mode,
                          list_str_options=ut.LIST_OUTPUT_MODES)
 
 
-def check_distance_to_pos(min_distance_to_pos, max_distance_to_pos):
+def check_distance_to_pos(min_distance_to_pos, max_distance_to_pos) -> None:
     """Validate the ``(min, max)`` distance-to-positive band.
 
     Each bound is either a non-negative ``int`` or ``None`` (meaning "no bound").
@@ -178,7 +178,7 @@ def check_motif_args(motif_pwm, motif_score_threshold, motif_match, window_size)
     return pwm
 
 
-def check_context_args(aa_context_col, context_in, context_out):
+def check_context_args(aa_context_col, context_in, context_out) -> None:
     """Guard against silent-drop foot-gun: ``context_in``/``context_out`` require ``aa_context_col``."""
     if (context_in is not None or context_out is not None) and aa_context_col is None:
         raise ValueError("'context_in'/'context_out' require 'aa_context_col' to be set.")
@@ -193,7 +193,7 @@ def check_custom_filter(custom_filter):
     return custom_filter
 
 
-def check_arms(arms):
+def check_arms(arms) -> None:
     """Validate the ``arms`` mapping passed to :meth:`AAWindowSampler.sample_benchmark_set`.
 
     Each value must be a dict carrying a ``"method"`` key whose value is one of
@@ -427,7 +427,7 @@ class AAWindowSampler:
 
     # Sampling methods
     def sample_same_protein(self,
-                            df_seq: pd.DataFrame = None,
+                            df_seq: Optional[pd.DataFrame] = None,
                             n: int = 100,
                             window_size: int = 9,
                             pos_col: str = ut.COL_POS,
@@ -601,7 +601,7 @@ class AAWindowSampler:
                                        mark_test=True)
 
     def sample_different_protein(self,
-                                 df_seq: pd.DataFrame = None,
+                                 df_seq: Optional[pd.DataFrame] = None,
                                  n: int = 100,
                                  window_size: int = 9,
                                  pos_col: str = ut.COL_POS,
@@ -740,7 +740,7 @@ class AAWindowSampler:
                                        mark_test=True)
 
     def sample_synthetic(self,
-                         df_seq: pd.DataFrame = None,
+                         df_seq: Optional[pd.DataFrame] = None,
                          n: int = 100,
                          window_size: int = 9,
                          generator: Union[Literal["uniform", "global_freq",
@@ -920,7 +920,7 @@ class AAWindowSampler:
         return df[ut.COLS_SEGMENTS].copy()
 
     def sample_motif_matched(self,
-                              df_seq: pd.DataFrame = None,
+                              df_seq: Optional[pd.DataFrame] = None,
                               n: int = 100,
                               window_size: int = 9,
                               motif_pwm: Optional[pd.DataFrame] = None,
@@ -1056,8 +1056,8 @@ class AAWindowSampler:
                                        mark_test=True)
 
     def sample_benchmark_set(self,
-                             df_seq: pd.DataFrame = None,
-                             arms: Dict[str, Dict] = None,
+                             df_seq: Optional[pd.DataFrame] = None,
+                             arms: Optional[Dict[str, Dict]] = None,
                              seed: Optional[int] = None,
                              ) -> pd.DataFrame:
         """Run several named sampling arms and concatenate them into one benchmark set.

--- a/aaanalysis/seq_analysis/_aalogo.py
+++ b/aaanalysis/seq_analysis/_aalogo.py
@@ -10,7 +10,7 @@ from ._backend._aalogo.aalogo import get_df_logo_, get_df_logo_info_, get_conser
 
 
 # I Helper Functions
-def check_df_logo_info(df_logo_info=None):
+def check_df_logo_info(df_logo_info=None) -> None:
     """Check if df_logo_info is a valid pd.Series with index name 'pos'."""
     ut.check_df(name="df_logo_info", df=df_logo_info,
                 check_series=True, accept_none=False, accept_nan=False)
@@ -26,7 +26,7 @@ def check_match_df_parts_logo_parts(df_parts=None):
     return list_parts
 
 
-def check_tmd_len(tmd_len=None, df_parts=None):
+def check_tmd_len(tmd_len=None, df_parts=None) -> None:
     """Check if tmd_len is valid and does not exceed the maximum TMD length in df_parts."""
     ut.check_number_range(name="tmd_len", val=tmd_len, min_val=1, just_int=True, accept_none=True)
     if tmd_len is not None and ut.COL_TMD in list(df_parts):
@@ -36,13 +36,13 @@ def check_tmd_len(tmd_len=None, df_parts=None):
                              f"in 'df_parts' ({max_tmd_len}).")
 
 
-def check_pseudocount(pseudocount=None):
+def check_pseudocount(pseudocount=None) -> None:
     """Check if pseudocount is a non-negative float."""
     ut.check_number_range(name="pseudocount", val=pseudocount, min_val=0,
                           just_int=False, accept_none=False)
 
 
-def check_characters_to_ignore(characters_to_ignore=None):
+def check_characters_to_ignore(characters_to_ignore=None) -> None:
     """Check if characters_to_ignore is a string."""
     ut.check_str(name="characters_to_ignore", val=characters_to_ignore, accept_none=False)
 
@@ -85,7 +85,7 @@ class AAlogo:
         self._logo_type = logo_type
 
     def get_df_logo(self,
-                    df_parts: pd.DataFrame = None,
+                    df_parts: Optional[pd.DataFrame] = None,
                     labels: Optional[ut.ArrayLike1D] = None,
                     label_test: int = 1,
                     tmd_len: Optional[int] = None,
@@ -168,7 +168,7 @@ class AAlogo:
         return df_logo
 
     def get_df_logo_info(self,
-                         df_parts: pd.DataFrame = None,
+                         df_parts: Optional[pd.DataFrame] = None,
                          labels: Optional[ut.ArrayLike1D] = None,
                          label_test: int = 1,
                          tmd_len: Optional[int] = None,
@@ -249,7 +249,7 @@ class AAlogo:
         return df_logo_info
 
     @staticmethod
-    def get_conservation(df_logo_info: pd.Series = None,
+    def get_conservation(df_logo_info: Optional[pd.Series] = None,
                          value_type: Literal["min", "mean", "median", "max"] = "mean",
                          ) -> float:
         """

--- a/aaanalysis/seq_analysis/_aalogo_plot.py
+++ b/aaanalysis/seq_analysis/_aalogo_plot.py
@@ -18,7 +18,7 @@ DICT_LOGO_LABELS = {"probability": "Probability [%]",
 
 
 # I Helper Functions
-def check_df_logo(df_logo=None):
+def check_df_logo(df_logo=None) -> None:
     """Check that df_logo is a valid non-empty DataFrame with numeric values."""
     ut.check_df(name="df_logo", df=df_logo, accept_none=False, accept_nan=False)
     if len(df_logo) == 0:
@@ -33,7 +33,7 @@ def _valid_aal_kws_keys(include_info=True):
     return keys
 
 
-def check_aal_kws_keys(name=None, aal_kws=None, include_info=True):
+def check_aal_kws_keys(name=None, aal_kws=None, include_info=True) -> None:
     """Check that every key in an aal_kws dict is a valid AAlogo argument name."""
     valid_keys = _valid_aal_kws_keys(include_info=include_info)
     invalid_keys = set(aal_kws) - valid_keys
@@ -43,7 +43,7 @@ def check_aal_kws_keys(name=None, aal_kws=None, include_info=True):
             f"{sorted(valid_keys)}.")
 
 
-def check_aal_kws(aal_kws=None, df_logo=None, df_logo_info=None):
+def check_aal_kws(aal_kws=None, df_logo=None, df_logo_info=None) -> None:
     """Check aal_kws is a valid-key dict not combined with df_logo/df_logo_info."""
     if aal_kws is None:
         return
@@ -60,7 +60,7 @@ def check_aal_kws(aal_kws=None, df_logo=None, df_logo_info=None):
 
 
 def check_logo_input_source(df_logo=None, df_logo_info=None, aal_kws=None,
-                            df_parts=None, labels=None, tmd_len=None):
+                            df_parts=None, labels=None, tmd_len=None) -> None:
     """Check exactly one logo-data source is given (precomputed, aal_kws, or df_parts)."""
     if labels is not None and df_parts is None:
         raise ValueError("'labels' requires 'df_parts' to be given as well.")
@@ -85,7 +85,7 @@ def check_logo_input_source(df_logo=None, df_logo_info=None, aal_kws=None,
             "'labels', 'label_test', 'tmd_len') or 'aal_kws'.")
 
 
-def check_list_aal_kws(list_aal_kws=None, list_df_logo=None, list_df_logo_info=None):
+def check_list_aal_kws(list_aal_kws=None, list_df_logo=None, list_df_logo_info=None) -> None:
     """Check list_aal_kws is a list of valid dicts not combined with precomputed data."""
     if list_aal_kws is None:
         return
@@ -107,7 +107,7 @@ def check_list_aal_kws(list_aal_kws=None, list_df_logo=None, list_df_logo_info=N
             "internally) or precomputed 'list_df_logo'/'list_df_logo_info', not both.")
 
 
-def check_list_df_logo(list_df_logo=None):
+def check_list_df_logo(list_df_logo=None) -> None:
     """Check that list_df_logo is a non-empty list of valid logo DataFrames."""
     if not isinstance(list_df_logo, list) or len(list_df_logo) == 0:
         raise ValueError("'list_df_logo' must be a non-empty list of DataFrames.")
@@ -121,7 +121,7 @@ def check_list_df_logo(list_df_logo=None):
                 f"list_df_logo[0] has {n_pos}, list_df_logo[{i}] has {len(df)}.")
 
 
-def check_list_df_logo_info(list_df_logo_info=None, list_df_logo=None):
+def check_list_df_logo_info(list_df_logo_info=None, list_df_logo=None) -> None:
     """Check list_df_logo_info is a list of Series matching list_df_logo in count and length."""
     if not isinstance(list_df_logo_info, list) or len(list_df_logo_info) == 0:
         raise ValueError("'list_df_logo_info' must be a non-empty list of Series.")
@@ -149,7 +149,7 @@ def check_parts_len(jmd_n_len=None, jmd_c_len=None, df_logo=None):
     return tmd_len, jmd_n_len, jmd_c_len
 
 
-def check_df_logo_info(df_logo_info=None, df_logo=None):
+def check_df_logo_info(df_logo_info=None, df_logo=None) -> None:
     """Check that df_logo_info is a valid Series with the same length as df_logo."""
     ut.check_df(name="df_logo_info", df=df_logo_info, check_series=True,
                 accept_none=False, accept_nan=False)
@@ -159,7 +159,7 @@ def check_df_logo_info(df_logo_info=None, df_logo=None):
             f"'df_logo' length ({len(df_logo)}).")
 
 
-def check_info_bar_ylim(info_bar_ylim=None):
+def check_info_bar_ylim(info_bar_ylim=None) -> None:
     """Check that info_bar_ylim is None or a valid (min, max) tuple of numbers."""
     if info_bar_ylim is None:
         return
@@ -171,14 +171,14 @@ def check_info_bar_ylim(info_bar_ylim=None):
             f"'info_bar_ylim[0]' ({info_bar_ylim[0]}) must be < 'info_bar_ylim[1]' ({info_bar_ylim[1]}).")
 
 
-def check_height_ratio(height_ratio=None):
+def check_height_ratio(height_ratio=None) -> None:
     """Check that height_ratio is a tuple of two positive numbers."""
     if (not isinstance(height_ratio, tuple) or len(height_ratio) != 2
             or not all(isinstance(v, (int, float)) and v > 0 for v in height_ratio)):
         raise ValueError("'height_ratio' must be a tuple of two positive numbers.")
 
 
-def check_list_name_data(list_name_data=None, list_df_logo=None):
+def check_list_name_data(list_name_data=None, list_df_logo=None) -> None:
     """Check that list_name_data matches the number of logos if provided."""
     if list_name_data is None:
         return
@@ -190,7 +190,7 @@ def check_list_name_data(list_name_data=None, list_df_logo=None):
             f"'list_df_logo' length ({len(list_df_logo)}).")
 
 
-def check_list_name_data_color(list_name_data_color=None, list_df_logo=None):
+def check_list_name_data_color(list_name_data_color=None, list_df_logo=None) -> None:
     """Check that list_name_data_color is a valid string or matching list of strings."""
     if isinstance(list_name_data_color, str):
         return

--- a/aaanalysis/seq_analysis_pro/_comp_seq_cons.py
+++ b/aaanalysis/seq_analysis_pro/_comp_seq_cons.py
@@ -20,7 +20,7 @@ pd.set_option('expand_frame_repr', False)  # Single line print for pd.Dataframe
 
 
 # I Helper Functions
-def check_is_tool(name: Optional[str] = None):
+def check_is_tool(name: Optional[str] = None) -> None:
     """Check whether `name` is on PATH and marked as executable."""
     if not shutil.which(name):
         raise ValueError(f"{name} is not installed or not in the PATH.")

--- a/aaanalysis/seq_analysis_pro/_filter_seq.py
+++ b/aaanalysis/seq_analysis_pro/_filter_seq.py
@@ -13,20 +13,20 @@ from ._backend.mmseq2 import run_mmseqs2
 
 
 # I Helper functions
-def check_is_tool(name=None):
+def check_is_tool(name=None) -> None:
     """Check whether `name` is on PATH and marked as executable."""
     if not shutil.which(name):
         raise ValueError(f"{name} is not installed or not in the PATH.")
 
 
-def check_match_identity_coverage(global_identity=True, coverage_short=0.0, coverage_long=0.0):
+def check_match_identity_coverage(global_identity=True, coverage_short=0.0, coverage_long=0.0) -> None:
     """Check if identity and coverage match"""
     if not global_identity and coverage_short == coverage_long == 0:
         raise ValueError(f"If 'global_identity' is False, 'coverage_short' ({coverage_short}) "
                          f"or 'coverage_long' ({coverage_long}) should be >0.0")
 
 
-def check_seq_len(df_seq=None, len_min=11):
+def check_seq_len(df_seq=None, len_min=11) -> None:
     """ Check if the length of each sequence in the specified column is at least `len_min`"""
     mask_seq_len_is_fine = df_seq[ut.COL_SEQ].str.len() >= len_min
     list_seq_too_short = df_seq[~mask_seq_len_is_fine][ut.COL_ENTRY].to_list()
@@ -35,7 +35,7 @@ def check_seq_len(df_seq=None, len_min=11):
                          f"is not meet by the following entries: {list_seq_too_short}")
 
 
-def check_seq_gaps(df_seq):
+def check_seq_gaps(df_seq) -> None:
     """Check if sequences in the specified column contain gaps ('-')."""
     mask_has_gaps = df_seq[ut.COL_SEQ].str.contains("-")
     list_seq_with_gaps = df_seq[mask_has_gaps][ut.COL_ENTRY].to_list()
@@ -45,7 +45,7 @@ def check_seq_gaps(df_seq):
 
 
 # II Main function
-def filter_seq(df_seq: pd.DataFrame = None,
+def filter_seq(df_seq: Optional[pd.DataFrame] = None,
                method: Literal['cd-hit', 'mmseqs'] = "cd-hit",
                similarity_threshold: float = 0.9,
                word_size: Optional[int] = None,

--- a/aaanalysis/seq_analysis_pro/_scan_motif.py
+++ b/aaanalysis/seq_analysis_pro/_scan_motif.py
@@ -20,7 +20,7 @@ from aaanalysis.seq_analysis._backend.aa_window_sampler.build_output import (
 
 
 # I Helper Functions
-def check_fimo_installed():
+def check_fimo_installed() -> None:
     """Raise ``RuntimeError`` if the ``fimo`` binary is not on PATH."""
     if not shutil.which("fimo"):
         raise RuntimeError(
@@ -126,11 +126,11 @@ def _run_fimo(motif_path, fasta_path, *, pvalue_threshold,
 
 
 # II Main Function
-def scan_motif(df_seq: pd.DataFrame = None,
+def scan_motif(df_seq: Optional[pd.DataFrame] = None,
                                   pos_col: str = "pos",
                                   n: int = 100,
                                   window_size: int = 9,
-                                  motif_pwm: pd.DataFrame = None,
+                                  motif_pwm: Optional[pd.DataFrame] = None,
                                   pvalue_threshold: float = 1e-4,
                                   label_test: Union[int, float] = 1,
                                   label_ref: Union[int, float] = 0,

--- a/aaanalysis/show_html/_display_df.py
+++ b/aaanalysis/show_html/_display_df.py
@@ -65,7 +65,7 @@ def _select_col(df=None, col_to_show=None):
 
 
 # Main functions
-def display_df(df: pd.DataFrame = None,
+def display_df(df: Optional[pd.DataFrame] = None,
                max_width_pct: int = 100,
                max_height: int = 300,
                char_limit: int = 30,
@@ -74,7 +74,7 @@ def display_df(df: pd.DataFrame = None,
                n_cols: Optional[int] = None,
                row_to_show: Optional[Union[int, str]] = None,
                col_to_show: Optional[Union[int, str]] = None,
-               ):
+               ) -> None:
     """
     Display DataFrame with specific style as HTML output for jupyter notebooks.
 

--- a/docs/adr/0035-validation-ut-check-not-pydantic.md
+++ b/docs/adr/0035-validation-ut-check-not-pydantic.md
@@ -1,0 +1,75 @@
+# ADR-0035 — Input validation stays `ut.check_*`; no Pydantic; agent-typed contracts live in ProtXplain
+
+Status: Accepted — 2026-06-22
+
+## Context
+
+An agent-readiness review proposed typed I/O contracts (Pydantic
+`CPPRequest`/`CPPResult`), a high-level "verb" facade (`run_cpp`,
+`run_prediction`, …), and a generated MCP / JSON-schema tool layer, to make the
+package legible to LLM agents.
+
+The package already covers the substance of that goal with its own primitives:
+every public method opens with a sklearn-style **Validate block** of hand-written
+helpers (`ut.check_number_range`, `ut.check_df_seq`, `ut.check_str_options`, …)
+that raise bare `ValueError` / `RuntimeError` in the canonical
+`"'<name>' (<got>) should be <expected>"` format; feature output is a `df_feat`
+DataFrame with a documented column convention (`ut.LIST_COLS_FEAT` +
+`sort_cols_feat`). A documented organizing principle already splits the work:
+**AAanalysis ships interpretable scientific primitives; ProtXplain orchestrates
+them** for agents (see `docs/guides/handoff_github_issues.md`, issue #26).
+
+## Decision
+
+D1. **Input validation remains `ut.check_*`.** Public methods keep the
+    sklearn-style Validate block. We do **not** adopt Pydantic — or any
+    model-validation framework — for input contracts, in v1 **or** v2.
+    `ut.check_*` already provides runtime validation plus the house error-message
+    format, with zero added dependency, and is the family-wide convention.
+
+D2. **No Pydantic / pandera dependency in AAanalysis.** Pydantic validates
+    scalar/nested models, not DataFrame columns; pandera (the DataFrame
+    equivalent) is likewise not adopted. The `df_feat` output contract is
+    expressed as a **data dictionary** — column name · dtype · nullability ·
+    value-semantics — published in the docs, anchored on the existing
+    `ut.LIST_COLS_FEAT` / `sort_cols_feat` order, and guarded by one
+    schema-stability test (issue #26). A new public schema *accessor* is deferred
+    until a concrete consumer needs to import it (strict-semver caution).
+
+D3. **Agent-facing typed contracts live downstream in ProtXplain.** Any
+    `CPPRequest`/`CPPResult` Pydantic models, JSON-schema emission,
+    MCP / function-calling tool definitions, and the verb-selection / ranking /
+    decision logic belong to ProtXplain, where agents call in. AAanalysis's only
+    obligation to that layer is a **stable, documented `df_feat` contract**;
+    ProtXplain pins to the documented column-name strings.
+
+## Rejected alternatives
+
+- **Pydantic for input contracts in AAanalysis.** Duplicates the existing
+  `ut.check_*` validation, adds a dependency, introduces `pydantic.ValidationError`
+  (conflicting with the bare-`ValueError`/`RuntimeError` rule), and reverses the
+  standing "no typed records until v2" position — all for a benefit (JSON-schema
+  emission for agent tools) needed only where agents call in (ProtXplain).
+- **pandera for runtime `df_feat` schema enforcement.** A new dependency to
+  enforce what a documented data dictionary + one stability test already cover.
+  Deferred unless a concrete OSS-side consumer needs runtime enforcement.
+- **A "verb" facade + MCP layer inside AAanalysis (OSS ships agent-ready tools).**
+  Pushes orchestration-adjacent surface and semver weight into the primitives
+  package, partly duplicates `CPPGrid`, and contradicts the primitives-vs-
+  orchestration boundary. Verbs / MCP / agent logic live in ProtXplain.
+
+## Consequences
+
+- The published `df_feat` data dictionary becomes a stability contract
+  (test-guarded); changing it is a semver event.
+- "Agent-readiness" for AAanalysis means **type hints + docstrings + a
+  documented, tested `df_feat` contract** — not a typed-model framework.
+- ProtXplain owns the Pydantic models and tool schemas; no new public symbol is
+  required in AAanalysis yet.
+
+## Out of scope
+
+- The OOD / uncertainty "refuse-to-predict" gate, counterfactuals, and
+  candidate-ranking — all ProtXplain-scoped.
+- Whether to ever expose a programmatic `df_feat` schema accessor in AAanalysis
+  (revisit only when ProtXplain needs programmatic import).

--- a/docs/adr/0036-type-hints-contract-checker-deferred-pyright.md
+++ b/docs/adr/0036-type-hints-contract-checker-deferred-pyright.md
@@ -1,0 +1,63 @@
+# ADR-0036 — Ship `py.typed` and adopt pyright (non-blocking) now; type hints are the contract
+
+Status: Accepted — 2026-06-22
+
+(Filename slug retains "deferred" from the superseded draft; the decision below is to
+**adopt now**, not defer. Rename the slug at commit if desired.)
+
+## Context
+
+An agent-readiness review recommended a static type checker so an agent gets a read-time
+contract plus a checker that catches mistakes before runtime. The package already **mandates
+type hints on every public parameter and return** (`code-conventions.md`) and validates
+inputs at runtime via `ut.check_*` (ADR-0035) — but it ships **no `py.typed` marker**, so
+those annotations are **invisible to every downstream consumer**, including ProtXplain
+(which wraps AAanalysis and would type-check against it). The standing `sharp-edges.md`
+position was "no type checker until v2."
+
+The **moat argument** resolves the tension in favour of acting now: agent-friendliness of the
+OSS substrate is **pure upside** (the moat lives in ProtXplain + the science + the data, not
+in package friction), and ProtXplain is the primary consumer — so making the substrate
+type-legible benefits *us* first. The withholding that matters (the typed verb/MCP layer)
+already lives in ProtXplain per ADR-0035; nothing is gained by keeping the package
+type-opaque.
+
+## Decision
+
+D1. **Type hints on public signatures are the read-time contract** and stay mandatory
+    (`code-conventions.md`; `Optional[...]` for `None`-defaults; `ut.ArrayLike1D/2D`).
+
+D2. **Ship `py.typed` (PEP 561).** This is the keystone: it turns the annotations the package
+    already has into a *consumable* contract for ProtXplain and any downstream type-checker.
+
+D3. **Adopt pyright now — `basic` mode, non-blocking (advisory CI), public-API-first.**
+    `pyrightconfig.json` includes the public surface and excludes `_backend` initially,
+    expanding inward over time. pyright (not mypy) for speed + editor/Pylance parity. The CI
+    job is **advisory and never gates merge** through v1.x.
+
+## Rejected alternatives
+
+- **Defer the checker to v2 (the prior `sharp-edges.md` stance).** Forgoes the cheap,
+  high-value `py.typed` win and leaves ProtXplain without consumable types. The moat argument
+  shows substrate type-legibility is pure upside, so deferral has no defensive payoff.
+- **A blocking type gate.** Too disruptive for a scientific numpy/pandas codebase at TRL 4–5;
+  advisory keeps annotations honest without freezing velocity.
+- **mypy as the checker.** Slower, weaker inference, not the editor engine (Pylance = pyright).
+- **Strict mode / whole-package at once.** Highest cost, lowest marginal value; public-API
+  signatures are the smallest, highest-leverage surface, and being wrong there is most
+  expensive (it is the published contract).
+
+## Consequences
+
+- **Shipping `py.typed` is a semver promise:** downstream now type-checks against us, so the
+  public **signatures** must be *honest* (``Optional[...]`` for None-defaults + real return
+  types) before the marker ships — **not** whole-body pyright-clean. The internal method-body
+  pyright errors (the bulk of the first-run baseline) remain **advisory** and are burned down
+  over time **without gating** anything. Breaking a public annotation becomes a breaking change.
+- pyright runs advisory in CI; backend/internal annotations are tightened later, working inward.
+- Validation remains `ut.check_*` (ADR-0035); this ADR adds *static* checking, not runtime
+  enforcement.
+
+## Out of scope
+
+- Backend/internal strict-mode annotation completeness; any runtime type enforcement.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -42,5 +42,7 @@ Regenerate this table with:
 | [0031](0031-integration-e2e-test-policy.md) | Integration & e2e test tiers: scope, taxonomy, and merge-gating | Accepted | 2026-06-13 |  |
 | [0032](0032-numerical-equivalence-tolerance-policy.md) | Numerical-equivalence tolerance policy for output-affecting optimizations | Accepted | 2026-06-13 |  |
 | [0033](0033-performance-audit-outcomes.md) | Whole-library performance audit: accepted wins and rejected optimizations | Accepted | 2026-06-13 |  |
+| [0035](0035-validation-ut-check-not-pydantic.md) | Input validation stays `ut.check_*`; no Pydantic; agent-typed contracts live in ProtXplain | Accepted | 2026-06-22 |  |
+| [0036](0036-type-hints-contract-checker-deferred-pyright.md) | Ship `py.typed` and adopt pyright (non-blocking) now; type hints are the contract | Accepted | 2026-06-22 |  |
 | [0037](0037-perf-ab-gate.md) | Same-runner A/B vs the latest PyPI release makes wall-clock a merge gate | Accepted | 2026-06-22 |  |
 <!-- ADR-INDEX:END -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ dev = [
   "pytest-xdist>=3.6.0",
   "pytest-mpl==0.19.0",
   "mutmut>=3.0",
+  "pyright>=1.1.400",
 ]
 
 [project.urls]
@@ -162,6 +163,7 @@ include = ["aaanalysis*"]
 
 [tool.setuptools.package-data]
 aaanalysis = [
+  "py.typed",
   "_data/*.xlsx",
   "_data/*.tsv",
   "_data/**/*.xlsx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,15 +183,19 @@ aaanalysis = [
 build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
 skip = "*-musllinux_i686 *-manylinux_i686 *-win32 pp*"
 build-verbosity = 1
-# Sanity-check the wheel after install by running the Cython parity test
-# end-to-end against the legacy path. Catches ABI / dtype / dispatch
-# regressions at build time rather than at user-install time.
+# Sanity-check the wheel after install against the real, non-editable artifact:
+# (1) the PEP 561 py.typed marker is present in the installed package — catches a
+#     package-data misconfiguration before the wheel ever reaches PyPI. Run as a
+#     standalone script (not via pytest) so import resolves to the installed wheel
+#     rather than the {project} source tree, which always carries the marker;
+# (2) the Cython parity test end-to-end vs the legacy path — catches ABI / dtype
+#     / dispatch regressions at build time rather than at user-install time.
 test-requires = [
   "pytest>=9.0.3", "hypothesis>=6.124.7",
   "pandas>=2.2.3", "scikit-learn>=1.6.1", "biopython>=1.87",
   "matplotlib>=3.5.3", "seaborn>=0.13.2", "logomaker>=0.8.6",
 ]
-test-command = "pytest {project}/tests/unit/cpp_tests/test_get_feature_matrix_c_parity.py -x -q"
+test-command = "python {project}/tests/_check_py_typed_packaged.py && pytest {project}/tests/unit/cpp_tests/test_get_feature_matrix_c_parity.py -x -q"
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,11 @@
+{
+  "include": ["aaanalysis"],
+  "exclude": [
+    "**/__pycache__",
+    "aaanalysis/**/_backend"
+  ],
+  "typeCheckingMode": "basic",
+  "pythonVersion": "3.10",
+  "reportMissingImports": true,
+  "reportMissingTypeStubs": false
+}

--- a/tests/_check_py_typed_packaged.py
+++ b/tests/_check_py_typed_packaged.py
@@ -1,0 +1,22 @@
+"""Guard: the PEP 561 ``py.typed`` marker must ship in the INSTALLED package.
+
+This is **not** a pytest test — it is invoked as a standalone script by the
+cibuildwheel ``test-command`` (see ``[tool.cibuildwheel]`` in ``pyproject.toml``)
+so it runs against the freshly built wheel installed in a clean env, on every
+shipped platform / Python. Run as ``python <this-file>``, Python prepends only
+this file's directory (``tests/``, which holds no ``aaanalysis`` package) to
+``sys.path`` — so ``import aaanalysis`` resolves to the installed wheel, never the
+source tree. That is the whole point: a pytest test under the editable dev matrix
+resolves to source (where the marker always exists) and would pass even if a
+``[tool.setuptools.package-data]`` misconfiguration dropped the marker from the
+artifact. This script catches that before the wheel reaches PyPI.
+"""
+import sys
+from importlib.resources import files
+
+import aaanalysis  # noqa: F401  (resolves to the installed wheel; see module docstring)
+
+marker = files("aaanalysis").joinpath("py.typed")
+if not marker.is_file():
+    sys.exit(f"FAIL: PEP 561 py.typed missing from installed aaanalysis ({marker})")
+print(f"OK: py.typed present in installed artifact -> {marker}")


### PR DESCRIPTION
## What & why

The **type-legibility track** of agent-readiness (PR-A). It makes AAanalysis's types **consumable** by ProtXplain and any downstream type-checker, and records the surrounding decisions. Guiding principle (the moat discussion): agent-friendliness of the OSS substrate is *pure upside* — the moat lives in ProtXplain + the science + the data; the agent *integration* (verbs/MCP/typed contracts) is withheld to ProtXplain, the *friendliness* is not.

## Decisions (ADRs)

- **ADR-0035** — validation stays `ut.check_*`; **no Pydantic/pandera** in AAanalysis (v1 or v2); agent-facing typed contracts (`CPPRequest`/`CPPResult`, MCP/JSON schemas) live in **ProtXplain**; the `df_feat` output is a documented **data dictionary**.
- **ADR-0036** — type hints are the read-time contract; **ship `py.typed`** and adopt **pyright** non-blocking (advisory), public-API-first; pyright not mypy. (`sharp-edges.md` updated — type checking is no longer v2-deferred.)

## Changes

- **`py.typed` (PEP 561)** shipped + packaged → downstream now reads AAanalysis's annotations instead of `Any`.
- **Advisory pyright CI** (`continue-on-error`, never gates merge) + `pyrightconfig.json` (basic, `_backend` excluded) + `pyright` in `[dev]`.
- **Public signatures made honest** (annotation-only, behavior-preserving):
  - 184 `param: T = None` → `Optional[T] = None` across 29 frontend files (no signature lies about a None default).
  - 111 void public functions → `-> None`.
  - `load_features -> pd.DataFrame` (the lone data-returning public gap).

## Verification

- All **41 frontend modules import clean**, `__all__` unchanged (47).
- `py_compile` clean; ADR hygiene **0 defects** (INDEX regenerated, 36 ADRs incl. perf 0037).
- Behavioral subset green (param-coverage, AAclust-fit).
- pyright net flat (~1232→1233) **by design**: lying-default signature errors cleared, method-body `Optional`-access errors surfaced in their place — those are the **advisory, non-gating burn-down**.

## Deliberate choices / follow-ups

- **black was NOT run.** The repo's committed code isn't black-26-clean, so running it reformats ~6k unrelated lines. Cost: 26 wrapped signatures exceed 88 chars — consistent with existing long lines; there's no flake8 CI gate. A repo-wide black pass is a separate concern.
- **Advisory burn-down (follow-up, non-blocking):** ~1,200 method-body `reportOptional*` errors (guarded by runtime `ut.check_*` pyright can't see) + ~44 file-private helper return annotations (not in `__all__`, not the public contract).
