### PR TITLE
refactor(types): import matplotlib Axes/Figure/Line2D from canonical modules (pyright slice)

### DIFF
--- a/aaanalysis/_utils/plotting.py
+++ b/aaanalysis/_utils/plotting.py
@@ -4,6 +4,7 @@ This is a script for the backend of the plotting module functions used by other 
 import seaborn as sns
 import matplotlib as mpl
 from matplotlib import pyplot as plt
+from matplotlib.lines import Line2D
 import matplotlib.lines as mlines
 import warnings
 
@@ -22,13 +23,13 @@ def _create_marker(color, label, marker, marker_size, lw, edgecolor, linestyle, 
                                  edgecolor=hatchcolor)
     # If marker is '-', treat it as a line
     if marker == "-":
-         return plt.Line2D(xdata=[0, 1], ydata=[0, 1],
+         return Line2D(xdata=[0, 1], ydata=[0, 1],
                            color=color,
                            linestyle=linestyle,
                            lw=lw,
                            label=label)
     # Creates marker element without line (lw=0)
-    return plt.Line2D(xdata=[0], ydata=[0],
+    return Line2D(xdata=[0], ydata=[0],
                       marker=marker,
                       label=label,
                       markerfacecolor=color,

--- a/aaanalysis/feature_engineering/_aaclust_plot.py
+++ b/aaanalysis/feature_engineering/_aaclust_plot.py
@@ -6,6 +6,8 @@ from sklearn.decomposition import PCA
 from typing import Optional, Dict, Union, List, Tuple, Type
 from sklearn.base import TransformerMixin
 import matplotlib.pyplot as plt
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 import matplotlib as mpl
 import numpy as np
 import warnings
@@ -194,7 +196,7 @@ class AAclustPlot:
     def eval(df_eval: Optional[pd.DataFrame] = None,
              figsize: Tuple[Union[int, float], Union[int, float]] = (6, 4),
              dict_xlims: Optional[dict] = None,
-             ) -> Tuple[plt.Figure, plt.Axes]:
+             ) -> Tuple[Figure, Axes]:
         """
         Plots evaluation of ``n_clusters`` and clustering metrics Bayesian Information Criterion
         (``BIC``), Calinski-Harabasz (``CH``), and Silhouette Coefficient (``SC``) from ``df_eval``.
@@ -223,9 +225,9 @@ class AAclustPlot:
 
         Returns
         -------
-        fig : plt.Figure
+        fig : Figure
             Figure object for evaluation plot
-        axes : array of plt.Axes
+        axes : array of Axes
             Array of Axes objects, each representing a subplot within the figure.
 
         Notes
@@ -258,13 +260,13 @@ class AAclustPlot:
                 df_scales: Optional[pd.DataFrame] = None,
                 component_x: int = 1,
                 component_y: int = 2,
-                ax: Optional[plt.Axes] = None,
+                ax: Optional[Axes] = None,
                 figsize: Tuple[Union[int, float], Union[int, float]] = (7, 6),
                 legend: bool = True,
                 dot_size: int = 100,
                 dot_alpha: Union[int, float] = 0.75,
                 palette: Optional[mpl.colors.ListedColormap] = None,
-                ) -> Tuple[plt.Axes, pd.DataFrame]:
+                ) -> Tuple[Axes, pd.DataFrame]:
         """
         Create a Principal Component Analysis (PCA) plot of clustering results with cluster
         centers highlighted.
@@ -294,7 +296,7 @@ class AAclustPlot:
             Index of the PCA component for the x-axis. Must be >= 1.
         component_y : int, default=2
             Index of the PCA component for the y-axis. Must be >= 1.
-        ax : plt.Axes, optional
+        ax : Axes, optional
             Pre-defined Axes object to plot on. If ``None``, a new Axes object is created.
         figsize : tuple, default=(7, 6)
             Figure dimensions (width, height) in inches.
@@ -309,7 +311,7 @@ class AAclustPlot:
 
         Returns
         -------
-        ax : plt.Axes
+        ax : Axes
             PCA plot axes object.
         df_components : pd.DataFrame
             DataFrame with the PCA components.
@@ -361,13 +363,13 @@ class AAclustPlot:
                 component_x: int = 1,
                 component_y: int = 2,
                 metric: str = "euclidean",
-                ax: Optional[plt.Axes] = None,
+                ax: Optional[Axes] = None,
                 figsize: Tuple[Union[int, float], Union[int, float]] = (7, 6),
                 legend: bool = True,
                 dot_size: int = 100,
                 dot_alpha: Union[int, float] = 0.75,
                 palette: Optional[mpl.colors.ListedColormap] = None,
-                ) -> Tuple[plt.Axes, pd.DataFrame]:
+                ) -> Tuple[Axes, pd.DataFrame]:
         """
         Principal Component Analysis (PCA) plot of clustering with medoids highlighted.
 
@@ -404,7 +406,7 @@ class AAclustPlot:
             - ``manhattan``: Manhattan distance (minimum)
             - ``cosine``: Cosine distance (minimum)
 
-        ax : plt.Axes, optional
+        ax : Axes, optional
             Pre-defined Axes object to plot on. If ``None``, a new Axes object is created.
         figsize : tuple, default=(7, 6)
             Figure dimensions (width, height) in inches.
@@ -419,7 +421,7 @@ class AAclustPlot:
 
         Returns
         -------
-        ax : plt.Axes
+        ax : Axes
             PCA plot axes object.
         df_components : pd.DataFrame
             DataFrame with the PCA components.
@@ -482,7 +484,7 @@ class AAclustPlot:
                     vmax: float = 1.0,
                     cmap: str = "viridis",
                     kwargs_heatmap: Optional[dict] = None
-                    ) -> plt.Axes:
+                    ) -> Axes:
         """
         Heatmap for correlation matrix with colored sidebar to label clusters.
 
