### PR TITLE
feat(contract): document and test the df_feat output schema (data dictionary)

### DIFF
--- a/aaanalysis/utils.py
+++ b/aaanalysis/utils.py
@@ -421,6 +421,42 @@ DICT_VALUE_TYPE = {COL_ABS_AUC: "mean",
                    COL_FEAT_IMPORT_STD: "mean",
                    COL_FEAT_IMPACT: "sum"}
 
+# df_feat interface contract — the machine-readable "data dictionary" pinning the CPP
+# output schema for downstream consumers (e.g. ProtXplain). Each entry maps a column
+# name to a (dtype, required, nullable, semantics) tuple:
+#   dtype     — coarse kind: 'str' | 'float' | 'int'
+#   required  — True only for the canonical lower-bound columns (LIST_COLS_FEAT) that
+#               every CPP.run() output carries; False = optional/dynamic (test-dependent
+#               p-value variant, diagnostic, or appended post-fit by TreeModel/ShapModel)
+#   nullable  — whether NaN is a valid value for the column
+#   semantics — one-line value meaning
+# Internal contract only (no public accessor; strict-semver caution): rendered to the
+# df_feat contract doc and guarded by tests/unit/api_tests/test_df_feat_contract.py.
+DICT_DF_FEAT = {
+    COL_FEATURE:         ("str",   True,  False, "Opaque PART-SPLIT-SCALE feature id (e.g. 'TMD_C_JMD_C-Segment(3,4)-KLEP840101'); split with split_feat_id, never parse by hand."),
+    COL_CAT:             ("str",   True,  False, "AAontology scale category of the feature's scale."),
+    COL_SUBCAT:          ("str",   True,  False, "AAontology scale subcategory."),
+    COL_SCALE_NAME:      ("str",   True,  False, "Human-readable scale name."),
+    COL_SCALE_DES:       ("str",   True,  False, "One-sentence scale description."),
+    COL_ABS_AUC:         ("float", True,  False, "Absolute adjusted AUC, range [-0.5, 0.5]; primary feature ranking statistic."),
+    COL_ABS_MEAN_DIF:    ("float", True,  False, "Absolute mean difference between test and reference group, range [0, 1]."),
+    COL_MEAN_DIF:        ("float", True,  False, "Signed mean difference (test - reference), range [-1, 1]; the sign gives the direction."),
+    COL_STD_TEST:        ("float", True,  False, "Standard deviation of the feature in the test group."),
+    COL_STD_REF:         ("float", True,  False, "Standard deviation of the feature in the reference group."),
+    COL_PVAL_MW:         ("float", True,  False, "Mann-Whitney U p-value (default, non-parametric). Named 'p_val_ttest_indep' instead when parametric=True."),
+    COL_PVAL_FDR:        ("float", True,  False, "Benjamini-Hochberg FDR-corrected p-value."),
+    COL_POSITION:        ("str",   True,  False, "Comma-separated 1-based residue positions the feature spans."),
+    # Optional / dynamic — present depending on settings or appended downstream.
+    COL_PVAL_TTEST:      ("float", False, False, "Independent t-test p-value; replaces 'p_val_mann_whitney' when parametric=True."),
+    COL_AA_TEST:         ("str",   False, False, "Amino acids at the feature positions in the test group (diagnostic)."),
+    COL_AA_REF:          ("str",   False, False, "Amino acids at the feature positions in the reference group (diagnostic)."),
+    COL_FEAT_DES:        ("str",   False, True,  "Optional readable one-sentence feature description."),
+    COL_FEAT_IMPORT:     ("float", False, False, "Feature importance from TreeModel.fit (post-fit)."),
+    COL_FEAT_IMPORT_STD: ("float", False, False, "Standard deviation of the feature importance across CV rounds (post-fit)."),
+    COL_FEAT_IMPACT:     ("float", False, False, "SHAP-based signed feature impact from ShapModel (post-fit, pro)."),
+    COL_FEAT_IMPACT_STD: ("float", False, False, "Standard deviation of the feature impact (post-fit, pro)."),
+}
+
 
 # Columns of df_eval
 # AAclust (evaluation)

--- a/docs/source/index/usage_principles.rst
+++ b/docs/source/index/usage_principles.rst
@@ -65,5 +65,6 @@ concepts of AAanalysis are provided by the following sections:
    usage_principles/aaontology
    usage_principles/aaclust
    usage_principles/feature_identification
