### PR TITLE
feat(contract): rich data dictionary for all key DataFrames (DICT_DF_SCHEMAS)

### DIFF
--- a/.github/scripts/gen_df_schemas_doc.py
+++ b/.github/scripts/gen_df_schemas_doc.py
@@ -1,0 +1,41 @@
+"""Generate the DataFrame-schemas reference page from the machine-readable registry.
+
+The data dictionary lives in ``aaanalysis.utils.DICT_DF_SCHEMAS``; this script renders
+it to ``docs/source/index/usage_principles/df_schemas.rst`` so the documentation has a
+single source of truth. ``tests/unit/api_tests/test_df_schemas.py`` re-runs the render
+and asserts the committed page matches, so the docs cannot drift from the code.
+
+Usage:
+    python .github/scripts/gen_df_schemas_doc.py            # write the page
+    python .github/scripts/gen_df_schemas_doc.py --check    # exit 1 if out of sync
+"""
+import argparse
+import pathlib
+import sys
+
+import aaanalysis.utils as ut
+
+DOC_PATH = (pathlib.Path(__file__).resolve().parents[1].parent
+            / "docs/source/index/usage_principles/df_schemas.rst")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true",
+                        help="exit non-zero if the committed page is out of sync")
+    args = parser.parse_args()
+    rendered = ut.render_schemas_rst()
+    if args.check:
+        current = DOC_PATH.read_text() if DOC_PATH.exists() else ""
+        if current != rendered:
+            print("df_schemas.rst is out of sync; run gen_df_schemas_doc.py", file=sys.stderr)
+            return 1
+        print("df_schemas.rst is in sync")
+        return 0
+    DOC_PATH.write_text(rendered)
+    print(f"wrote {DOC_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/aaanalysis/_schemas.py
+++ b/aaanalysis/_schemas.py
@@ -1,0 +1,471 @@
+"""This is a script for the data dictionary / interface contract of the key AAanalysis
+DataFrames.
+
+``DICT_DF_SCHEMAS`` is the machine-readable contract that documents, for every important
+DataFrame, what columns exist, their dtype / nullability / uniqueness, the allowed values
+or numeric range, a one-line meaning, and an example value. It is the single source of
+truth rendered to the documentation (via ``render_schemas_rst``) and guarded by the
+contract tests in ``tests/unit/api_tests/test_df_schemas.py``.
+
+The module imports only ``._constants`` (column-name + vocabulary constants) -- never
+``aaanalysis.utils`` -- so it stays circular-free; ``utils.py`` re-exports
+``DICT_DF_SCHEMAS`` so it is reachable as ``ut.DICT_DF_SCHEMAS``.
+
+Each frame entry has:
+    description : str
+    columns     : dict[col_name -> field record]   (column-table frames)
+and, where relevant, one of:
+    formats         : dict[name -> required column set]  (df_seq's conditional formats)
+    dynamic_columns : dict                                (df_parts: columns are part names)
+    matrix          : dict(index, columns, values, dtype) (df_scales / df_logo / X)
+
+Each field record (built by ``_field``) has:
+    dtype, required, nullable, unique, description
+and optionally: range, allowed_values, example, validation.
+"""
+from ._constants import (
+    COL_ENTRY, COL_SEQ, COL_LABEL, COL_NAME, COL_TMD_START, COL_TMD_STOP,
+    COL_JMD_N, COL_TMD, COL_JMD_C,
+    COL_SCALE_ID, COL_CAT, COL_SUBCAT, COL_SCALE_NAME, COL_SCALE_DES,
+    COL_CLUSTER, COL_INTERPRET_GRADE, COL_TOP_EXPLAIN, COL_N_SCALES,
+    COL_N_SCALES_AAINDEX, COL_SUBCAT_DES, COL_KEY_REFERENCES,
+    COL_FEATURE, COL_ABS_AUC, COL_ABS_MEAN_DIF, COL_MEAN_DIF, COL_STD_TEST,
+    COL_STD_REF, COL_PVAL_MW, COL_PVAL_TTEST, COL_PVAL_FDR, COL_POSITION,
+    COL_AA_TEST, COL_AA_REF, COL_FEAT_DES,
+    COL_FEAT_IMPORT, COL_FEAT_IMPORT_STD, COL_FEAT_IMPACT, COL_FEAT_IMPACT_STD,
+    COL_FROM_AA, COL_TO_AA, COL_MUTATION, COL_DELTA, COL_ABS_DELTA,
+    COL_POS, COL_REGION, COL_DELTA_CPP, COL_SHIFT_SCORE,
+    COL_N_MUT, COL_N_DISRUPTIVE, COL_FRAC_DISRUPTIVE, COL_MEAN_DELTA_CPP,
+    COL_PROTEIN_ID, COL_START, COL_STOP, COL_AA, COL_FEATURE_TYPE, COL_SOURCE,
+    COL_EVIDENCE, COL_SCORE, COL_BOND_ID,
+    LIST_CAT, LIST_ALL_PARTS, LIST_CANONICAL_AA, COLS_SEQ_POS, COLS_SEQ_PARTS,
+    COLS_SEQ_TMD,
+)
+
+# Field-record keys (kept positionless / dict-based on purpose; documented above).
+FIELD_KEYS = ("dtype", "required", "nullable", "unique", "range",
+              "allowed_values", "example", "validation", "description")
+
+
+def _field(dtype, description, *, required=True, nullable=False, unique=False,
+           range=None, allowed_values=None, example=None, validation=None):
+    """Build one column's field record; optional keys are omitted when None."""
+    rec = {"dtype": dtype, "required": required, "nullable": nullable,
+           "unique": unique, "description": description}
+    if range is not None:
+        rec["range"] = range
+    if allowed_values is not None:
+        rec["allowed_values"] = allowed_values
+    if example is not None:
+        rec["example"] = example
+    if validation is not None:
+        rec["validation"] = validation
+    return rec
+
+
+DICT_DF_SCHEMAS = {
+    # ---------------------------------------------------------------- inputs
+    "df_seq": {
+        "description": (
+            "Sequence-level input table; one row per protein/sequence. Accepts four "
+            "column formats (besides the always-required 'entry'): position-based "
+            f"{COLS_SEQ_POS}, part-based {COLS_SEQ_PARTS}, sequence-based ['sequence'], "
+            f"or sequence-TMD-based {COLS_SEQ_TMD}."),
+        "formats": {
+            "position_based": COLS_SEQ_POS,
+            "part_based": COLS_SEQ_PARTS,
+            "sequence_based": [COL_SEQ],
+            "sequence_tmd_based": COLS_SEQ_TMD,
+        },
+        "columns": {
+            COL_ENTRY: _field("str", "Unique protein/sequence identifier.",
+                              required=True, unique=True, example="P05067"),
+            COL_SEQ: _field("str", "Amino acid sequence (one-letter code).",
+                            required=False, validation="amino_acid_sequence",
+                            example="MLPGLALLLL..."),
+            COL_TMD_START: _field("int", "1-based start position of the TMD in 'sequence' "
+                                  "(position-based format).", required=False,
+                                  range=[1, None], example=37),
+            COL_TMD_STOP: _field("int", "1-based stop position of the TMD in 'sequence', "
+                                 "inclusive (position-based format).", required=False,
+                                 range=[1, None], example=59),
+            COL_JMD_N: _field("str", "N-terminal juxtamembrane domain subsequence "
+                              "(part-based format).", required=False, example="NSPFYYDWHS"),
+            COL_TMD: _field("str", "Transmembrane domain subsequence (part-/sequence-TMD "
+                            "formats).", required=False, example="LQVGGLICAGVL"),
+            COL_JMD_C: _field("str", "C-terminal juxtamembrane domain subsequence "
+                              "(part-based format).", required=False, example="KCKCKFGQKS"),
+            COL_LABEL: _field("int", "Class/group label. Binary contrasts by convention "
+                              "(reference=0, test=1); multi-class via the "
+                              "SequenceFeature.get_labels_* helpers.", required=False,
+                              example=1),
+            COL_NAME: _field("str", "Human-readable protein name.", required=False,
+                             nullable=True, example="APP"),
+        },
+    },
+    "df_parts": {
+        "description": (
+            "Sequence parts table consumed by CPP / SequenceFeature; one row per "
+            "sequence. Columns are DYNAMIC: one column per selected sequence part, named "
+            "by the part vocabulary; each value is the part's amino acid subsequence."),
+        "dynamic_columns": {
+            "name_from": "LIST_ALL_PARTS",
+            "allowed_names": list(LIST_ALL_PARTS),
+            "dtype": "str",
+            "nullable": False,
+            "description": "Amino acid subsequence of the named sequence part.",
+            "example": "NSPFYYDWHSLQVGGL",
+        },
+    },
+    # ------------------------------------------------------------- reference
+    "df_scales": {
+        "description": (
+            "Amino acid scale matrix (AAontology / AAindex-derived). Loaded via "
+            "load_scales; consumed by CPP / SequenceFeature."),
+        "matrix": {
+            "index": "amino acid (one-letter; 20 canonical)",
+            "columns": "scale id (e.g. 'KLEP840101')",
+            "values": "min-max normalised scale value in [0, 1]",
+            "dtype": "float",
+        },
+    },
+    "df_cat": {
+        "description": (
+            "AAontology scale metadata (one row per scale id). Loaded via "
+            "load_scales(name='scales_cat')."),
+        "columns": {
+            COL_SCALE_ID: _field("str", "Amino acid scale identifier; the join key to "
+                                 "df_scales columns.", required=True, unique=True,
+                                 example="KLEP840101"),
+            COL_CAT: _field("str", "AAontology main category.", required=True,
+                            allowed_values=list(LIST_CAT), example="Energy"),
+            COL_SUBCAT: _field("str", "AAontology subcategory.", required=True,
+                               example="Charge"),
+            COL_SCALE_NAME: _field("str", "Human-readable scale name.", required=True,
+                                   example="Charge"),
+            COL_SCALE_DES: _field("str", "One-sentence scale description.", required=True,
+                                  example="Net charge (Klein et al., 1984)."),
+        },
+    },
+    "df_subcat": {
+        "description": (
+            "AAontology subcategory overview (one row per subcategory). Loaded via "
+            "load_scales(name='subcat')."),
+        "columns": {
+            COL_CAT: _field("str", "AAontology main category.", required=True,
+                            allowed_values=list(LIST_CAT), example="Energy"),
+            COL_SUBCAT: _field("str", "AAontology subcategory.", required=True,
+                               unique=True, example="Charge"),
+            COL_CLUSTER: _field("str", "Cluster the subcategory belongs to.",
+                                required=True, example="Electrostatics"),
+            COL_INTERPRET_GRADE: _field("int", "Interpretability grade, 1-10 (1 = best).",
+                                        required=True, range=[1, 10], example=2),
+            COL_TOP_EXPLAIN: _field("float", "Interpretability-tier threshold; NaN for "
+                                    "unclassified subcategories.", required=True,
+                                    nullable=True, example=0.5),
+            COL_N_SCALES: _field("int", "Number of scales in the subcategory.",
+                                 required=True, range=[1, None], example=12),
+            COL_N_SCALES_AAINDEX: _field("int", "Number of those scales originating from "
+                                         "AAindex.", required=True, range=[0, None],
+                                         example=10),
+            COL_SUBCAT_DES: _field("str", "Subcategory description.", required=True,
+                                   example="Net charge of the residue."),
+            COL_KEY_REFERENCES: _field("str", "Key literature references.", required=True,
+                                       nullable=True, example="Klein84"),
+        },
+    },
+    # --------------------------------------------------------------- outputs
+    "df_feat": {
+        "description": (
+            "CPP feature table (the primary downstream contract; see also the simple "
+            "DICT_DF_FEAT). One row per feature. Columns 1-13 are the canonical lower "
+            "bound (LIST_COLS_FEAT); optional/dynamic columns follow in stable order."),
+        "columns": {
+            COL_FEATURE: _field("str", "Opaque PART-SPLIT-SCALE feature id; split with "
+                                "split_feat_id, never parse by hand.", required=True,
+                                unique=True, validation="feature_id",
+                                example="TMD_C_JMD_C-Segment(3,4)-KLEP840101"),
+            COL_CAT: _field("str", "AAontology category of the feature's scale.",
+                            required=True, allowed_values=list(LIST_CAT), example="Energy"),
+            COL_SUBCAT: _field("str", "AAontology subcategory.", required=True,
+                               example="Charge"),
+            COL_SCALE_NAME: _field("str", "Human-readable scale name.", required=True,
+                                   example="Charge"),
+            COL_SCALE_DES: _field("str", "One-sentence scale description.", required=True,
+                                  example="Net charge (Klein et al., 1984)."),
+            COL_ABS_AUC: _field("float", "Absolute adjusted AUC; primary ranking "
+                                "statistic.", required=True, range=[-0.5, 0.5],
+                                example=0.244),
+            COL_ABS_MEAN_DIF: _field("float", "Absolute mean difference between test and "
+                                     "reference group.", required=True, range=[0, 1],
+                                     example=0.104),
+            COL_MEAN_DIF: _field("float", "Signed mean difference (test - reference); the "
+                                 "sign gives the direction.", required=True,
+                                 range=[-1, 1], example=0.104),
+            COL_STD_TEST: _field("float", "Standard deviation in the test group.",
+                                 required=True, range=[0, None], example=0.107),
+            COL_STD_REF: _field("float", "Standard deviation in the reference group.",
+                                required=True, range=[0, None], example=0.110),
+            COL_PVAL_MW: _field("float", "Mann-Whitney U p-value (default). Named "
+                                "'p_val_ttest_indep' when parametric=True.", required=True,
+                                range=[0, 1], example=0.0),
+            COL_PVAL_FDR: _field("float", "Benjamini-Hochberg FDR-corrected p-value.",
+                                 required=True, range=[0, 1], example=0.0),
+            COL_POSITION: _field("str", "Comma-separated 1-based residue positions the "
+                                 "feature spans.", required=True, example="31,32,33,34,35"),
+            COL_PVAL_TTEST: _field("float", "Independent t-test p-value; replaces "
+                                   "'p_val_mann_whitney' when parametric=True.",
+                                   required=False, range=[0, 1], example=0.01),
+            COL_AA_TEST: _field("str", "Amino acids at the feature positions in the test "
+                                "group (diagnostic).", required=False, example="K,R,K"),
+            COL_AA_REF: _field("str", "Amino acids at the feature positions in the "
+                               "reference group (diagnostic).", required=False,
+                               example="A,L,G"),
+            COL_FEAT_DES: _field("str", "Optional readable one-sentence feature "
+                                 "description.", required=False, nullable=True,
+                                 example="Charge of the C-terminal TMD segment."),
+            COL_FEAT_IMPORT: _field("float", "Feature importance from TreeModel.fit "
+                                    "(post-fit).", required=False, range=[0, None],
+                                    example=0.97),
+            COL_FEAT_IMPORT_STD: _field("float", "Std of the feature importance across CV "
+                                        "rounds (post-fit).", required=False,
+                                        range=[0, None], example=1.44),
+            COL_FEAT_IMPACT: _field("float", "SHAP-based signed feature impact from "
+                                    "ShapModel (post-fit, pro).", required=False,
+                                    example=0.12),
+            COL_FEAT_IMPACT_STD: _field("float", "Std of the feature impact (post-fit, "
+                                        "pro).", required=False, range=[0, None],
+                                        example=0.03),
+        },
+    },
+    "df_eval": {
+        "description": (
+            "Evaluation table; one row per evaluated set. Columns depend on the "
+            "evaluating class (AAclust vs dPULearn); 'name' labels the row when present."),
+        "columns": {
+            COL_NAME: _field("str", "Label of the evaluated set.", required=False,
+                             example="Set 1"),
+            "n_clusters": _field("int", "AAclust: number of clusters.", required=False,
+                                 range=[1, None], example=8),
+            "BIC": _field("float", "AAclust: Bayesian Information Criterion.",
+                          required=False, example=-1234.5),
+            "CH": _field("float", "AAclust: Calinski-Harabasz score.", required=False,
+                         range=[0, None], example=42.1),
+            "SC": _field("float", "AAclust: Silhouette Coefficient.", required=False,
+                         range=[-1, 1], example=0.34),
+            "n_rel_neg": _field("int", "dPULearn: number of reliable negatives "
+                                "identified.", required=False, range=[0, None],
+                                example=50),
+            "avg_STD": _field("float", "dPULearn: average within-group standard "
+                              "deviation.", required=False, range=[0, None], example=0.21),
+            "avg_KLD_pos": _field("float", "dPULearn: average KL divergence vs the "
+                                  "positive set.", required=False, example=0.12),
+        },
+    },
+    "df_mut": {
+        "description": (
+            "AAMut per-scale mutation effects (one row per scale for a substitution)."),
+        "columns": {
+            COL_FROM_AA: _field("str", "Substituted-from amino acid (one letter).",
+                                required=True, allowed_values=list(LIST_CANONICAL_AA),
+                                example="M"),
+            COL_TO_AA: _field("str", "Substituted-to amino acid (one letter).",
+                              required=True, allowed_values=list(LIST_CANONICAL_AA),
+                              example="V"),
+            COL_SCALE_ID: _field("str", "Amino acid scale identifier.", required=True,
+                                 example="KLEP840101"),
+            COL_CAT: _field("str", "AAontology category.", required=True,
+                            allowed_values=list(LIST_CAT), example="Energy"),
+            COL_SUBCAT: _field("str", "AAontology subcategory.", required=True,
+                               example="Charge"),
+            COL_DELTA: _field("float", "Signed per-scale substitution delta "
+                              "(to_aa - from_aa).", required=True, example=-0.31),
+            COL_ABS_DELTA: _field("float", "Magnitude of the per-scale delta.",
+                                  required=True, range=[0, None], example=0.31),
+        },
+    },
+    "df_seqmut_scan": {
+        "description": (
+            "SeqMut.scan per-mutation scan (one row per scanned single mutation)."),
+        "columns": {
+            COL_ENTRY: _field("str", "Protein/sequence identifier.", required=True,
+                              example="P05067"),
+            COL_POS: _field("int", "1-based mutated position.", required=True,
+                            range=[1, None], example=123),
+            COL_FROM_AA: _field("str", "Original amino acid.", required=True,
+                                allowed_values=list(LIST_CANONICAL_AA), example="M"),
+            COL_TO_AA: _field("str", "Substituted amino acid.", required=True,
+                              allowed_values=list(LIST_CANONICAL_AA), example="V"),
+            COL_MUTATION: _field("str", "HGVS-like label '<from><pos><to>'.",
+                                 required=True, example="M123V"),
+            COL_REGION: _field("str", "Sequence part the position falls in.",
+                               required=True, allowed_values=list(COLS_SEQ_PARTS),
+                               example="tmd"),
+            COL_DELTA_CPP: _field("float", "Sum|dX| feature-space magnitude of the "
+                                  "mutation.", required=True, range=[0, None],
+                                  example=2.4),
+            COL_SHIFT_SCORE: _field("float", "Signed shift toward the test-class "
+                                    "profile.", required=True, example=-0.8),
+        },
+    },
+    "df_seqmut_eval": {
+        "description": "SeqMut.eval per-protein/region summary (one row per region).",
+        "columns": {
+            COL_ENTRY: _field("str", "Protein/sequence identifier.", required=True,
+                              example="P05067"),
+            COL_REGION: _field("str", "Sequence part.", required=True,
+                               allowed_values=list(COLS_SEQ_PARTS), example="tmd"),
+            COL_N_MUT: _field("int", "Number of scanned mutations.", required=True,
+                              range=[0, None], example=20),
+            COL_N_DISRUPTIVE: _field("int", "Number flagged disruptive.", required=True,
+                                     range=[0, None], example=3),
+            COL_FRAC_DISRUPTIVE: _field("float", "n_disruptive / n_mut.", required=True,
+                                        range=[0, 1], example=0.15),
+            COL_MEAN_DELTA_CPP: _field("float", "Mean |delta_cpp| over scanned "
+                                       "mutations.", required=True, range=[0, None],
+                                       example=1.1),
+        },
+    },
+    "df_annot": {
+        "description": (
+            "Canonical per-residue annotation table (AnnotationPreprocessor); one row "
+            "per annotated residue/feature."),
+        "columns": {
+            COL_PROTEIN_ID: _field("str", "UniProt accession (mirrors 'entry').",
+                                   required=True, example="P05067"),
+            COL_START: _field("int", "1-based start (UniProt-canonical frame).",
+                              required=True, range=[1, None], example=672),
+            COL_STOP: _field("int", "1-based stop, inclusive (single residue: "
+                             "start==end).", required=True, range=[1, None], example=714),
+            COL_AA: _field("str", "Expected residue identity (encode-time guard).",
+                           required=True, nullable=True, example="K"),
+            COL_FEATURE_TYPE: _field("str", "Registry key (e.g. 'phospho', 'binding').",
+                                     required=True, example="binding"),
+            COL_CAT: _field("str", "Annotation category.", required=False, example="PTM"),
+            COL_SOURCE: _field("str", "'UniProt' or a user source name.", required=True,
+                               example="UniProt"),
+            COL_EVIDENCE: _field("str", "ECO evidence code.", required=False,
+                                 nullable=True, example="ECO:0000269"),
+            COL_SCORE: _field("float", "Optional annotation score.", required=False,
+                              nullable=True, range=[0, 1], example=0.9),
+            COL_BOND_ID: _field("str", "Pairing id for DISULFID / CROSSLNK endpoints.",
+                                required=False, nullable=True, example="b1"),
+        },
+    },
+    "df_logo": {
+        "description": (
+            "AAlogo composition/probability matrix consumed by sequence-logo plots."),
+        "matrix": {
+            "index": "1-based sequence position",
+            "columns": "amino acid (one-letter)",
+            "values": "per-position composition / probability / information value",
+            "dtype": "float",
+        },
+    },
+    # ------------------------------------------------ non-DataFrame contracts
+    "X": {
+        "description": (
+            "ML-ready numeric feature matrix produced by "
+            "SequenceFeature.feature_matrix; consumed by TreeModel / sklearn."),
+        "matrix": {
+            "index": "sample (row order matches df_seq / labels)",
+            "columns": "feature (column order matches df_feat['feature'])",
+            "values": "scale value of the feature for the sample",
+            "dtype": "float",
+        },
+    },
+    "prediction": {
+        "description": (
+            "TreeModel.predict_proba output: two 1-D arrays of length n_samples, "
+            "(pred, pred_std) -- the Monte-Carlo mean and standard deviation of the "
+            "positive-class probability per sample."),
+        "matrix": {
+            "index": "sample (row order matches X)",
+            "columns": "(pred, pred_std)",
+            "values": "positive-class probability in [0, 1] (pred) and its std",
+            "dtype": "float",
+        },
+    },
+}
+
+
+def _format_value(v):
+    if isinstance(v, (list, tuple)):
+        return ", ".join(str(x) for x in v)
+    return str(v)
+
+
+def render_schemas_rst():
+    """Render ``DICT_DF_SCHEMAS`` to the reStructuredText reference page (single source
+    of truth for the docs; a drift test asserts the committed page matches this output)."""
+    out = []
+    out.append(".. _df_schemas:")
+    out.append("")
+    out.append("DataFrame Schemas (Data Dictionary)")
+    out.append("===================================")
+    out.append("")
+    out.append("This page is the data dictionary for the key AAanalysis DataFrames: the "
+               "documented, test-guarded contract for the columns each frame carries. It "
+               "is generated from ``aaanalysis.utils.DICT_DF_SCHEMAS`` and kept in sync "
+               "by a contract test, so the documentation cannot drift from the code.")
+    out.append("")
+    out.append("Every column lists its dtype, whether it is required / nullable / unique, "
+               "the allowed values or numeric range where applicable, a one-line meaning, "
+               "and an example value.")
+    out.append("")
+    for frame, spec in DICT_DF_SCHEMAS.items():
+        out.append(f"``{frame}``")
+        out.append("-" * (len(frame) + 4))
+        out.append("")
+        out.append(spec["description"])
+        out.append("")
+        if "formats" in spec:
+            out.append("Accepted column formats (besides the always-required columns):")
+            out.append("")
+            for name, cols in spec["formats"].items():
+                out.append(f"- **{name}**: {', '.join(f'``{c}``' for c in cols)}")
+            out.append("")
+        if "matrix" in spec:
+            m = spec["matrix"]
+            out.append("Matrix / array contract:")
+            out.append("")
+            out.append(f"- **index**: {m['index']}")
+            out.append(f"- **columns**: {m['columns']}")
+            out.append(f"- **values**: {m['values']} (dtype: {m['dtype']})")
+            out.append("")
+            continue
+        if "dynamic_columns" in spec:
+            d = spec["dynamic_columns"]
+            out.append(f"Dynamic columns (dtype: {d['dtype']}, nullable: {d['nullable']}): "
+                       f"{d['description']} Column names are drawn from the part "
+                       f"vocabulary: {', '.join(f'``{c}``' for c in d['allowed_names'])}.")
+            out.append("")
+            continue
+        # Column table.
+        out.append(".. list-table::")
+        out.append("   :header-rows: 1")
+        out.append("   :widths: 18 8 8 8 8 34 18")
+        out.append("")
+        out.append("   * - Column\n     - Type\n     - Required\n     - Nullable\n"
+                   "     - Unique\n     - Description\n     - Allowed / range / example")
+        for col, rec in spec["columns"].items():
+            extra = []
+            if "allowed_values" in rec:
+                vals = rec["allowed_values"]
+                shown = ", ".join(str(x) for x in vals[:6]) + (", ..." if len(vals) > 6 else "")
+                extra.append(f"allowed: {shown}")
+            if "range" in rec:
+                lo, hi = rec["range"]
+                extra.append(f"range: [{lo if lo is not None else '-inf'}, "
+                             f"{hi if hi is not None else 'inf'}]")
+            if "example" in rec:
+                extra.append(f"e.g. {_format_value(rec['example'])}")
+            extra_str = "; ".join(extra) if extra else ""
+            out.append(
+                f"   * - ``{col}``\n     - {rec['dtype']}\n"
+                f"     - {'yes' if rec['required'] else 'no'}\n"
+                f"     - {'yes' if rec['nullable'] else 'no'}\n"
+                f"     - {'yes' if rec['unique'] else 'no'}\n"
+                f"     - {rec['description']}\n     - {extra_str}")
+        out.append("")
+    return "\n".join(out).rstrip() + "\n"

--- a/aaanalysis/utils.py
+++ b/aaanalysis/utils.py
@@ -111,6 +111,9 @@ from ._utils.metrics import (auc_adjusted_,
 # and are re-exported here so utils.py stays a thin import barrel; every ``ut.X`` call
 # site is unchanged.
 from ._constants import *  # noqa: F401,F403
+# Data dictionary / interface contract for the key DataFrames (df_seq, df_parts,
+# df_scales, df_cat, df_feat, ...), re-exported so it is reachable as ut.DICT_DF_SCHEMAS.
+from ._schemas import DICT_DF_SCHEMAS, render_schemas_rst  # noqa: F401
 
 # I Helper functions
 def _retrieve_string_starting_at_end(seq, start=None, end=None):

--- a/docs/source/index/usage_principles.rst
+++ b/docs/source/index/usage_principles.rst
@@ -66,5 +66,6 @@ concepts of AAanalysis are provided by the following sections:
    usage_principles/aaclust
    usage_principles/feature_identification
    usage_principles/df_feat_contract
+   usage_principles/df_schemas
    usage_principles/pu_learning
    usage_principles/xai

--- a/docs/source/index/usage_principles/df_schemas.rst
+++ b/docs/source/index/usage_principles/df_schemas.rst
@@ -1,0 +1,800 @@
+.. _df_schemas:
+
+DataFrame Schemas (Data Dictionary)
+===================================
+
+This page is the data dictionary for the key AAanalysis DataFrames: the documented, test-guarded contract for the columns each frame carries. It is generated from ``aaanalysis.utils.DICT_DF_SCHEMAS`` and kept in sync by a contract test, so the documentation cannot drift from the code.
+
+Every column lists its dtype, whether it is required / nullable / unique, the allowed values or numeric range where applicable, a one-line meaning, and an example value.
+
+``df_seq``
+----------
+
+Sequence-level input table; one row per protein/sequence. Accepts four column formats (besides the always-required 'entry'): position-based ['sequence', 'tmd_start', 'tmd_stop'], part-based ['jmd_n', 'tmd', 'jmd_c'], sequence-based ['sequence'], or sequence-TMD-based ['sequence', 'tmd'].
+
+Accepted column formats (besides the always-required columns):
+
+- **position_based**: ``sequence``, ``tmd_start``, ``tmd_stop``
+- **part_based**: ``jmd_n``, ``tmd``, ``jmd_c``
+- **sequence_based**: ``sequence``
+- **sequence_tmd_based**: ``sequence``, ``tmd``
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 8 8 8 8 34 18
+
+   * - Column
+     - Type
+     - Required
+     - Nullable
+     - Unique
+     - Description
+     - Allowed / range / example
+   * - ``entry``
+     - str
+     - yes
+     - no
+     - yes
+     - Unique protein/sequence identifier.
+     - e.g. P05067
+   * - ``sequence``
+     - str
+     - no
+     - no
+     - no
+     - Amino acid sequence (one-letter code).
+     - e.g. MLPGLALLLL...
+   * - ``tmd_start``
+     - int
+     - no
+     - no
+     - no
+     - 1-based start position of the TMD in 'sequence' (position-based format).
+     - range: [1, inf]; e.g. 37
+   * - ``tmd_stop``
+     - int
+     - no
+     - no
+     - no
+     - 1-based stop position of the TMD in 'sequence', inclusive (position-based format).
+     - range: [1, inf]; e.g. 59
+   * - ``jmd_n``
+     - str
+     - no
+     - no
+     - no
+     - N-terminal juxtamembrane domain subsequence (part-based format).
+     - e.g. NSPFYYDWHS
+   * - ``tmd``
+     - str
+     - no
+     - no
+     - no
+     - Transmembrane domain subsequence (part-/sequence-TMD formats).
+     - e.g. LQVGGLICAGVL
+   * - ``jmd_c``
+     - str
+     - no
+     - no
+     - no
+     - C-terminal juxtamembrane domain subsequence (part-based format).
+     - e.g. KCKCKFGQKS
+   * - ``label``
+     - int
+     - no
+     - no
+     - no
+     - Class/group label. Binary contrasts by convention (reference=0, test=1); multi-class via the SequenceFeature.get_labels_* helpers.
+     - e.g. 1
+   * - ``name``
+     - str
+     - no
+     - yes
+     - no
+     - Human-readable protein name.
+     - e.g. APP
+
+``df_parts``
+------------
+
+Sequence parts table consumed by CPP / SequenceFeature; one row per sequence. Columns are DYNAMIC: one column per selected sequence part, named by the part vocabulary; each value is the part's amino acid subsequence.
+
+Dynamic columns (dtype: str, nullable: False): Amino acid subsequence of the named sequence part. Column names are drawn from the part vocabulary: ``tmd``, ``tmd_e``, ``tmd_n``, ``tmd_c``, ``jmd_n``, ``jmd_c``, ``ext_c``, ``ext_n``, ``tmd_jmd``, ``jmd_n_tmd_n``, ``tmd_c_jmd_c``, ``ext_n_tmd_n``, ``tmd_c_ext_c``.
+
+``df_scales``
+-------------
+
+Amino acid scale matrix (AAontology / AAindex-derived). Loaded via load_scales; consumed by CPP / SequenceFeature.
+
+Matrix / array contract:
+
+- **index**: amino acid (one-letter; 20 canonical)
+- **columns**: scale id (e.g. 'KLEP840101')
+- **values**: min-max normalised scale value in [0, 1] (dtype: float)
+
+``df_cat``
+----------
+
+AAontology scale metadata (one row per scale id). Loaded via load_scales(name='scales_cat').
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 8 8 8 8 34 18
+
+   * - Column
+     - Type
+     - Required
+     - Nullable
+     - Unique
+     - Description
+     - Allowed / range / example
+   * - ``scale_id``
+     - str
+     - yes
+     - no
+     - yes
+     - Amino acid scale identifier; the join key to df_scales columns.
+     - e.g. KLEP840101
+   * - ``category``
+     - str
+     - yes
+     - no
+     - no
+     - AAontology main category.
+     - allowed: ASA/Volume, Composition, Conformation, Energy, Others, Polarity, ...; e.g. Energy
+   * - ``subcategory``
+     - str
+     - yes
+     - no
+     - no
+     - AAontology subcategory.
+     - e.g. Charge
+   * - ``scale_name``
+     - str
+     - yes
+     - no
+     - no
+     - Human-readable scale name.
+     - e.g. Charge
+   * - ``scale_description``
+     - str
+     - yes
+     - no
+     - no
+     - One-sentence scale description.
+     - e.g. Net charge (Klein et al., 1984).
+
+``df_subcat``
+-------------
+
+AAontology subcategory overview (one row per subcategory). Loaded via load_scales(name='subcat').
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 8 8 8 8 34 18
+
+   * - Column
+     - Type
+     - Required
+     - Nullable
+     - Unique
+     - Description
+     - Allowed / range / example
+   * - ``category``
+     - str
+     - yes
+     - no
+     - no
+     - AAontology main category.
+     - allowed: ASA/Volume, Composition, Conformation, Energy, Others, Polarity, ...; e.g. Energy
+   * - ``subcategory``
+     - str
+     - yes
+     - no
+     - yes
+     - AAontology subcategory.
+     - e.g. Charge
+   * - ``cluster``
+     - str
+     - yes
+     - no
+     - no
+     - Cluster the subcategory belongs to.
+     - e.g. Electrostatics
+   * - ``interpret_grade``
+     - int
+     - yes
+     - no
+     - no
+     - Interpretability grade, 1-10 (1 = best).
+     - range: [1, 10]; e.g. 2
+   * - ``top_explain``
+     - float
+     - yes
+     - yes
+     - no
+     - Interpretability-tier threshold; NaN for unclassified subcategories.
+     - e.g. 0.5
+   * - ``n_scales``
+     - int
+     - yes
+     - no
+     - no
+     - Number of scales in the subcategory.
+     - range: [1, inf]; e.g. 12
+   * - ``n_scales_aaindex``
+     - int
+     - yes
+     - no
+     - no
+     - Number of those scales originating from AAindex.
+     - range: [0, inf]; e.g. 10
+   * - ``subcategory_description``
+     - str
+     - yes
+     - no
+     - no
+     - Subcategory description.
+     - e.g. Net charge of the residue.
+   * - ``key_references``
+     - str
+     - yes
+     - yes
+     - no
+     - Key literature references.
+     - e.g. Klein84
+
+``df_feat``
+-----------
+
+CPP feature table (the primary downstream contract; see also the simple DICT_DF_FEAT). One row per feature. Columns 1-13 are the canonical lower bound (LIST_COLS_FEAT); optional/dynamic columns follow in stable order.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 8 8 8 8 34 18
+
+   * - Column
+     - Type
+     - Required
+     - Nullable
+     - Unique
+     - Description
+     - Allowed / range / example
+   * - ``feature``
+     - str
+     - yes
+     - no
+     - yes
+     - Opaque PART-SPLIT-SCALE feature id; split with split_feat_id, never parse by hand.
+     - e.g. TMD_C_JMD_C-Segment(3,4)-KLEP840101
+   * - ``category``
+     - str
+     - yes
+     - no
+     - no
+     - AAontology category of the feature's scale.
+     - allowed: ASA/Volume, Composition, Conformation, Energy, Others, Polarity, ...; e.g. Energy
+   * - ``subcategory``
+     - str
+     - yes
+     - no
+     - no
+     - AAontology subcategory.
+     - e.g. Charge
+   * - ``scale_name``
+     - str
+     - yes
+     - no
+     - no
+     - Human-readable scale name.
+     - e.g. Charge
+   * - ``scale_description``
+     - str
+     - yes
+     - no
+     - no
+     - One-sentence scale description.
+     - e.g. Net charge (Klein et al., 1984).
+   * - ``abs_auc``
+     - float
+     - yes
+     - no
+     - no
+     - Absolute adjusted AUC; primary ranking statistic.
+     - range: [-0.5, 0.5]; e.g. 0.244
+   * - ``abs_mean_dif``
+     - float
+     - yes
+     - no
+     - no
+     - Absolute mean difference between test and reference group.
+     - range: [0, 1]; e.g. 0.104
+   * - ``mean_dif``
+     - float
+     - yes
+     - no
+     - no
+     - Signed mean difference (test - reference); the sign gives the direction.
+     - range: [-1, 1]; e.g. 0.104
+   * - ``std_test``
+     - float
+     - yes
+     - no
+     - no
+     - Standard deviation in the test group.
+     - range: [0, inf]; e.g. 0.107
+   * - ``std_ref``
+     - float
+     - yes
+     - no
+     - no
+     - Standard deviation in the reference group.
+     - range: [0, inf]; e.g. 0.11
+   * - ``p_val_mann_whitney``
+     - float
+     - yes
+     - no
+     - no
+     - Mann-Whitney U p-value (default). Named 'p_val_ttest_indep' when parametric=True.
+     - range: [0, 1]; e.g. 0.0
+   * - ``p_val_fdr_bh``
+     - float
+     - yes
+     - no
+     - no
+     - Benjamini-Hochberg FDR-corrected p-value.
+     - range: [0, 1]; e.g. 0.0
+   * - ``positions``
+     - str
+     - yes
+     - no
+     - no
+     - Comma-separated 1-based residue positions the feature spans.
+     - e.g. 31,32,33,34,35
+   * - ``p_val_ttest_indep``
+     - float
+     - no
+     - no
+     - no
+     - Independent t-test p-value; replaces 'p_val_mann_whitney' when parametric=True.
+     - range: [0, 1]; e.g. 0.01
+   * - ``amino_acids_test``
+     - str
+     - no
+     - no
+     - no
+     - Amino acids at the feature positions in the test group (diagnostic).
+     - e.g. K,R,K
+   * - ``amino_acids_ref``
+     - str
+     - no
+     - no
+     - no
+     - Amino acids at the feature positions in the reference group (diagnostic).
+     - e.g. A,L,G
+   * - ``feature_description``
+     - str
+     - no
+     - yes
+     - no
+     - Optional readable one-sentence feature description.
+     - e.g. Charge of the C-terminal TMD segment.
+   * - ``feat_importance``
+     - float
+     - no
+     - no
+     - no
+     - Feature importance from TreeModel.fit (post-fit).
+     - range: [0, inf]; e.g. 0.97
+   * - ``feat_importance_std``
+     - float
+     - no
+     - no
+     - no
+     - Std of the feature importance across CV rounds (post-fit).
+     - range: [0, inf]; e.g. 1.44
+   * - ``feat_impact``
+     - float
+     - no
+     - no
+     - no
+     - SHAP-based signed feature impact from ShapModel (post-fit, pro).
+     - e.g. 0.12
+   * - ``feat_impact_std``
+     - float
+     - no
+     - no
+     - no
+     - Std of the feature impact (post-fit, pro).
+     - range: [0, inf]; e.g. 0.03
+
+``df_eval``
+-----------
+
+Evaluation table; one row per evaluated set. Columns depend on the evaluating class (AAclust vs dPULearn); 'name' labels the row when present.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 8 8 8 8 34 18
+
+   * - Column
+     - Type
+     - Required
+     - Nullable
+     - Unique
+     - Description
+     - Allowed / range / example
+   * - ``name``
+     - str
+     - no
+     - no
+     - no
+     - Label of the evaluated set.
+     - e.g. Set 1
+   * - ``n_clusters``
+     - int
+     - no
+     - no
+     - no
+     - AAclust: number of clusters.
+     - range: [1, inf]; e.g. 8
+   * - ``BIC``
+     - float
+     - no
+     - no
+     - no
+     - AAclust: Bayesian Information Criterion.
+     - e.g. -1234.5
+   * - ``CH``
+     - float
+     - no
+     - no
+     - no
+     - AAclust: Calinski-Harabasz score.
+     - range: [0, inf]; e.g. 42.1
+   * - ``SC``
+     - float
+     - no
+     - no
+     - no
+     - AAclust: Silhouette Coefficient.
+     - range: [-1, 1]; e.g. 0.34
+   * - ``n_rel_neg``
+     - int
+     - no
+     - no
+     - no
+     - dPULearn: number of reliable negatives identified.
+     - range: [0, inf]; e.g. 50
+   * - ``avg_STD``
+     - float
+     - no
+     - no
+     - no
+     - dPULearn: average within-group standard deviation.
+     - range: [0, inf]; e.g. 0.21
+   * - ``avg_KLD_pos``
+     - float
+     - no
+     - no
+     - no
+     - dPULearn: average KL divergence vs the positive set.
+     - e.g. 0.12
+
+``df_mut``
+----------
+
+AAMut per-scale mutation effects (one row per scale for a substitution).
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 8 8 8 8 34 18
+
+   * - Column
+     - Type
+     - Required
+     - Nullable
+     - Unique
+     - Description
+     - Allowed / range / example
+   * - ``from_aa``
+     - str
+     - yes
+     - no
+     - no
+     - Substituted-from amino acid (one letter).
+     - allowed: A, C, D, E, F, G, ...; e.g. M
+   * - ``to_aa``
+     - str
+     - yes
+     - no
+     - no
+     - Substituted-to amino acid (one letter).
+     - allowed: A, C, D, E, F, G, ...; e.g. V
+   * - ``scale_id``
+     - str
+     - yes
+     - no
+     - no
+     - Amino acid scale identifier.
+     - e.g. KLEP840101
+   * - ``category``
+     - str
+     - yes
+     - no
+     - no
+     - AAontology category.
+     - allowed: ASA/Volume, Composition, Conformation, Energy, Others, Polarity, ...; e.g. Energy
+   * - ``subcategory``
+     - str
+     - yes
+     - no
+     - no
+     - AAontology subcategory.
+     - e.g. Charge
+   * - ``delta``
+     - float
+     - yes
+     - no
+     - no
+     - Signed per-scale substitution delta (to_aa - from_aa).
+     - e.g. -0.31
+   * - ``abs_delta``
+     - float
+     - yes
+     - no
+     - no
+     - Magnitude of the per-scale delta.
+     - range: [0, inf]; e.g. 0.31
+
+``df_seqmut_scan``
+------------------
+
+SeqMut.scan per-mutation scan (one row per scanned single mutation).
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 8 8 8 8 34 18
+
+   * - Column
+     - Type
+     - Required
+     - Nullable
+     - Unique
+     - Description
+     - Allowed / range / example
+   * - ``entry``
+     - str
+     - yes
+     - no
+     - no
+     - Protein/sequence identifier.
+     - e.g. P05067
+   * - ``pos``
+     - int
+     - yes
+     - no
+     - no
+     - 1-based mutated position.
+     - range: [1, inf]; e.g. 123
+   * - ``from_aa``
+     - str
+     - yes
+     - no
+     - no
+     - Original amino acid.
+     - allowed: A, C, D, E, F, G, ...; e.g. M
+   * - ``to_aa``
+     - str
+     - yes
+     - no
+     - no
+     - Substituted amino acid.
+     - allowed: A, C, D, E, F, G, ...; e.g. V
+   * - ``mutation``
+     - str
+     - yes
+     - no
+     - no
+     - HGVS-like label '<from><pos><to>'.
+     - e.g. M123V
+   * - ``region``
+     - str
+     - yes
+     - no
+     - no
+     - Sequence part the position falls in.
+     - allowed: jmd_n, tmd, jmd_c; e.g. tmd
+   * - ``delta_cpp``
+     - float
+     - yes
+     - no
+     - no
+     - Sum|dX| feature-space magnitude of the mutation.
+     - range: [0, inf]; e.g. 2.4
+   * - ``shift_score``
+     - float
+     - yes
+     - no
+     - no
+     - Signed shift toward the test-class profile.
+     - e.g. -0.8
+
+``df_seqmut_eval``
+------------------
+
+SeqMut.eval per-protein/region summary (one row per region).
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 8 8 8 8 34 18
+
+   * - Column
+     - Type
+     - Required
+     - Nullable
+     - Unique
+     - Description
+     - Allowed / range / example
+   * - ``entry``
+     - str
+     - yes
+     - no
+     - no
+     - Protein/sequence identifier.
+     - e.g. P05067
+   * - ``region``
+     - str
+     - yes
+     - no
+     - no
+     - Sequence part.
+     - allowed: jmd_n, tmd, jmd_c; e.g. tmd
+   * - ``n_mut``
+     - int
+     - yes
+     - no
+     - no
+     - Number of scanned mutations.
+     - range: [0, inf]; e.g. 20
+   * - ``n_disruptive``
+     - int
+     - yes
+     - no
+     - no
+     - Number flagged disruptive.
+     - range: [0, inf]; e.g. 3
+   * - ``frac_disruptive``
+     - float
+     - yes
+     - no
+     - no
+     - n_disruptive / n_mut.
+     - range: [0, 1]; e.g. 0.15
+   * - ``mean_delta_cpp``
+     - float
+     - yes
+     - no
+     - no
+     - Mean |delta_cpp| over scanned mutations.
+     - range: [0, inf]; e.g. 1.1
+
+``df_annot``
+------------
+
+Canonical per-residue annotation table (AnnotationPreprocessor); one row per annotated residue/feature.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 8 8 8 8 34 18
+
+   * - Column
+     - Type
+     - Required
+     - Nullable
+     - Unique
+     - Description
+     - Allowed / range / example
+   * - ``protein_id``
+     - str
+     - yes
+     - no
+     - no
+     - UniProt accession (mirrors 'entry').
+     - e.g. P05067
+   * - ``start``
+     - int
+     - yes
+     - no
+     - no
+     - 1-based start (UniProt-canonical frame).
+     - range: [1, inf]; e.g. 672
+   * - ``end``
+     - int
+     - yes
+     - no
+     - no
+     - 1-based stop, inclusive (single residue: start==end).
+     - range: [1, inf]; e.g. 714
+   * - ``aa``
+     - str
+     - yes
+     - yes
+     - no
+     - Expected residue identity (encode-time guard).
+     - e.g. K
+   * - ``feature_type``
+     - str
+     - yes
+     - no
+     - no
+     - Registry key (e.g. 'phospho', 'binding').
+     - e.g. binding
+   * - ``category``
+     - str
+     - no
+     - no
+     - no
+     - Annotation category.
+     - e.g. PTM
+   * - ``source``
+     - str
+     - yes
+     - no
+     - no
+     - 'UniProt' or a user source name.
+     - e.g. UniProt
+   * - ``evidence``
+     - str
+     - no
+     - yes
+     - no
+     - ECO evidence code.
+     - e.g. ECO:0000269
+   * - ``score``
+     - float
+     - no
+     - yes
+     - no
+     - Optional annotation score.
+     - range: [0, 1]; e.g. 0.9
+   * - ``bond_id``
+     - str
+     - no
+     - yes
+     - no
+     - Pairing id for DISULFID / CROSSLNK endpoints.
+     - e.g. b1
+
+``df_logo``
+-----------
+
+AAlogo composition/probability matrix consumed by sequence-logo plots.
+
+Matrix / array contract:
+
+- **index**: 1-based sequence position
+- **columns**: amino acid (one-letter)
+- **values**: per-position composition / probability / information value (dtype: float)
+
+``X``
+-----
+
+ML-ready numeric feature matrix produced by SequenceFeature.feature_matrix; consumed by TreeModel / sklearn.
+
+Matrix / array contract:
+
+- **index**: sample (row order matches df_seq / labels)
+- **columns**: feature (column order matches df_feat['feature'])
+- **values**: scale value of the feature for the sample (dtype: float)
+
+``prediction``
+--------------
+
+TreeModel.predict_proba output: two 1-D arrays of length n_samples, (pred, pred_std) -- the Monte-Carlo mean and standard deviation of the positive-class probability per sample.
+
+Matrix / array contract:
+
+- **index**: sample (row order matches X)
+- **columns**: (pred, pred_std)
+- **values**: positive-class probability in [0, 1] (pred) and its std (dtype: float)

--- a/tests/unit/api_tests/test_df_schemas.py
+++ b/tests/unit/api_tests/test_df_schemas.py
@@ -1,0 +1,173 @@
+"""This is a script to test the DataFrame data dictionary / interface contract
+(``ut.DICT_DF_SCHEMAS``) for the key AAanalysis DataFrames.
+
+Three layers, all guarded so drift is detectable in CI:
+- structural: every frame + field record is well-formed, and the rich df_feat view agrees
+  with the simple ``ut.DICT_DF_FEAT``;
+- golden conformance: real frames (load_dataset / get_df_parts / load_scales /
+  load_features / AAlogo) satisfy their schema (columns, dtypes, ranges, uniqueness);
+- cross-frame contract: a real df_feat references valid scales/parts/categories, and its
+  numeric columns are finite and in range;
+- doc sync: the committed schemas doc page matches the rendered registry.
+"""
+import pathlib
+import re
+
+import numpy as np
+import pandas.api.types as pdt
+import pytest
+
+import aaanalysis as aa
+import aaanalysis.utils as ut
+
+aa.options["verbose"] = False
+
+
+def _kind(series):
+    if pdt.is_bool_dtype(series):
+        return "bool"
+    if pdt.is_float_dtype(series):
+        return "float"
+    if pdt.is_integer_dtype(series):
+        return "int"
+    if pdt.is_string_dtype(series) or series.dtype == object:
+        return "str"
+    return str(series.dtype)
+
+
+# --------------------------------------------------------------------------- fixtures
+@pytest.fixture(scope="module")
+def df_seq():
+    return aa.load_dataset(name="DOM_GSEC", n=5)
+
+
+@pytest.fixture(scope="module")
+def df_feat():
+    return aa.load_features()
+
+
+@pytest.fixture(scope="module")
+def df_cat():
+    return aa.load_scales(name="scales_cat")
+
+
+@pytest.fixture(scope="module")
+def df_scales():
+    return aa.load_scales()
+
+
+# ------------------------------------------------------------------------- structural
+class TestSchemaStructure:
+    def test_every_frame_documented(self):
+        for frame, spec in ut.DICT_DF_SCHEMAS.items():
+            assert isinstance(spec.get("description"), str) and spec["description"]
+            assert any(k in spec for k in ("columns", "matrix", "dynamic_columns")), frame
+
+    def test_field_records_well_formed(self):
+        for frame, spec in ut.DICT_DF_SCHEMAS.items():
+            for col, rec in spec.get("columns", {}).items():
+                assert rec["dtype"] in {"str", "float", "int", "bool"}, (frame, col)
+                assert isinstance(rec["required"], bool)
+                assert isinstance(rec["nullable"], bool)
+                assert isinstance(rec["unique"], bool)
+                assert isinstance(rec["description"], str) and rec["description"].endswith(".")
+                if "range" in rec:
+                    assert len(rec["range"]) == 2
+                if "allowed_values" in rec:
+                    assert isinstance(rec["allowed_values"], list) and rec["allowed_values"]
+
+    def test_expected_frames_present(self):
+        for frame in ["df_seq", "df_parts", "df_scales", "df_cat", "df_subcat",
+                      "df_feat", "df_eval", "X", "prediction"]:
+            assert frame in ut.DICT_DF_SCHEMAS
+
+    def test_rich_df_feat_agrees_with_simple_dict(self):
+        # The rich registry and the simple DICT_DF_FEAT must not drift on the df_feat
+        # columns (set, required flag, dtype).
+        rich = ut.DICT_DF_SCHEMAS["df_feat"]["columns"]
+        simple = ut.DICT_DF_FEAT
+        assert set(rich) == set(simple)
+        for col, (dtype, required, nullable, _semantics) in simple.items():
+            assert rich[col]["dtype"] == dtype, col
+            assert rich[col]["required"] == required, col
+
+
+# -------------------------------------------------------------------- golden conformance
+class TestGoldenConformance:
+    @staticmethod
+    def _check_columns(df, schema_cols):
+        for col in df.columns:
+            if col not in schema_cols:
+                continue  # dynamic / post-fit extra column
+            rec = schema_cols[col]
+            assert _kind(df[col]) == rec["dtype"], f"{col}: dtype kind drift"
+            if rec["required"] and not rec["nullable"]:
+                assert df[col].notna().all(), f"{col} unexpectedly NaN"
+            if rec["unique"]:
+                assert df[col].is_unique, f"{col} not unique"
+            if "range" in rec and _kind(df[col]) in {"int", "float"}:
+                lo, hi = rec["range"]
+                vals = df[col].dropna()
+                if lo is not None:
+                    assert (vals >= lo - 1e-9).all(), f"{col} below range"
+                if hi is not None:
+                    assert (vals <= hi + 1e-9).all(), f"{col} above range"
+
+    def test_df_seq_conforms(self, df_seq):
+        self._check_columns(df_seq, ut.DICT_DF_SCHEMAS["df_seq"]["columns"])
+        assert ut.COL_ENTRY in df_seq.columns and df_seq[ut.COL_ENTRY].is_unique
+
+    def test_df_cat_conforms(self, df_cat):
+        self._check_columns(df_cat, ut.DICT_DF_SCHEMAS["df_cat"]["columns"])
+
+    def test_df_feat_conforms(self, df_feat):
+        self._check_columns(df_feat, ut.DICT_DF_SCHEMAS["df_feat"]["columns"])
+
+    def test_df_parts_dynamic_columns(self):
+        df_parts = aa.SequenceFeature().get_df_parts(df_seq=aa.load_dataset(name="DOM_GSEC", n=3))
+        allowed = set(ut.DICT_DF_SCHEMAS["df_parts"]["dynamic_columns"]["allowed_names"])
+        assert set(df_parts.columns).issubset(allowed)
+        assert all(_kind(df_parts[c]) == "str" for c in df_parts.columns)
+
+    def test_df_scales_matrix(self, df_scales):
+        spec = ut.DICT_DF_SCHEMAS["df_scales"]["matrix"]
+        assert spec["dtype"] == "float"
+        assert pdt.is_float_dtype(df_scales.iloc[:, 0])
+        assert set(df_scales.index).issubset(set(ut.LIST_CANONICAL_AA))
+
+
+# ---------------------------------------------------------------------- cross-frame
+class TestCrossFrameContract:
+    def test_feature_id_references_valid_scale_and_part(self, df_feat, df_scales):
+        valid_scales = set(df_scales.columns)
+        valid_parts = set(ut.LIST_ALL_PARTS)
+        for feat_id in df_feat[ut.COL_FEATURE]:
+            part, split, scale_id = ut.split_feat_id(feat_id)
+            assert scale_id in valid_scales, f"{scale_id} not in df_scales"
+            # The feature id uppercases the part name (e.g. 'TMD_C_JMD_C').
+            assert part.lower() in valid_parts, f"{part} not a known part"
+            assert split.startswith(("Segment", "Pattern", "PeriodicPattern"))
+
+    def test_feature_unique(self, df_feat):
+        assert df_feat[ut.COL_FEATURE].is_unique
+
+    def test_category_in_allowed_values(self, df_feat):
+        allowed = set(ut.DICT_DF_SCHEMAS["df_feat"]["columns"][ut.COL_CAT]["allowed_values"])
+        assert set(df_feat[ut.COL_CAT]).issubset(allowed)
+
+    def test_numeric_columns_finite_and_in_range(self, df_feat):
+        for col, rec in ut.DICT_DF_SCHEMAS["df_feat"]["columns"].items():
+            if rec["dtype"] != "float" or col not in df_feat.columns:
+                continue
+            vals = df_feat[col].to_numpy(dtype=float)
+            assert np.isfinite(vals).all(), f"{col} has non-finite values"
+
+
+# ------------------------------------------------------------------------- doc sync
+class TestDocSync:
+    def test_committed_doc_matches_registry(self):
+        doc = (pathlib.Path(aa.__file__).resolve().parent.parent
+               / "docs/source/index/usage_principles/df_schemas.rst")
+        assert doc.exists(), "df_schemas.rst not generated"
+        assert doc.read_text() == ut.render_schemas_rst(), (
+            "df_schemas.rst out of sync; run .github/scripts/gen_df_schemas_doc.py")


### PR DESCRIPTION
## What
Generalises the df_feat data dictionary (#234) into a **contract-grade registry for the whole DataFrame family** — the frames an agent/user constructs, reads, and consumes — per your spec (dtype, required, nullable, unique, allowed_values, range, description, example; auto-rendered docs; cross-frame tests).

- **`ut.DICT_DF_SCHEMAS`** (`aaanalysis/_schemas.py`): machine-readable registry; each frame = a description + per-column field records. Covers:
  - **inputs**: `df_seq` (incl. its 4 conditional formats), `df_parts` (dynamic part columns)
  - **reference**: `df_scales` (matrix), `df_cat`, `df_subcat`
  - **outputs**: `df_feat`, `df_eval`, `df_mut` (AAMut), `df_seqmut_scan/eval` (SeqMut), `df_annot`, `df_logo`
  - **non-table contracts**: `X` feature matrix, `prediction` arrays (documented by shape)
  - Imports only `._constants` (circular-free); re-exported as `ut.DICT_DF_SCHEMAS`.
- **Auto-rendered docs**: `render_schemas_rst()` is the single source for a generated usage-principles page; `.github/scripts/gen_df_schemas_doc.py` writes it (`--check` verifies sync), wired into the toctree.
- **Contract-grade tests** (`test_df_schemas.py`): structural well-formedness; the rich df_feat view agrees with the simple `DICT_DF_FEAT` (no drift); **golden conformance** of real frames to dtypes/ranges/uniqueness; **cross-frame integrity** (every `df_feat` feature id references a real scale + part, `category` ∈ allowed values, numerics finite/in-range); and a **doc-drift guard** (committed page == rendered registry).

## Design choices
- **Python dict, not YAML** — YAML would need a runtime dep (`pyyaml`) + a `pyproject.toml` edit (CONFIRM-FIRST / no-new-deps). The dict is machine-readable and the docs + tests generate straight from it. Say the word if you want YAML and I'll wire it with your dep approval.
- **Additive** — the only new public symbol is `ut.DICT_DF_SCHEMAS`; no `__init__.py`/`__all__` change. The simple `DICT_DF_FEAT` from #234 stays and is kept consistent by a test.
- One cross-frame test surfaced a real detail now documented: the feature-id **PART is uppercased** (`TMD_C_JMD_C`) vs the lowercase part vocabulary.

## Verification
- `test_df_schemas` (28 with the related contract tests) + `api_tests` + `utils_tests` + `smoke`: **203 passed**.
- Generated RST validated with docutils (0 system messages); no `:class:` roles → no cross-ref warnings (RTD builds it on the PR once retargeted).

## Note for reviewer
**5th in the stack**, base `refactor/pyright-burndown` (#237) → merges after the others. Slight overlap with #234's `df_feat_contract.rst` (narrative) vs this generated reference — easy to consolidate later if you prefer one page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)