@@ -532,7 +534,7 @@ class AAclustPlot:
 
         Returns
         -------
-        ax : plt.Axes
+        ax : Axes
             Axes object with the correlation heatmap.
 
         Notes

--- a/aaanalysis/feature_engineering/_cpp_plot.py
+++ b/aaanalysis/feature_engineering/_cpp_plot.py
@@ -4,6 +4,8 @@ This is a script for the frontend of the CPPPlot class.
 from typing import Optional, Dict, Union, List, Tuple, Type, Literal
 import pandas as pd
 import matplotlib.pyplot as plt
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 import warnings
 
 import aaanalysis.utils as ut
@@ -289,7 +291,7 @@ class CPPPlot:
              legend_y: float = -0.3,
              dict_color: Optional[dict] = None,
              list_cat: Optional[List[str]] = None,
-             ) -> Tuple[plt.Figure, plt.Axes]:
+             ) -> Tuple[Figure, Axes]:
         """
         Plot evaluation output of Comparative Physicochemical Profiling (CPP) comparing multiple
         sets of identified feature sets.
@@ -334,9 +336,9 @@ class CPPPlot:
 
         Returns
         -------
-        fig : plt.Figure
+        fig : Figure
             Figure object for evaluation plot
-        axes : array of plt.Axes
+        axes : array of Axes
             Array of Axes objects, each representing a subplot within the figure.
 
         Notes
@@ -387,7 +389,7 @@ class CPPPlot:
                 labels: Optional[ut.ArrayLike1D] = None,
                 label_test: int = 1,
                 label_ref: int = 0, 
-                ax: Optional[plt.Axes] = None,
+                ax: Optional[Axes] = None,
                 figsize: Tuple[Union[int, float], Union[int, float]] = (5.6, 4.8),
                 names_to_show: Optional[Union[List[str], str]] = None,
                 name_test: str = "TEST",
@@ -404,7 +406,7 @@ class CPPPlot:
                 fontsize_names_to_show: Union[int, float, None] = 11,
                 alpha_hist: int or float = 0.1,
                 alpha_dif: int or float = 0.2,
-                ) -> plt.Axes:
+                ) -> Axes:
         """
         Plot distributions of Comparative Physicochemical Profiling (CPP) feature values for test
         and reference datasets highlighting their mean difference.
@@ -440,7 +442,7 @@ class CPPPlot:
             Class label of test group in ``labels``.
         label_ref : int, default=0,
             Class label of reference group in ``labels``.
-        ax : plt.Axes, optional
+        ax : Axes, optional
             Pre-defined Axes object to plot on. If ``None``, a new Axes object is created.
         figsize : tuple, default=(5.6, 4.8)
             Figure dimensions (width, height) in inches.
@@ -480,7 +482,7 @@ class CPPPlot:
 
         Returns
         -------