+   usage_principles/df_feat_contract
    usage_principles/pu_learning
    usage_principles/xai

--- a/docs/source/index/usage_principles/df_feat_contract.rst
+++ b/docs/source/index/usage_principles/df_feat_contract.rst
@@ -1,0 +1,171 @@
+.. _df_feat_contract:
+
+df_feat: the CPP Output Contract
+================================
+
+The feature DataFrame ``df_feat`` returned by ``CPP.run`` is the primary
+output other tools build on. To make that boundary safe to depend on, its schema
+is a **documented, test-guarded contract**: each consumer reads columns by their
+documented name and type, and a schema-stability test fails if a contracted column
+is renamed or removed, a dtype changes, or the feature-id format changes.
+
+``df_feat`` follows a **standardized, deterministic column order**. The columns below
+are the *canonical lower bound* — every ``CPP.run`` output carries them, always in this
+order. Optional and dynamic columns (a test-dependent p-value variant, diagnostic
+residue columns, and the explainable-AI columns appended by ``TreeModel`` /
+``ShapModel``) are appended after ``positions`` in a stable order, so the canonical order
+is a lower bound, never a restriction.
+
+Feature id grammar
+------------------
+
+The ``feature`` column is an opaque ``PART-SPLIT-SCALE`` string, for example
+``TMD_C_JMD_C-Segment(3,4)-KLEP840101``:
+
+- **PART** — the sequence part (e.g. ``TMD``, ``JMD_N``, or a compound part such as
+  ``TMD_C_JMD_C``).
+- **SPLIT** — the split selector, one of ``Segment(...)``, ``Pattern(...)``, or
+  ``PeriodicPattern(...)``.
+- **SCALE** — the AAontology scale id (e.g. ``KLEP840101``).
+
+Split the id with the canonical parser ``aa.utils.split_feat_id(feat_id)`` (returns
+``(part, split, scale_id)``) rather than parsing it by hand, so the grammar stays in one
+place.
+
+Column schema
+-------------
+
+Required columns are present in every ``CPP.run`` output; optional columns appear
+depending on settings or are appended downstream.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 8 9 9 52
+
+   * - Column
+     - Type
+     - Required
+     - Nullable
+     - Description
+   * - ``feature``
+     - str
+     - yes
+     - no
+     - Opaque ``PART-SPLIT-SCALE`` feature id; split with ``split_feat_id``.
+   * - ``category``
+     - str
+     - yes
+     - no
+     - AAontology scale category of the feature's scale.
+   * - ``subcategory``
+     - str
+     - yes
+     - no
+     - AAontology scale subcategory.
+   * - ``scale_name``
+     - str
+     - yes
+     - no
+     - Human-readable scale name.
+   * - ``scale_description``
+     - str
+     - yes
+     - no
+     - One-sentence scale description.
+   * - ``abs_auc``
+     - float
+     - yes
+     - no
+     - Absolute adjusted AUC, range [-0.5, 0.5]; primary feature ranking statistic.
+   * - ``abs_mean_dif``
+     - float
+     - yes
+     - no
+     - Absolute mean difference between test and reference group, range [0, 1].
+   * - ``mean_dif``
+     - float
+     - yes
+     - no
+     - Signed mean difference (test - reference), range [-1, 1]; the sign gives the direction.
+   * - ``std_test``
+     - float
+     - yes
+     - no
+     - Standard deviation of the feature in the test group.
+   * - ``std_ref``
+     - float
+     - yes
+     - no
+     - Standard deviation of the feature in the reference group.
+   * - ``p_val_mann_whitney``
+     - float
+     - yes
+     - no
+     - Mann-Whitney U p-value (default, non-parametric). Named ``p_val_ttest_indep`` instead when ``parametric=True``.
+   * - ``p_val_fdr_bh``
+     - float
+     - yes
+     - no
+     - Benjamini-Hochberg FDR-corrected p-value.
+   * - ``positions``
+     - str
+     - yes
+     - no
+     - Comma-separated 1-based residue positions the feature spans.
+   * - ``p_val_ttest_indep``
+     - float
+     - no
+     - no
+     - Independent t-test p-value; replaces ``p_val_mann_whitney`` when ``parametric=True``.
+   * - ``amino_acids_test``
+     - str
+     - no
+     - no
+     - Amino acids at the feature positions in the test group (diagnostic).
+   * - ``amino_acids_ref``
+     - str
+     - no
+     - no
+     - Amino acids at the feature positions in the reference group (diagnostic).
+   * - ``feature_description``
+     - str
+     - no
+     - yes
+     - Optional readable one-sentence feature description.
+   * - ``feat_importance``
+     - float
+     - no
+     - no
+     - Feature importance from ``TreeModel.fit`` (post-fit).
+   * - ``feat_importance_std``
+     - float
+     - no
+     - no
+     - Standard deviation of the feature importance across CV rounds (post-fit).
+   * - ``feat_impact``
+     - float
+     - no
+     - no
+     - SHAP-based signed feature impact from ``ShapModel`` (post-fit, pro).
+   * - ``feat_impact_std``
+     - float
+     - no
+     - no
+     - Standard deviation of the feature impact (post-fit, pro).
+
+Per-residue positions
+---------------------
+
+The ``positions`` column encodes the residue positions a feature spans as a
+comma-separated list of **1-based** indices into the sequence parts. Downstream tools
+that map features back to single residues (for per-residue scoring) parse this column;
+its 1-based, comma-separated format is part of the contract.
+
+Stability notes
+---------------
+
+- The contract is pinned to **column-name strings**; depend on those names, not on
+  column positions.
+- The canonical column set is a lower bound: new optional columns may be appended in a
+  stable order without breaking the contract, but a required column is never renamed or
+  removed without a major-version change.

