### PR TITLE
test(smoke): add a sub-minute critical-path smoke gate

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -11,6 +11,11 @@ uv pip install -e ".[dev]"
 # run all tests
 pytest tests -x -vv --durations=20
 
+# sub-minute smoke gate — the critical CPP path end to end
+# (load -> CPP.run -> TreeModel.fit). Fast local sanity before the full suite;
+# finishes in a few seconds. Non-blocking (no dedicated CI job).
+pytest -m smoke -c tests/pytest.ini
+
 # run a single file or method
 pytest tests/unit/aa_window_sampler_tests/test_aa_window_sampler_synthetic.py -x -vv
 pytest tests/unit/aaclust_tests/test_aaclust_fit.py::TestAAclustFit::test_valid_min_th -x -vv

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -21,3 +21,4 @@ markers =
     network: hits a live external endpoint (AlphaFold/UniProt/HF); deselected by default with -m "not network", run on demand / in the nightly to catch upstream API breakage.
     integration: cross-component seam test (two/three real classes, no mocks). Runs in the dedicated 'Integration & E2E Tests' workflow (excluded from the Unit Tests matrix). See ADR-0031.
     e2e: full user-facing pipeline mirroring a protocol notebook, tiny+seeded. Runs in the dedicated 'Integration & E2E Tests' workflow (excluded from the Unit Tests matrix). See ADR-0031.
+    smoke: sub-minute critical-path check (load -> CPP.run -> TreeModel.fit) for a fast local sanity gate; run with `pytest -m smoke -c tests/pytest.ini`. Non-blocking (not a separate CI job).

--- a/tests/smoke/test_smoke_pipeline.py
+++ b/tests/smoke/test_smoke_pipeline.py
@@ -1,0 +1,51 @@
+"""This is a script for the sub-minute smoke gate: the critical CPP path end to end.
+
+A single, tiny, seeded ``load -> parts -> CPP.run -> feature_matrix -> TreeModel.fit``
+run that exercises the spine most changes touch. It is a fast local sanity check —
+``pytest -m smoke -c tests/pytest.ini`` should finish in well under a minute and catch a
+gross break (import error, broken CPP output, model that won't fit) before the full suite.
+
+Marked ``smoke`` (registered in ``tests/pytest.ini``); deliberately NOT a separate CI job
+(the full matrix already covers these paths). It reuses ``tests/_pipeline`` so the call
+pattern stays defined in one place.
+"""
+import pytest
+
+import aaanalysis as aa
+import aaanalysis.utils as ut
+from tests import _pipeline
+
+pytestmark = pytest.mark.smoke
+
+
+def test_pipeline_load_cpp_treemodel():
+    """The full spine runs and produces a model fitted on real CPP features."""
+    art = _pipeline.build_pipeline(n=5, n_filter=30, n_scales=15)
+    df_feat, X, labels = art["df_feat"], art["X"], art["labels"]
+
+    # CPP produced a ranked, non-empty feature set and a matching design matrix.
+    assert df_feat.shape[0] > 0
+    assert X.shape[0] == len(labels)
+    assert X.shape[1] == df_feat.shape[0]
+
+    # df_feat carries the canonical contract columns (ties to the df_feat data dictionary).
+    missing = [c for c in ut.LIST_COLS_FEAT if c not in df_feat.columns]
+    assert not missing, f"df_feat missing contract columns: {missing}"
+
+    # The downstream model fits on those features and reports feature importances,
+    # which land back on df_feat as the contracted post-fit column.
+    tm = aa.TreeModel(random_state=0)
+    tm.fit(X, labels=labels, n_rounds=2, n_cv=3, n_feat_min=10, n_feat_max=20)
+    df_feat_imp = tm.add_feat_importance(df_feat=df_feat)
+    assert ut.COL_FEAT_IMPORT in df_feat_imp.columns
+
+
+def test_pipeline_predict_proba_shape():
+    """A fitted model predicts class probabilities with the expected shape."""
+    art = _pipeline.build_pipeline(n=5, n_filter=30, n_scales=15)
+    X, labels = art["X"], art["labels"]
+    tm = aa.TreeModel(random_state=0)
+    tm.fit(X, labels=labels, n_rounds=2, n_cv=3, n_feat_min=10, n_feat_max=20)
+    pred, proba = tm.predict_proba(X)
+    assert len(pred) == X.shape[0]
+    assert len(proba) == X.shape[0]


### PR DESCRIPTION
## What
Adds a `smoke` pytest marker and one tiny, seeded end-to-end check of the spine most changes touch:
`load → parts → CPP.run → feature_matrix → TreeModel.fit` (+ `predict_proba`).

`pytest -m smoke -c tests/pytest.ini` finishes in **~7s** locally and catches a gross break (import error, empty/malformed `df_feat`, model that won't fit) before the full suite.

- Register the `smoke` marker in `tests/pytest.ini`.
- `tests/smoke/test_smoke_pipeline.py` reuses `tests/_pipeline` (call pattern defined once); asserts the `df_feat` canonical contract columns, design-matrix shape, a fitted model with feature importances, and `predict_proba` shape.
- Documented in `workflow.md`.

## Scope / safety
- **Non-blocking** — deliberately NOT a separate CI job (the full matrix already covers these paths); a developer-convenience gate only. No `.github/workflows/*` or other CONFIRM-FIRST surface touched.

## Verification
- `pytest -m smoke -c tests/pytest.ini`: 2 passed, 4729 deselected in 4.8s (7.2s wall incl. startup).
- Marker registers cleanly (no unknown-marker warning).

## Note for reviewer
Second of a **stacked set** (5 → **7** → 8 → 9). **Base is `feat/df-feat-contract` (PR #234)**, so the diff here is smoke-only; GitHub will retarget this to `master` once #234 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)