-        ax : plt.Axes
+        ax : Axes
             CPP feature plot axes object.
 
         See Also
@@ -560,7 +562,7 @@ class CPPPlot:
                 xlim_dif: Union[Tuple[Union[int, float], Union[int, float]], None] = (-17.5, 17.5),
                 xlim_rank: Optional[Tuple[Union[int, float], Union[int, float]]] = (0, 4),
                 rank_info_xy: Optional[Tuple[Optional[Union[int, float]], Optional[Union[int, float]]]] = None,
-                ) -> Tuple[plt.Figure, plt.Axes]:
+                ) -> Tuple[Figure, Axes]:
         """
         Plot CPP/-SHAP feature ranking based on feature importance or sample-specific feature impact.
 
@@ -634,9 +636,9 @@ class CPPPlot:
 
         Returns
         -------
-        fig : plt.Figure
+        fig : Figure
             The Figure object for the ranking plot.
-        axes : array of plt.Axes
+        axes : array of Axes
             Array of Axes objects, each representing a subplot within the figure.
 
         Notes
@@ -717,7 +719,7 @@ class CPPPlot:
                 shap_plot: bool = False,
                 col_imp: Union[str, None] = "feat_importance",
                 normalize: bool = True,
-                ax: Optional[plt.Axes] = None,
+                ax: Optional[Axes] = None,
                 figsize: Tuple[Union[int, float], Union[int, float]] = (7, 5),
 
                 # Appearance of Parts (TMD-JMD)
@@ -751,7 +753,7 @@ class CPPPlot:
                 ytick_size: Optional[Union[int, float]] = None,
                 ytick_width: Optional[Union[int, float]] = None,
                 ytick_length: Union[int, float] = 5.0,
-                ) -> Tuple[plt.Figure, plt.Axes]:
+                ) -> Tuple[Figure, Axes]:
         """
         Plot CPP/-SHAP profile showing feature importance/impact per residue position.
 
@@ -786,7 +788,7 @@ class CPPPlot:
             If ``None``, the number of features per residue position will be shown.
         normalize : bool, default=True
             If ``True``, normalizes aggregated numerical values to a total of 100%.
-        ax : plt.Axes, optional
+        ax : Axes, optional
             Pre-defined Axes object to plot on. If ``None``, a new Axes object is created.
         figsize : tuple, default=(7, 5)
             Figure dimensions (width, height) in inches.
@@ -852,9 +854,9 @@ class CPPPlot:
 
         Returns
         -------
-        fig : plt.Figure
+        fig : Figure
             The Figure object for the CPP profile plot.
-        ax : plt.Axes
+        ax : Axes
             CPP profile plot axes object.
 
         Notes
@@ -982,7 +984,7 @@ class CPPPlot:
                 xtick_size: Union[int, float] = 11.0,
                 xtick_width: Union[int, float] = 2.0,
                 xtick_length: Union[int, float] = 5.0,
-                ) -> Tuple[plt.Figure, plt.Axes]:
+                ) -> Tuple[Figure, Axes]:
         """
         Plot a CPP/-SHAP heatmap showing the feature value mean difference/feature impact
         per scale subcategory (y-axis) and residue position (x-axis).
@@ -1092,9 +1094,9 @@ class CPPPlot:
 
         Returns
         -------
-        fig : plt.Figure
+        fig : Figure
             The Figure object for the CPP heatmap.
-        ax : plt.Axes
+        ax : Axes
             Axes object for the CPP heatmap.
 
         Notes
@@ -1248,7 +1250,7 @@ class CPPPlot:
                     xtick_size: Union[int, float] = 11.0,
                     xtick_width: Union[int, float] = 2.0,
                     xtick_length: Union[int, float] = 5.0,
-                    ) -> Tuple[plt.Figure, plt.Axes]:
+                    ) -> Tuple[Figure, Axes]:
         """
         Plot Comparative Physicochemical Profiling (CPP) feature map showing feature value mean
         difference and feature importance per scale subcategory (y-axis) and residue position
@@ -1391,9 +1393,9 @@ class CPPPlot:
 
         Returns
         -------
-        fig : plt.Figure
+        fig : Figure
             The Figure object for the CPP feature map.
-        ax : plt.Axes
+        ax : Axes
             Axes object for the CPP feature map.
 
         Notes