--- a/tests/unit/api_tests/test_df_feat_contract.py
+++ b/tests/unit/api_tests/test_df_feat_contract.py
@@ -1,0 +1,105 @@
+"""This is a script to test the df_feat interface contract (the documented "data
+dictionary" downstream consumers such as ProtXplain pin to).
+
+The contract has two halves, both guarded here so drift is detectable in CI:
+- the machine-readable schema ``ut.DICT_DF_FEAT`` stays internally consistent with the
+  canonical column order ``ut.LIST_COLS_FEAT``;
+- a real, committed ``df_feat`` (``aa.load_features()``) conforms to it — every required
+  column is present with the contracted dtype, and the PART-SPLIT-SCALE feature id parses.
+
+A rename/removal of a contracted column, a dtype change, or a feature-id format change
+fails one of these tests.
+"""
+import re
+
+import pandas.api.types as pdt
+import pytest
+
+import aaanalysis as aa
+import aaanalysis.utils as ut
+
+
+def _kind(series):
+    """Map a pandas dtype to the coarse kind used in DICT_DF_FEAT."""
+    if pdt.is_float_dtype(series):
+        return "float"
+    if pdt.is_integer_dtype(series):
+        return "int"
+    if pdt.is_string_dtype(series) or series.dtype == object:
+        return "str"
+    return str(series.dtype)
+
+
+@pytest.fixture(scope="module")
+def df_feat():
+    return aa.load_features()
+
+
+class TestDfFeatSchemaConsistency:
+    """The internal data dictionary must agree with the canonical column order."""
+
+    def test_required_set_equals_canonical_lower_bound(self):
+        required = {col for col, (_, req, _, _) in ut.DICT_DF_FEAT.items() if req}
+        assert required == set(ut.LIST_COLS_FEAT)
+
+    def test_canonical_columns_all_documented(self):
+        assert set(ut.LIST_COLS_FEAT).issubset(set(ut.DICT_DF_FEAT))
+
+    def test_entries_well_formed(self):
+        for col, entry in ut.DICT_DF_FEAT.items():
+            assert isinstance(col, str) and col
+            dtype, required, nullable, semantics = entry
+            assert dtype in {"str", "float", "int"}
+            assert isinstance(required, bool)
+            assert isinstance(nullable, bool)
+            assert isinstance(semantics, str) and semantics.endswith(".")
+
+    def test_no_duplicate_columns(self):
+        assert len(ut.DICT_DF_FEAT) == len(set(ut.DICT_DF_FEAT))
+
+
+class TestDfFeatGolden:
+    """A real df_feat (load_features) must conform to the contract."""
+
+    def test_all_required_columns_present(self, df_feat):
+        required = [c for c, (_, req, _, _) in ut.DICT_DF_FEAT.items() if req]
+        missing = [c for c in required if c not in df_feat.columns]
+        assert not missing, f"required df_feat columns missing: {missing}"
+
+    def test_columns_in_canonical_order(self, df_feat):
+        # The canonical columns appear first and in LIST_COLS_FEAT order.
+        canonical_present = [c for c in df_feat.columns if c in ut.LIST_COLS_FEAT]
+        assert canonical_present == ut.LIST_COLS_FEAT
+
+    def test_dtypes_match_contract(self, df_feat):
+        for col in df_feat.columns:
+            if col not in ut.DICT_DF_FEAT:
+                continue  # dynamic per-substrate column (feat_impact_<name>, ...)
+            expected = ut.DICT_DF_FEAT[col][0]
+            assert _kind(df_feat[col]) == expected, f"{col}: dtype kind drifted"
+
+    def test_non_nullable_required_columns_have_no_nan(self, df_feat):
+        for col, (_, required, nullable, _) in ut.DICT_DF_FEAT.items():
+            if required and not nullable and col in df_feat.columns:
+                assert df_feat[col].notna().all(), f"{col} unexpectedly contains NaN"
+
+
+class TestFeatureIdFormat:
+    """The PART-SPLIT-SCALE feature-id grammar is part of the contract."""
+
+    SPLIT_TYPES = ("Segment", "Pattern", "PeriodicPattern")
+
+    def test_feature_id_splits_into_three(self, df_feat):
+        for feat_id in df_feat[ut.COL_FEATURE]:
+            part, split, scale_id = ut.split_feat_id(feat_id)
+            assert part and split and scale_id
+
+    def test_split_type_is_known(self, df_feat):
+        for feat_id in df_feat[ut.COL_FEATURE]:
+            _, split, _ = ut.split_feat_id(feat_id)
+            assert split.startswith(self.SPLIT_TYPES), f"unknown split in {feat_id}"
+
+    def test_positions_are_1based_ints(self, df_feat):
+        for pos in df_feat[ut.COL_POSITION]:
+            nums = [int(p) for p in re.split(r"[,\s]+", str(pos).strip()) if p != ""]
+            assert nums and all(n >= 1 for n in nums)