@@ -1513,8 +1515,8 @@ class CPPPlot:
         return fig, ax
 
     def update_seq_size(self,
-                        ax: Optional[plt.Axes] = None,
-                        fig: Optional[plt.Figure] = None,
+                        ax: Optional[Axes] = None,
+                        fig: Optional[Figure] = None,
                         max_x_dist: float = 0.1,
                         fontsize_tmd_jmd: Optional[Union[int, float]] = None,
                         weight_tmd_jmd: Literal['normal', 'bold'] = 'normal',
@@ -1522,7 +1524,7 @@ class CPPPlot:
                         jmd_color: str = "blue",
                         tmd_seq_color: str = "black",
                         jmd_seq_color: str = "white",
-                        ) -> plt.Axes:
+                        ) -> Axes:
         """
         Update the font size of the sequence characters to prevent overlap.
 
@@ -1533,9 +1535,9 @@ class CPPPlot:
 
         Parameters
         ----------
-        ax : plt.Axes
+        ax : Axes
             Comparative Physicochemical Profiling (CPP) plot axes object.
-        fig : plt.Figure, optional
+        fig : Figure, optional
             CPP plot figure object. If given, ``fontsize_tmd_jmd`` will be automatically adjusted.
         max_x_dist : float, default=0.1
             Maximum allowed horizontal distance between sequence characters during font size optimization.
@@ -1555,7 +1557,7 @@ class CPPPlot:
 
         Returns
         -------
-        ax : plt.Axes
+        ax : Axes
             CPP plot axes object.
 
         Notes

--- a/aaanalysis/plotting/_plot_legend.py
+++ b/aaanalysis/plotting/_plot_legend.py
@@ -4,13 +4,14 @@ The backend is in general utility module to provide function to remaining AAanal
 """
 from typing import Optional, List, Dict, Union, Tuple
 from matplotlib import pyplot as plt
+from matplotlib.axes import Axes
 from aaanalysis import utils as ut
 
 # I Helper functions
 
 
 # II Main function
-def plot_legend(ax: Optional[plt.Axes] = None,
+def plot_legend(ax: Optional[Axes] = None,
                 # Categories and colors
                 dict_color: Optional[Dict[str, str]] = None,
                 list_cat: Optional[List[str]] = None,
@@ -45,7 +46,7 @@ def plot_legend(ax: Optional[plt.Axes] = None,
                 # Additional arguments
                 keep_legend: bool = False,
                 **kwargs
-                ) -> Union[plt.Axes, Tuple[List, List[str]]]:
+                ) -> Union[Axes, Tuple[List, List[str]]]:
     """
     Set an independently customizable plot legend.
 
@@ -56,7 +57,7 @@ def plot_legend(ax: Optional[plt.Axes] = None,
 
     Parameters
     ----------
-    ax : plt.Axes, optional
+    ax : Axes, optional
         The axes to attach the legend to. If not provided, the current axes will be used.
     dict_color : dict, optional
         A dictionary mapping categories to colors.
@@ -117,7 +118,7 @@ def plot_legend(ax: Optional[plt.Axes] = None,
 
     Returns
     -------
-    ax : plt.Axes
+    ax : Axes
         The axes object on which legend is applied to.
 
     Notes

--- a/aaanalysis/plotting/_plot_rank.py
+++ b/aaanalysis/plotting/_plot_rank.py
@@ -6,6 +6,8 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 from matplotlib import pyplot as plt
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 
 from aaanalysis import utils as ut
 from ._plot_get_clist import plot_get_clist
@@ -49,13 +51,13 @@ def plot_rank(df_rank: Optional[pd.DataFrame] = None,
               group_order: Optional[List[str]] = None,
               dict_color: Optional[Dict[str, str]] = None,
               threshold: Optional[Union[int, float, List[Union[int, float]]]] = None,
-              ax: Optional[plt.Axes] = None,
+              ax: Optional[Axes] = None,
               figsize: Tuple[Union[int, float], Union[int, float]] = (7, 5),
               marker_size: Union[int, float] = 25,
               xlabel: str = "Protein rank",
               ylabel: str = "Max score per protein",
               fontsize_labels: Optional[Union[int, float]] = None,
-              ) -> Tuple[plt.Figure, plt.Axes]:
+              ) -> Tuple[Figure, Axes]:
     """
     Plot a per-protein rank scatter: max-score-per-protein sorted by score, colored by group.
 

--- a/aaanalysis/protein_design/_aamut_plot.py
+++ b/aaanalysis/protein_design/_aamut_plot.py
@@ -5,6 +5,7 @@ substitution impact across physicochemical scales.
 from typing import Optional, Tuple, Union
 import pandas as pd
 import matplotlib.pyplot as plt
+from matplotlib.axes import Axes
 import seaborn as sns
 
 import aaanalysis.utils as ut
@@ -52,10 +53,10 @@ class AAMutPlot:
     # Main methods
     def substitution_matrix(self,
                             df_impact: Optional[pd.DataFrame] = None,
-                            ax: Optional[plt.Axes] = None,
+                            ax: Optional[Axes] = None,
                             figsize: Tuple[Union[int, float], Union[int, float]] = (7, 6),
                             cmap: str = "viridis",
-                            ) -> plt.Axes:
+                            ) -> Axes:
         """
         Plot the 20x20 amino acid substitution-impact matrix.
 
@@ -66,7 +67,7 @@ class AAMutPlot:
         ----------
         df_impact : pd.DataFrame
             Substitution-impact table produced by :meth:`AAMut.run`.
-        ax : plt.Axes, optional
+        ax : Axes, optional
             Pre-defined Axes object to plot on. If ``None``, a new one is created.
         figsize : tuple, default=(7, 6)
             Figure dimensions (width, height) in inches (used when ``ax`` is ``None``).
@@ -75,7 +76,7 @@ class AAMutPlot:
 
         Returns
         -------
-        ax : plt.Axes
+        ax : Axes
             Axes object of the substitution matrix.
 
         Examples
@@ -98,10 +99,10 @@ class AAMutPlot:
     def scale_ranking(self,
                       df_impact: Optional[pd.DataFrame] = None,
                       top_n: int = 20,
-                      ax: Optional[plt.Axes] = None,
+                      ax: Optional[Axes] = None,
                       figsize: Tuple[Union[int, float], Union[int, float]] = (6, 5),
                       color: Optional[str] = None,
-                      ) -> plt.Axes:
+                      ) -> Axes:
         """
         Plot the per-scale ranking of substitution sensitivity.
 
@@ -114,7 +115,7 @@ class AAMutPlot:
             Substitution-impact table produced by :meth:`AAMut.run`.
         top_n : int, default=20
             Number of most sensitive scales to show.
-        ax : plt.Axes, optional
+        ax : Axes, optional
             Pre-defined Axes object to plot on. If ``None``, a new one is created.
         figsize : tuple, default=(6, 5)
             Figure dimensions (width, height) in inches (used when ``ax`` is ``None``).
@@ -123,7 +124,7 @@ class AAMutPlot:
 
         Returns
         -------
-        ax : plt.Axes
+        ax : Axes
             Axes object of the scale-ranking plot.
 
         Examples
@@ -149,9 +150,9 @@ class AAMutPlot:
                       from_aa: Optional[str] = None,
                       to_aa: Optional[str] = None,
                       top_n: int = 20,
-                      ax: Optional[plt.Axes] = None,
+                      ax: Optional[Axes] = None,
                       figsize: Tuple[Union[int, float], Union[int, float]] = (6, 5),
-                      ) -> plt.Axes:
+                      ) -> Axes:
         """
         Plot the per-scale signed delta for one amino acid substitution pair.
 
@@ -168,14 +169,14 @@ class AAMutPlot:
             Substituted-to amino acid (single letter).
         top_n : int, default=20
             Number of scales with the largest absolute delta to show.
-        ax : plt.Axes, optional
+        ax : Axes, optional
             Pre-defined Axes object to plot on. If ``None``, a new one is created.
         figsize : tuple, default=(6, 5)
             Figure dimensions (width, height) in inches (used when ``ax`` is ``None``).
 
         Returns
         -------
-        ax : plt.Axes
+        ax : Axes
             Axes object of the amino acid comparison plot.
 
         Examples

--- a/aaanalysis/protein_design/_seqmut_plot.py
+++ b/aaanalysis/protein_design/_seqmut_plot.py
@@ -5,6 +5,7 @@ This is a script for the frontend of the SeqMutPlot class for visualizing per-po
 from typing import Optional, Tuple, Union
 import pandas as pd
 import matplotlib.pyplot as plt
+from matplotlib.axes import Axes
 import seaborn as sns
 
 import aaanalysis.utils as ut
@@ -58,10 +59,10 @@ class SeqMutPlot:
     def mutation_landscape(self,
                            df_scan: Optional[pd.DataFrame] = None,
                            entry: Optional[str] = None,
-                           ax: Optional[plt.Axes] = None,
+                           ax: Optional[Axes] = None,
                            figsize: Tuple[Union[int, float], Union[int, float]] = (10, 5),
                            cmap: str = "viridis",
-                           ) -> plt.Axes:
+                           ) -> Axes:
         """
         Plot the per-position ΔCPP mutation landscape for one sequence.
 