### PR DESCRIPTION
## What
Pins the CPP `df_feat` output as a stable, **documented + test-guarded** interface contract that downstream consumers (e.g. ProtXplain) can depend on — without adding downstream-specific code or a new public accessor.

- **`ut.DICT_DF_FEAT`** — a machine-readable data dictionary mapping each `df_feat` column to `(dtype, required, nullable, semantics)`. `required` marks the canonical lower-bound columns (`LIST_COLS_FEAT`); optional/dynamic columns (the test-dependent p-value variant, diagnostic residue columns, post-fit explainable-AI columns) are documented as non-required.
- **Doc page** — `usage_principles/df_feat_contract.rst` rendering the full column schema, the `PART-SPLIT-SCALE` feature-id grammar, and the 1-based `positions` format; wired into the `usage_principles` toctree.
- **Golden/contract test** — `tests/unit/api_tests/test_df_feat_contract.py` fails on column rename/removal, dtype drift, or feature-id format change. Asserts `DICT_DF_FEAT` ↔ `LIST_COLS_FEAT` consistency and that a real `df_feat` (`load_features()`) conforms (columns present + canonical order, dtypes, no required NaNs, feature-id parses via `split_feat_id`, 1-based positions).

## Scope / safety
- **Internal contract only** — no `__init__.py` / `__all__` / public-API change (per the strict-semver decision: consumers pin to documented column-name strings, not a new accessor). No CONFIRM-FIRST surface touched.
- **Zero downstream deps** added to core.

## Tests / verification
- New contract test: 11 tests, green.
- `tests/unit/api_tests` + `tests/unit/utils_tests`: 184 passed locally.
- New RST validated with docutils (0 system messages); class names use code formatting (not `:class:` roles) to avoid cross-ref warnings. The RTD PR check builds the docs.

## Issue
Addresses **#26** (Prepare AAanalysis interface for ProtXplain integration; built on the now-closed #18 schema). Left **without** a `Closes` keyword so merging doesn't auto-close before you confirm the per-residue-score scope on review.

## Note for reviewer
First of a **stacked set** (5 → 7 → 8 → 9). This is the base; the smoke-path PR branches off this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)