@@ -74,7 +75,7 @@ class SeqMutPlot:
             Mutational landscape produced by :meth:`SeqMut.scan`.
         entry : str, optional
             Protein entry to plot. If ``None``, the first entry in ``df_scan`` is used.
-        ax : plt.Axes, optional
+        ax : Axes, optional
             Pre-defined Axes object to plot on. If ``None``, a new one is created.
         figsize : tuple, default=(10, 5)
             Figure dimensions (width, height) in inches (used when ``ax`` is ``None``).
@@ -83,7 +84,7 @@ class SeqMutPlot:
 
         Returns
         -------
-        ax : plt.Axes
+        ax : Axes
             Axes object of the mutation landscape.
 
         Examples
@@ -108,10 +109,10 @@ class SeqMutPlot:
                                 df_scan: Optional[pd.DataFrame] = None,
                                 entry: Optional[str] = None,
                                 pos: Optional[int] = None,
-                                ax: Optional[plt.Axes] = None,
+                                ax: Optional[Axes] = None,
                                 figsize: Tuple[Union[int, float], Union[int, float]] = (6, 5),
                                 color: Optional[str] = None,
-                                ) -> plt.Axes:
+                                ) -> Axes:
         """
         Plot the substitution impact for a single residue across all substitutions.
 
@@ -126,7 +127,7 @@ class SeqMutPlot:
             Protein entry to plot. If ``None``, the first entry in ``df_scan`` is used.
         pos : int
             1-based residue position to plot.
-        ax : plt.Axes, optional
+        ax : Axes, optional
             Pre-defined Axes object to plot on. If ``None``, a new one is created.
         figsize : tuple, default=(6, 5)
             Figure dimensions (width, height) in inches (used when ``ax`` is ``None``).
@@ -135,7 +136,7 @@ class SeqMutPlot:
 
         Returns
         -------
-        ax : plt.Axes
+        ax : Axes
             Axes object of the residue mutation-impact plot.
 
         Examples

--- a/aaanalysis/pu_learning/_dpulearn_plot.py
+++ b/aaanalysis/pu_learning/_dpulearn_plot.py
@@ -7,6 +7,8 @@ import pandas as pd
 import numpy as np
 from sklearn.decomposition import PCA
 import matplotlib.pyplot as plt
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 from typing import Optional, Dict, Union, List, Tuple, Type
 
 
@@ -86,7 +88,7 @@ class dPULearnPlot:
              legend: bool = True,
              legend_y: float = -0.175,
              colors: Optional[List[str]] = None,
-             ) -> Tuple[plt.Figure, plt.Axes]:
+             ) -> Tuple[Figure, Axes]:
         """
         Plot evaluation output of dPULearn comparing multiple sets of identified negatives.
 
@@ -130,9 +132,9 @@ class dPULearnPlot:
 
         Returns
         -------
-        fig : plt.Figure
+        fig : Figure
             Figure object for evaluation plot
-        axes : array of plt.Axes
+        axes : array of Axes
             Array of Axes objects, each representing a subplot within the figure. .
 
         Notes
@@ -177,7 +179,7 @@ class dPULearnPlot:
             legend: bool = True,
             legend_y: float = -0.15,
             kwargs_scatterplot: Optional[dict] = None,
-            ) -> plt.Axes:
+            ) -> Axes:
         """
         Principal component analysis (PCA) plot for set of identified negatives.
 
@@ -218,7 +220,7 @@ class dPULearnPlot:
 
         Returns
         -------
-        ax : plt.Axes
+        ax : Axes
             PCA plot axes object.
 
         See Also

--- a/aaanalysis/seq_analysis/_aalogo_plot.py
+++ b/aaanalysis/seq_analysis/_aalogo_plot.py
@@ -3,6 +3,8 @@ This is a script for the frontend of the AAlogoPlot class.
 """
 import inspect
 import matplotlib.pyplot as plt
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 import pandas as pd
 from typing import Optional, Union, List, Tuple, Literal
 
@@ -298,7 +300,7 @@ class AAlogoPlot:
                     xtick_size: Optional[Union[int, float]] = None,
                     xtick_width: Union[int, float] = 2.0,
                     xtick_length: Union[int, float] = 11.0,
-                    ) -> Tuple[plt.Figure, plt.Axes]:
+                    ) -> Tuple[Figure, Axes]:
         """
         Plot a single sequence logo with optional bit-score bar and target middle domain
         (TMD) / juxta middle domain (JMD) annotations.
@@ -398,9 +400,9 @@ class AAlogoPlot:
 
         Returns
         -------
-        fig : plt.Figure
+        fig : Figure
             Figure object.
-        axes : plt.Axes or tuple of (plt.Axes, plt.Axes)
+        axes : Axes or tuple of (Axes, Axes)
             When ``df_logo_info`` is ``None``: a single ``Axes`` for the logo panel.
             When ``df_logo_info`` is provided: a tuple ``(ax_logo, ax_info)`` where
             ``ax_info`` is the bit-score bar above the logo.
@@ -540,7 +542,7 @@ class AAlogoPlot:
                    xtick_size: Optional[Union[int, float]] = None,
                    xtick_width: Union[int, float] = 2.0,
                    xtick_length: Union[int, float] = 11.0,
-                   ) -> Tuple[plt.Figure, List[plt.Axes]]:
+                   ) -> Tuple[Figure, List[Axes]]:
         """
         Plot multiple sequence logos stacked vertically for group comparison, each with
         an optional bit-score bar on top.
@@ -627,9 +629,9 @@ class AAlogoPlot:
 
         Returns
         -------
-        fig : plt.Figure
+        fig : Figure
             Figure object.
-        axes : list of plt.Axes or list of tuple of (plt.Axes, plt.Axes)
+        axes : list of Axes or list of tuple of (Axes, Axes)
             When no bit-score bars are shown: one ``Axes`` per logo. When
             ``list_df_logo_info`` (or ``list_aal_kws``) is given: one
             ``(ax_logo, ax_info)`` tuple per group, where ``ax_info`` is the bar above.


### PR DESCRIPTION
## What
First **safe slice** of the advisory-pyright burn-down (the program's non-blocking follow-up).

The plot classes annotate types as `plt.Axes` / `plt.Figure` / `plt.Line2D`, which pyright flags under `reportPrivateImportUsage` ("not exported from `matplotlib.pyplot`"). This imports each type from its canonical public module (`matplotlib.axes` / `matplotlib.figure` / `matplotlib.lines`) and uses the bare name in annotations and docstrings, across 9 files.

## Why this slice
- **Runtime-identical** — `plt.Axes is matplotlib.axes.Axes`; the change is import/annotation only, zero behavior risk. Ideal for an unattended run.
- **Clears a whole category** — `reportPrivateImportUsage` goes from 47 → **0**; total pyright errors **1250 → 1203**.

## What's deliberately left
The dominant categories — `reportArgumentType` (564) and `reportOptional*` (~426) — come from the pervasive `param: Optional[T] = None` sklearn pattern where the runtime Validate block guarantees non-None but pyright can't see it. "Fixing" those means per-site narrowing (`assert`s) or signature changes — **behavior-adjacent judgment calls** not safe to bulk-apply unattended. `reportReturnType` (33) is a mix of real-Optionals and false positives, also per-site. These are left for an interactive follow-up. pyright is **advisory / non-blocking**, so a partial reduction is correct and safe.

## Verification
- pyright: errors 1250 → 1203; `reportPrivateImportUsage` 0.
- Plot suites green: **1112 passed** (cpp_plot, aaclust_plot, dpulearn_plot, plotting, protein_design, seq_analysis).
- Package imports cleanly (new bare-name annotations resolve at runtime).
- No CONFIRM-FIRST surface touched.

## Note for reviewer
Fourth and last of the **stacked set** (5 → 7 → 8 → **9**). **Base is `refactor/utils-barrel-split` (PR #236)**; GitHub retargets to `master` as the lower PRs merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)