### PR TITLE
refactor(types): honest required-arg signatures across the public API

### DIFF
--- a/.claude/rules/code-conventions.md
+++ b/.claude/rules/code-conventions.md
@@ -88,14 +88,40 @@ directly.
 
 ## Type hints
 
-- Annotate every public parameter and return type. Use `Optional[...]` for
-  `None`-defaults.
-- Avoid `pd.DataFrame = None` for required args. Either accept `None`
-  honestly (and `check_df_seq(accept_none=True)`) or make the arg required
-  by removing the default.
+- Annotate every public parameter and return type. Use `Optional[...]` **only**
+  for params that genuinely accept `None` (the Validate block passes
+  `accept_none=True` or `None` carries a real meaning). `Optional[T] = None` on
+  an argument the check then *rejects* is a lie — it advertises `None` as valid
+  when the call raises.
+- **Required args carry no default and no `Optional`.** Never write
+  `df_feat: pd.DataFrame = None` for an argument that must be given (the
+  Validate block would reject `None` anyway — the `Optional[...] = None` then
+  lies). Make it required by removing the default: `df_feat: pd.DataFrame`.
+  Required args that lead the signature stay **positional-or-keyword** (no `*`
+  separator — see `frontend-backend.md`); positional remains allowed so dropping
+  a stale `= None` is non-breaking. Place required args before any defaulted arg
+  (Python forbids a non-default after a default). When a required arg must sit
+  **after** a defaulted one and can't be reordered without breaking positional
+  callers, resolve it in priority order: (1) if a canonical default exists, give
+  it one and keep `Optional[T] = None` honestly (e.g. `df_cat` defaults to
+  `ut.load_default_scales(scale_cat=True)`); else (2) make it **keyword-only**
+  with a `*` before it — `def feature(self, feature, feat_rank=1, *, df_seq,
+  labels, ...)`. This `*` for an otherwise-stranded required arg is the **only**
+  sanctioned `*` use; never add `*` merely to force keywords on args that could
+  lead.
 - Use `ut.ArrayLike1D` / `ut.ArrayLike2D` for numpy/list duck types.
 - **No type checker runs in CI.** Local IDE-side type checking (Pylance in
   VS Code) is up to the contributor.
+
+## Blank lines between methods (hard rule, test-enforced)
+
+Two consecutive methods in a class body MUST be separated by at least one blank
+line (PEP 8 E301). A `return` glued directly to the next `def` is a defect, not a
+style preference. Because readable code review has missed this, it is enforced
+programmatically by `tests/unit/api_tests/test_style_method_spacing.py` (AST
+scan over the whole package). The check is narrow on purpose — it flags only
+method-after-method spacing, not the blank line between a class docstring and the
+first method.
 
 ## Linting and Python floor
 

--- a/.claude/rules/frontend-backend.md
+++ b/.claude/rules/frontend-backend.md
@@ -13,10 +13,17 @@ policy.
 
 ## Signatures
 
-Frontend (public methods) and backend functions both use
-positional-or-keyword parameters with sklearn-style defaults. Pass kwargs
-explicitly at call sites (`func(name=value)`) for readability — enforced by
-code review, not by `*` separators in the signature.
+Frontend (public methods) and backend functions use positional-or-keyword
+parameters: required args first (no default, no `Optional`), then optional args
+with sklearn-style defaults. Pass kwargs explicitly at call sites
+(`func(name=value)`) for readability — enforced by code review, **not** by `*`
+separators in the signature. Required args have no default and no `Optional`
+(see `code-conventions.md` → Type hints) but stay positional-or-keyword, so
+removing a stale `= None` from a required arg is non-breaking (keyword and
+positional calls both keep working). The single exception: a required arg that
+must sit after a defaulted one (can't lead, no canonical default) becomes
+**keyword-only** with a `*` — that is the only sanctioned `*`. Never add `*`
+merely to force keywords on args that could lead.
 
 ## Validation
 

--- a/aaanalysis/data_handling/_combine_dict_nums.py
+++ b/aaanalysis/data_handling/_combine_dict_nums.py
@@ -71,7 +71,7 @@ def _check_arrays_shape_per_entry(
 
 # II Main Functions
 def combine_dict_nums(
-    dict_nums: Optional[List[Dict[str, np.ndarray]]] = None,
+    dict_nums: List[Dict[str, np.ndarray]],
 ) -> Dict[str, np.ndarray]:
     """Concatenate multiple per-residue ``dict_num`` inputs along the D axis.
 

--- a/aaanalysis/data_handling/_embed_preproc.py
+++ b/aaanalysis/data_handling/_embed_preproc.py
@@ -133,8 +133,8 @@ class EmbeddingPreprocessor:
 
     def encode(
         self,
-        df_seq: Optional[pd.DataFrame] = None,
-        embeddings: Optional[Dict[str, np.ndarray]] = None,
+        df_seq: pd.DataFrame,
+        embeddings: Dict[str, np.ndarray],
         method: Literal["minmax", "quantile", "sigmoid"] = "minmax",
         clip: Tuple[float, float] = (1.0, 99.0),
         return_df: bool = False,
@@ -229,8 +229,8 @@ class EmbeddingPreprocessor:
 
     def build_scales(
         self,
-        df_seq: Optional[pd.DataFrame] = None,
-        dict_num: Optional[Dict[str, np.ndarray]] = None,
+        df_seq: pd.DataFrame,
+        dict_num: Dict[str, np.ndarray],
         return_std: bool = False,
     ) -> Union[pd.DataFrame, Tuple[pd.DataFrame, pd.DataFrame]]:
         """
@@ -325,7 +325,7 @@ class EmbeddingPreprocessor:
 
     def build_cat(
         self,
-        df_scales: Optional[pd.DataFrame] = None,
+        df_scales: pd.DataFrame,
         df_stds: Optional[pd.DataFrame] = None,
         cat_min_th: float = 0.5,
         subcat_min_th: float = 0.7,
@@ -440,7 +440,7 @@ class EmbeddingPreprocessor:
 
     def fetch_embeddings(
         self,
-        df_seq: Optional[pd.DataFrame] = None,
+        df_seq: pd.DataFrame,
         mode: Literal["protein", "residue"] = "protein",
         model: Literal["esm2_t6_8M", "esm2_t12_35M", "esm2_t30_150M",
                        "esm2_t33_650M", "esm2_t36_3B", "esm1b",
@@ -681,7 +681,7 @@ class EmbeddingPreprocessor:
 
     def pool_embeddings(
         self,
-        embeddings: Optional[Dict[str, np.ndarray]] = None,
+        embeddings: Dict[str, np.ndarray],
         pooling: Literal["mean", "max"] = "mean",
         df_seq: Optional[pd.DataFrame] = None,
     ) -> Union[Dict[str, np.ndarray], np.ndarray]:

--- a/aaanalysis/data_handling/_seq_preproc.py
+++ b/aaanalysis/data_handling/_seq_preproc.py
@@ -132,7 +132,7 @@ class SequencePreprocessor:
 
     # Sequence encoding
     @staticmethod
-    def encode_one_hot(list_seq: Optional[Union[List[str], str]] = None,
+    def encode_one_hot(list_seq: Union[List[str], str],
                        alphabet: str = "ACDEFGHIKLMNPQRSTVWY",
                        gap: str = "-",
                        pad_at: Literal["C", "N"] = "C",
@@ -187,7 +187,7 @@ class SequencePreprocessor:
         return X, features
 
     @staticmethod
-    def encode_integer(list_seq: Optional[Union[List[str], str]] = None,
+    def encode_integer(list_seq: Union[List[str], str],
                        alphabet: str = "ACDEFGHIKLMNPQRSTVWY",
                        gap: str = "-",
                        pad_at: Literal["C", "N"] = "C",
@@ -240,7 +240,7 @@ class SequencePreprocessor:
         return X, features
 
     @staticmethod
-    def get_aa_window(seq: Optional[str] = None,
+    def get_aa_window(seq: str,
                       pos_start: int = 0,
                       pos_stop: Optional[int] = None,
                       window_size: Optional[int] = None,
@@ -313,7 +313,7 @@ class SequencePreprocessor:
         return window
 
     @staticmethod
-    def get_sliding_aa_window(seq: Optional[str] = None,
+    def get_sliding_aa_window(seq: str,
                               slide_start: int = 0,
                               slide_stop: Optional[int] = None,
                               window_size: int = 5,

--- a/aaanalysis/data_handling/_to_fasta.py
+++ b/aaanalysis/data_handling/_to_fasta.py
@@ -13,8 +13,8 @@ from ._backend.parse_fasta import save_entries_to_fasta
 
 
 # II Main Functions
-def to_fasta(df_seq: Optional[pd.DataFrame] = None,
-             file_path: Optional[str] = None,
+def to_fasta(df_seq: pd.DataFrame,
+             file_path: str,
              col_id: str = "entry",
              col_seq: str = "sequence",
              sep: str = "|",

--- a/aaanalysis/data_handling_pro/_annot_preproc.py
+++ b/aaanalysis/data_handling_pro/_annot_preproc.py
@@ -164,7 +164,7 @@ class AnnotationPreprocessor:
     # ------------------------------------------------------------------
     def fetch_uniprot(
         self,
-        df_seq: Optional[pd.DataFrame] = None,
+        df_seq: pd.DataFrame,
         features: Optional[List[str]] = None,
         evidence: Literal["experimental", "manual", "all"] = "manual",
         timeout: float = 30.0,
@@ -252,7 +252,7 @@ class AnnotationPreprocessor:
     # ------------------------------------------------------------------
     # ingest
     # ------------------------------------------------------------------
-    def ingest(self, df_user: Optional[pd.DataFrame] = None) -> pd.DataFrame:
+    def ingest(self, df_user: pd.DataFrame) -> pd.DataFrame:
         """Ingest a user / predictor annotation table into ``df_annot``.
 
         Every ingested ``feature_type`` is treated as a ``'Functional sites'``
@@ -348,7 +348,7 @@ class AnnotationPreprocessor:
     # ------------------------------------------------------------------
     def register_feature(
         self,
-        key: Optional[str] = None,
+        key: str,
         subcategory: Optional[str] = None,
         normalization: Optional[Callable] = None,
     ) -> None:
@@ -399,9 +399,9 @@ class AnnotationPreprocessor:
     # ------------------------------------------------------------------
     def encode(
         self,
-        df_seq: Optional[pd.DataFrame] = None,
-        df_annot: Optional[pd.DataFrame] = None,
-        features: Optional[List[str]] = None,
+        df_seq: pd.DataFrame,
+        df_annot: pd.DataFrame,
+        features: List[str],
         on_mismatch: Literal["raise", "drop", "warn"] = "raise",
         return_df: bool = False,
     ) -> Union[Dict[str, np.ndarray], Tuple[Dict[str, np.ndarray], pd.DataFrame]]:
@@ -545,9 +545,9 @@ class AnnotationPreprocessor:
     # ------------------------------------------------------------------
     def build_scales(
         self,
-        df_seq: Optional[pd.DataFrame] = None,
-        dict_num: Optional[Dict[str, np.ndarray]] = None,
-        features: Optional[List[str]] = None,
+        df_seq: pd.DataFrame,
+        dict_num: Dict[str, np.ndarray],
+        features: List[str],
         return_std: bool = False,
         dim_names_override: Optional[List[str]] = None,
     ) -> Union[pd.DataFrame, Tuple[pd.DataFrame, pd.DataFrame]]:
@@ -689,7 +689,7 @@ class AnnotationPreprocessor:
     # ------------------------------------------------------------------
     def build_cat(
         self,
-        features: Optional[List[str]] = None,
+        features: List[str],
         dim_names_override: Optional[List[str]] = None,
     ) -> pd.DataFrame:
         """Build the ``df_cat`` metadata frame for ``features`` (corpus-free).
@@ -745,9 +745,9 @@ class AnnotationPreprocessor:
     # ------------------------------------------------------------------
     def to_df_seq(
         self,
-        df_seq: Optional[pd.DataFrame] = None,
-        df_annot: Optional[pd.DataFrame] = None,
-        feature_type: Optional[str] = None,
+        df_seq: pd.DataFrame,
+        df_annot: pd.DataFrame,
+        feature_type: str,
         match_residue_type: bool = True,
         exclude_other_annotations: bool = True,
         pos_col: Optional[str] = None,

--- a/aaanalysis/data_handling_pro/_struct_preproc.py
+++ b/aaanalysis/data_handling_pro/_struct_preproc.py
@@ -459,8 +459,8 @@ class StructurePreprocessor:
     # ------------------------------------------------------------------
     def fetch_alphafold(
         self,
-        df_seq: Optional[pd.DataFrame] = None,
-        out_folder: Optional[Union[str, Path]] = None,
+        df_seq: pd.DataFrame,
+        out_folder: Union[str, Path],
         file_format: Literal["pdb", "cif"] = "pdb",
         timeout: float = 30.0,
         skip_existing: bool = True,
@@ -605,8 +605,8 @@ class StructurePreprocessor:
     # ------------------------------------------------------------------
     def get_dssp(
         self,
-        df_seq: Optional[pd.DataFrame] = None,
-        pdb_folder: Optional[Union[str, Path]] = None,
+        df_seq: pd.DataFrame,
+        pdb_folder: Union[str, Path],
         features: Optional[List[str]] = None,
         ss_mode: Literal["ss3", "ss8"] = "ss3",
         gap_handling: Literal["pad", "omit"] = "pad",
@@ -695,9 +695,10 @@ class StructurePreprocessor:
     # ------------------------------------------------------------------
     def encode_dssp(
         self,
-        df_seq: Optional[pd.DataFrame] = None,
+        df_seq: pd.DataFrame,
         pdb_folder: Optional[Union[str, Path]] = None,
-        features: Optional[List[str]] = None,
+        *,
+        features: List[str],
         ss_mode: Literal["ss3", "ss8"] = "ss3",
         gap_handling: Literal["pad", "omit"] = "pad",
         on_failure: Literal["nan", "drop", "raise"] = "nan",
@@ -901,9 +902,9 @@ class StructurePreprocessor:
     # ------------------------------------------------------------------
     def encode_pdb(
         self,
-        df_seq: Optional[pd.DataFrame] = None,
-        pdb_folder: Optional[Union[str, Path]] = None,
-        features: Optional[List[str]] = None,
+        df_seq: pd.DataFrame,
+        pdb_folder: Union[str, Path],
+        features: List[str],
         plddt_disorder_threshold: float = 70.0,
         on_failure: Literal["nan", "drop", "raise"] = "nan",
         return_df: bool = False,
@@ -1150,9 +1151,9 @@ class StructurePreprocessor:
     # ------------------------------------------------------------------
     def encode_pae(
         self,
-        df_seq: Optional[pd.DataFrame] = None,
-        pae_folder: Optional[Union[str, Path]] = None,
-        features: Optional[List[str]] = None,
+        df_seq: pd.DataFrame,
+        pae_folder: Union[str, Path],
+        features: List[str],
         local_window: int = 5,
         pae_band_edges: Tuple[int, int] = (5, 15),
         on_failure: Literal["nan", "drop", "raise"] = "nan",
@@ -1355,7 +1356,7 @@ class StructurePreprocessor:
     # ------------------------------------------------------------------
     def get_domains(
         self,
-        df_seq: Optional[pd.DataFrame] = None,
+        df_seq: pd.DataFrame,
         pdb_folder: Optional[Union[str, Path]] = None,
         pae_folder: Optional[Union[str, Path]] = None,
         tool: Literal["chainsaw", "afragmenter"] = "afragmenter",
@@ -1539,9 +1540,10 @@ class StructurePreprocessor:
     # ------------------------------------------------------------------
     def encode_domains(
         self,
-        df_seq: Optional[pd.DataFrame] = None,
+        df_seq: pd.DataFrame,
         domain_folder: Optional[Union[str, Path]] = None,
-        features: Optional[List[str]] = None,
+        *,
+        features: List[str],
         on_failure: Literal["nan", "drop", "raise"] = "nan",
         return_df: bool = False,
     ) -> Union[Dict[str, np.ndarray], Tuple[Dict[str, np.ndarray], pd.DataFrame]]:
@@ -1765,9 +1767,9 @@ class StructurePreprocessor:
     # ------------------------------------------------------------------
     def build_scales(
         self,
-        df_seq: Optional[pd.DataFrame] = None,
-        dict_num: Optional[Dict[str, np.ndarray]] = None,
-        features: Optional[List[str]] = None,
+        df_seq: pd.DataFrame,
+        dict_num: Dict[str, np.ndarray],
+        features: List[str],
         return_std: bool = False,
         dim_names_override: Optional[List[str]] = None,
     ) -> Union[pd.DataFrame, Tuple[pd.DataFrame, pd.DataFrame]]:
@@ -1919,7 +1921,7 @@ class StructurePreprocessor:
 
     def build_cat(
         self,
-        features: Optional[List[str]] = None,
+        features: List[str],
         dim_names_override: Optional[List[str]] = None,
     ) -> pd.DataFrame:
         """Build the ``df_cat`` metadata frame for ``features``.

--- a/aaanalysis/explainable_ai/_tree_model.py
+++ b/aaanalysis/explainable_ai/_tree_model.py
@@ -260,7 +260,7 @@ class TreeModel(Wrapper):
 
     def fit(self,
             X: ut.ArrayLike2D,
-            labels: Optional[ut.ArrayLike1D] = None,
+            labels: ut.ArrayLike1D,
             n_rounds: int = 5,
             use_rfe: bool = False,
             n_cv: int = 5,
@@ -354,8 +354,8 @@ class TreeModel(Wrapper):
 
     def eval(self,
              X: ut.ArrayLike2D,
-             labels: Optional[ut.ArrayLike1D] = None,
-             list_is_selected: Optional[List[ut.ArrayLike2D]] = None,
+             labels: ut.ArrayLike1D,
+             list_is_selected: List[ut.ArrayLike2D],
              convert_1d_to_2d: bool = False,
              names_feature_selections: Optional[List[str]] = None,
              n_cv: int = 5,
@@ -486,7 +486,7 @@ class TreeModel(Wrapper):
         return pred, pred_std
 
     def add_feat_importance(self,
-                            df_feat: Optional[pd.DataFrame] = None,
+                            df_feat: pd.DataFrame,
                             drop: bool = False,
                             sort: bool = False,
                             ) -> pd.DataFrame:
@@ -543,9 +543,9 @@ class TreeModel(Wrapper):
         return df_feat
 
     def select_features(self,
-                        df_feat: Optional[pd.DataFrame] = None,
-                        strategy: Optional[Literal["top_k", "threshold", "frequency"]] = None,
-                        param: Optional[Union[int, float, dict]] = None,
+                        df_feat: pd.DataFrame,
+                        strategy: Literal["top_k", "threshold", "frequency"],
+                        param: Union[int, float, dict],
                         ) -> pd.DataFrame:
         """
         Select a subset of features from a feature DataFrame using tree-based feature importance.

--- a/aaanalysis/explainable_ai_pro/_shap_model.py
+++ b/aaanalysis/explainable_ai_pro/_shap_model.py
@@ -467,7 +467,7 @@ class ShapModel(Wrapper):
 
     def fit(self,
             X: ut.ArrayLike2D,
-            labels: Optional[ut.ArrayLike1D] = None,
+            labels: ut.ArrayLike1D,
             label_target_class: int = 1,
             n_rounds: int = 5,
             is_selected: Optional[ut.ArrayLike2D] = None,
@@ -596,7 +596,7 @@ class ShapModel(Wrapper):
         raise NotImplementedError("ShapModel.eval is under construction.")
 
     def add_feat_impact(self,
-                        df_feat: Optional[pd.DataFrame] = None,
+                        df_feat: pd.DataFrame,
                         drop: bool = False,
                         samples: Union[int, List[int], str, List[str], None] = None,
                         names: Optional[Union[str, List[str]]] = None,
@@ -733,9 +733,10 @@ class ShapModel(Wrapper):
 
     @staticmethod
     def add_sample_mean_dif(X: ut.ArrayLike2D,
-                            labels: Optional[ut.ArrayLike1D] = None,
+                            labels: ut.ArrayLike1D,
                             label_ref: int = 0,
-                            df_feat: Optional[pd.DataFrame] = None,
+                            *,
+                            df_feat: pd.DataFrame,
                             drop: bool = False,
                             samples: Union[int, List[int], str, List[str], None] = None,
                             names: Optional[Union[str, List[str]]] = None,

--- a/aaanalysis/feature_engineering/_aaclust.py
+++ b/aaanalysis/feature_engineering/_aaclust.py
@@ -339,7 +339,7 @@ class AAclust(Wrapper):
 
     def eval(self,
              X: ut.ArrayLike2D,
-             list_labels: Optional[ut.ArrayLike2D] = None,
+             list_labels: ut.ArrayLike2D,
              names_datasets: Optional[List[str]] = None,
              ) -> pd.DataFrame:
         """
@@ -414,7 +414,7 @@ class AAclust(Wrapper):
 
     @staticmethod
     def name_clusters(X: ut.ArrayLike2D,
-                      labels: Optional[ut.ArrayLike1D] = None,
+                      labels: ut.ArrayLike1D,
                       names: Optional[List[str]] = None,
                       shorten_names : bool = True,
                       ) -> List[str]:
@@ -465,7 +465,7 @@ class AAclust(Wrapper):
 
     @staticmethod
     def comp_centers(X: ut.ArrayLike2D,
-                     labels: Optional[ut.ArrayLike1D] = None
+                     labels: ut.ArrayLike1D
                      ) -> Tuple[ut.ArrayLike1D, ut.ArrayLike1D]:
         """
         Computes the center of each cluster based on the given labels.
@@ -504,7 +504,7 @@ class AAclust(Wrapper):
 
     @staticmethod
     def comp_medoids(X: ut.ArrayLike2D,
-                     labels: Optional[ut.ArrayLike1D] = None,
+                     labels: ut.ArrayLike1D,
                      metric: Literal["correlation", "manhattan", "euclidean", "cosine"] = "correlation"
                      ) -> Tuple[ut.ArrayLike1D, ut.ArrayLike1D]:
         """
@@ -553,7 +553,7 @@ class AAclust(Wrapper):
 
     @staticmethod
     def comp_correlation(X: ut.ArrayLike2D,
-                         labels: Optional[ut.ArrayLike1D] = None,
+                         labels: ut.ArrayLike1D,
                          X_ref: Optional[ut.ArrayLike2D] = None,
                          labels_ref: Optional[ut.ArrayLike1D] = None,
                          names: Optional[List[str]] = None,
@@ -624,8 +624,8 @@ class AAclust(Wrapper):
         return df_corr, labels_sorted
 
     @staticmethod
-    def comp_coverage(names: Optional[List[str]] = None,
-                      names_ref: Optional[List[str]] = None
+    def comp_coverage(names: List[str],
+                      names_ref: List[str]
                       ) -> float:
         """
         Computes the percentage of unique names from ``names`` that are present in ``names_ref``.
@@ -663,7 +663,7 @@ class AAclust(Wrapper):
         return coverage
 
     def select_scales(self,
-                      df_scales: Optional[pd.DataFrame] = None,
+                      df_scales: pd.DataFrame,
                       n_clusters: Optional[int] = None,
                       on_center: bool = True,
                       min_th: float = 0.3,
@@ -731,8 +731,8 @@ class AAclust(Wrapper):
 
     def filter_coverage(self,
                         X: ut.ArrayLike2D,
-                        scale_ids: Optional[List[str]] = None,
-                        names_ref: Optional[List[str]] = None,
+                        scale_ids: List[str],
+                        names_ref: List[str],
                         min_coverage: int = 100,
                         df_cat: Optional[pd.DataFrame] = None,
                         col_name: Literal['category', 'subcategory', 'scale_name'] = "subcategory"
@@ -787,6 +787,8 @@ class AAclust(Wrapper):
         names_ref = ut.check_list_like(name="names_ref", val=names_ref, accept_none=False)
         ut.check_number_range(name="min_coverage", val=min_coverage, just_int=True,
                               min_val=10, max_val=100, accept_none=False)
+        if df_cat is None:
+            df_cat = ut.load_default_scales(scale_cat=True)
         check_df_cat(df_cat=df_cat, accept_none=False)
         ut.check_str_options(name="col_name", val=col_name,
                              list_str_options=[ut.COL_CAT, ut.COL_SUBCAT, ut.COL_SCALE_NAME])

--- a/aaanalysis/feature_engineering/_aaclust_plot.py
+++ b/aaanalysis/feature_engineering/_aaclust_plot.py
@@ -193,7 +193,7 @@ class AAclustPlot:
         self._model_kwargs = model_kwargs
 
     @staticmethod
-    def eval(df_eval: Optional[pd.DataFrame] = None,
+    def eval(df_eval: pd.DataFrame,
              figsize: Tuple[Union[int, float], Union[int, float]] = (6, 4),
              dict_xlims: Optional[dict] = None,
              ) -> Tuple[Figure, Axes]:
@@ -256,7 +256,8 @@ class AAclustPlot:
 
     def centers(self,
                 X: Optional[ut.ArrayLike2D] = None,
-                labels: Optional[Union[np.ndarray, list]] = None,
+                *,
+                labels: Union[np.ndarray, list],
                 df_scales: Optional[pd.DataFrame] = None,
                 component_x: int = 1,
                 component_y: int = 2,
@@ -358,7 +359,8 @@ class AAclustPlot:
 
     def medoids(self,
                 X: Optional[ut.ArrayLike2D] = None,
-                labels: Optional[ut.ArrayLike1D] = None,
+                *,
+                labels: ut.ArrayLike1D,
                 df_scales: Optional[pd.DataFrame] = None,
                 component_x: int = 1,
                 component_y: int = 2,
@@ -467,8 +469,8 @@ class AAclustPlot:
         return ax, df_components
 
     def correlation(self,
-                    df_corr: Optional[pd.DataFrame] = None,
-                    labels: Optional[ut.ArrayLike1D] = None,
+                    df_corr: pd.DataFrame,
+                    labels: ut.ArrayLike1D,
                     labels_ref: Optional[ut.ArrayLike1D] = None,
                     cluster_x: bool = False,
                     method: str = "average",

--- a/aaanalysis/feature_engineering/_cpp.py
+++ b/aaanalysis/feature_engineering/_cpp.py
@@ -292,7 +292,7 @@ class CPP(Tool):
 
     def __init__(
         self,
-        df_parts: Optional[pd.DataFrame] = None,
+        df_parts: pd.DataFrame,
         split_kws: Optional[dict] = None,
         df_scales: Optional[pd.DataFrame] = None,
         df_cat: Optional[pd.DataFrame] = None,
@@ -390,7 +390,7 @@ class CPP(Tool):
     # Main method
     def run(
         self,
-        labels: Optional[ut.ArrayLike1D] = None,
+        labels: ut.ArrayLike1D,
         label_test: int = 1,
         label_ref: int = 0,
         n_filter: int = 100,
@@ -689,8 +689,8 @@ class CPP(Tool):
 
     def run_num(
         self,
-        dict_num_parts: Optional[Dict[str, np.ndarray]] = None,
-        labels: Optional[ut.ArrayLike1D] = None,
+        dict_num_parts: Dict[str, np.ndarray],
+        labels: ut.ArrayLike1D,
         label_test: int = 1,
         label_ref: int = 0,
         n_filter: int = 100,
@@ -1017,8 +1017,8 @@ class CPP(Tool):
 
     def eval(
         self,
-        list_df_feat: Optional[List[pd.DataFrame]] = None,
-        labels: Optional[ut.ArrayLike1D] = None,
+        list_df_feat: List[pd.DataFrame],
+        labels: ut.ArrayLike1D,
         label_test: int = 1,
         label_ref: int = 0,
         min_th: float = 0.0,
@@ -1154,10 +1154,11 @@ class CPP(Tool):
             random_state=self._random_state,
         )
         return df_eval
+
     def simplify(
         self,
-        df_feat: Optional[pd.DataFrame] = None,
-        labels: Optional[ut.ArrayLike1D] = None,
+        df_feat: pd.DataFrame,
+        labels: ut.ArrayLike1D,
         strategy: Literal["greedy", "consolidate", "swap_all"] = "greedy",
         candidate_search: Literal["exact", "fast"] = "exact",
         max_interpret_grade: Optional[int] = None,

--- a/aaanalysis/feature_engineering/_cpp_grid.py
+++ b/aaanalysis/feature_engineering/_cpp_grid.py
@@ -179,8 +179,8 @@ class CPPGrid(Tool):
     """
 
     def __init__(self,
-                 df_seq: Optional[pd.DataFrame] = None,
-                 labels: Optional[ut.ArrayLike1D] = None,
+                 df_seq: pd.DataFrame,
+                 labels: ut.ArrayLike1D,
                  dict_num: Optional[Dict[str, np.ndarray]] = None,
                  accept_gaps: bool = False,
                  verbose: bool = True,

--- a/aaanalysis/feature_engineering/_cpp_plot.py
+++ b/aaanalysis/feature_engineering/_cpp_plot.py
@@ -284,7 +284,7 @@ class CPPPlot:
         self._jmd_c_len = jmd_c_len
 
     @staticmethod
-    def eval(df_eval: Optional[pd.DataFrame] = None,
+    def eval(df_eval: pd.DataFrame,
              figsize: Tuple[int or float, int or float] = (6, 4),
              dict_xlims: Optional[dict] = None,
              legend: bool = True,
@@ -383,10 +383,11 @@ class CPPPlot:
 
     # Plotting method for single feature
     def feature(self,
-                feature: Optional[Union[str, List[str], pd.DataFrame]] = None,
+                feature: Union[str, List[str], pd.DataFrame],
                 feat_rank: int = 1,
-                df_seq: Optional[pd.DataFrame] = None,
-                labels: Optional[ut.ArrayLike1D] = None,
+                *,
+                df_seq: pd.DataFrame,
+                labels: ut.ArrayLike1D,
                 label_test: int = 1,
                 label_ref: int = 0, 
                 ax: Optional[Axes] = None,
@@ -542,7 +543,7 @@ class CPPPlot:
 
     # Plotting methods for multiple features (group and sample level)
     def ranking(self,
-                df_feat: Optional[pd.DataFrame] = None,
+                df_feat: pd.DataFrame,
                 shap_plot: bool = False,
                 col_dif: str = "mean_dif",
                 col_imp: str = "feat_importance",
@@ -715,7 +716,7 @@ class CPPPlot:
 
     def profile(self,
                 # Data and Plot Type
-                df_feat: Optional[pd.DataFrame] = None,
+                df_feat: pd.DataFrame,
                 shap_plot: bool = False,
                 col_imp: Union[str, None] = "feat_importance",
                 normalize: bool = True,
@@ -942,7 +943,7 @@ class CPPPlot:
 
     def heatmap(self,
                 # Data and Plot Type
-                df_feat: Optional[pd.DataFrame] = None,
+                df_feat: pd.DataFrame,
                 shap_plot: bool = False,
                 col_cat: Literal['category', 'subcategory', 'scale_name'] = "subcategory",
                 col_val: str = "mean_dif",
@@ -1196,7 +1197,7 @@ class CPPPlot:
 
     def feature_map(self,
                     # Data and Plot Type
-                    df_feat: Optional[pd.DataFrame] = None,
+                    df_feat: pd.DataFrame,
                     shap_plot: bool = False,
                     col_cat: Literal['category', 'subcategory', 'scale_name'] = "subcategory",
                     col_val: str = "mean_dif",
@@ -1515,7 +1516,7 @@ class CPPPlot:
         return fig, ax
 
     def update_seq_size(self,
-                        ax: Optional[Axes] = None,
+                        ax: Axes,
                         fig: Optional[Figure] = None,
                         max_x_dist: float = 0.1,
                         fontsize_tmd_jmd: Optional[Union[int, float]] = None,

--- a/aaanalysis/feature_engineering/_numerical_feature.py
+++ b/aaanalysis/feature_engineering/_numerical_feature.py
@@ -124,8 +124,8 @@ class NumericalFeature:
         return is_selected
 
     @staticmethod
-    def get_parts(df_seq: Optional[pd.DataFrame] = None,
-                  dict_num: Optional[Dict[str, np.ndarray]] = None,
+    def get_parts(df_seq: pd.DataFrame,
+                  dict_num: Dict[str, np.ndarray],
                   list_parts: Optional[List[str]] = None,
                   all_parts: bool = False,
                   jmd_n_len: int = 10,
@@ -278,8 +278,8 @@ class NumericalFeature:
         return df_parts, dict_part_vals
 
     @staticmethod
-    def extend_alphabet(df_scales: Optional[pd.DataFrame] = None,
-                        new_letter: Optional[str] = None,
+    def extend_alphabet(df_scales: pd.DataFrame,
+                        new_letter: str,
                         value_type: Literal["min", "mean", "median", "max"] = "mean",
                         ) -> pd.DataFrame:
         """

--- a/aaanalysis/feature_engineering/_sequence_feature.py
+++ b/aaanalysis/feature_engineering/_sequence_feature.py
@@ -276,7 +276,7 @@ class SequenceFeature:
 
     # Part and Split methods
     def get_df_parts(self,
-                     df_seq: Optional[pd.DataFrame] = None,
+                     df_seq: pd.DataFrame,
                      list_parts: Optional[Union[str, List[str]]] = None,
                      all_parts: bool = False,
                      jmd_n_len: Union[int, None] = 10,
@@ -408,9 +408,9 @@ class SequenceFeature:
         return df_parts
 
     def get_seq_kws(self,
-                    df_seq: Optional[pd.DataFrame] = None,
-                    df_parts: Optional[pd.DataFrame] = None,
-                    sample: Optional[Union[int, str]] = None,
+                    df_seq: pd.DataFrame,
+                    df_parts: pd.DataFrame,
+                    sample: Union[int, str],
                     ) -> dict:
         """
         Get the per-part sequence keyword arguments (``jmd_n_seq``, ``tmd_seq``, ``jmd_c_seq``) for one protein.
@@ -571,9 +571,9 @@ class SequenceFeature:
 
     # Feature methods
     def get_df_feat(self,
-                    features: Optional[Union[ut.ArrayLike1D, pd.DataFrame]] = None,
-                    df_parts: Optional[pd.DataFrame] = None,
-                    labels: Optional[ut.ArrayLike1D] = None,
+                    features: Union[ut.ArrayLike1D, pd.DataFrame],
+                    df_parts: pd.DataFrame,
+                    labels: ut.ArrayLike1D,
                     label_test: int = 1,
                     label_ref: int = 0,
                     df_scales: Optional[pd.DataFrame] = None,
@@ -698,8 +698,8 @@ class SequenceFeature:
         return df_feat
 
     def feature_matrix(self,
-                       features: Optional[Union[ut.ArrayLike1D, pd.DataFrame]] = None,
-                       df_parts: Optional[Union[pd.DataFrame, List[pd.DataFrame]]] = None,
+                       features: Union[ut.ArrayLike1D, pd.DataFrame],
+                       df_parts: Union[pd.DataFrame, List[pd.DataFrame]],
                        df_scales: Optional[pd.DataFrame] = None,
                        accept_gaps: bool = False,
                        n_jobs: Union[int, None] = 1,
@@ -804,7 +804,7 @@ class SequenceFeature:
         return list_X if batch else list_X[0]
 
     def prune_by_variance(self,
-                          df_feat: Optional[pd.DataFrame] = None,
+                          df_feat: pd.DataFrame,
                           df_parts: Optional[pd.DataFrame] = None,
                           df_scales: Optional[pd.DataFrame] = None,
                           threshold: float = 0.0,
@@ -902,7 +902,7 @@ class SequenceFeature:
         return df_feat
 
     def prune_by_correlation(self,
-                             df_feat: Optional[pd.DataFrame] = None,
+                             df_feat: pd.DataFrame,
                              df_parts: Optional[pd.DataFrame] = None,
                              df_scales: Optional[pd.DataFrame] = None,
                              max_cor: float = 0.7,
@@ -1077,7 +1077,7 @@ class SequenceFeature:
         return features
 
     @staticmethod
-    def get_feature_names(features: Optional[Union[ut.ArrayLike1D, pd.DataFrame]] = None,
+    def get_feature_names(features: Union[ut.ArrayLike1D, pd.DataFrame],
                           df_cat: Optional[pd.DataFrame] = None,
                           start: int = 1,
                           tmd_len: int = 20,
@@ -1152,7 +1152,7 @@ class SequenceFeature:
         return feat_names
 
     @staticmethod
-    def get_feature_descriptions(features: Optional[Union[ut.ArrayLike1D, pd.DataFrame]] = None,
+    def get_feature_descriptions(features: Union[ut.ArrayLike1D, pd.DataFrame],
                                  df_cat: Optional[pd.DataFrame] = None,
                                  start: int = 1,
                                  tmd_len: int = 20,
@@ -1233,7 +1233,7 @@ class SequenceFeature:
         return feat_descriptions
 
     @staticmethod
-    def get_feature_positions(features: Optional[Union[ut.ArrayLike1D, pd.DataFrame]] = None,
+    def get_feature_positions(features: Union[ut.ArrayLike1D, pd.DataFrame],
                               start: int = 1,
                               tmd_len: int = 20,
                               jmd_n_len: int = 10,
@@ -1309,7 +1309,7 @@ class SequenceFeature:
             return list_pos
 
     @staticmethod
-    def get_df_pos(df_feat: Optional[pd.DataFrame] = None,
+    def get_df_pos(df_feat: pd.DataFrame,
                    col_val: str = "mean_dif",
                    col_cat: str = "category",
                    start: int = 1,
@@ -1390,7 +1390,7 @@ class SequenceFeature:
         return df_pos
 
     @staticmethod
-    def get_labels_ovr(labels: Optional[ut.ArrayLike1D] = None,
+    def get_labels_ovr(labels: ut.ArrayLike1D,
                        label_test: int = 1,
                        label_ref: int = 0,
                        ) -> Dict[int, np.ndarray]:
@@ -1451,7 +1451,7 @@ class SequenceFeature:
         return get_labels_ovr_(labels=labels, label_test=label_test, label_ref=label_ref)
 
     @staticmethod
-    def get_labels_ovo(labels: Optional[ut.ArrayLike1D] = None,
+    def get_labels_ovo(labels: ut.ArrayLike1D,
                        df_parts: Optional[pd.DataFrame] = None,
                        dict_num_parts: Optional[Dict[str, np.ndarray]] = None,
                        label_test: int = 1,
@@ -1531,7 +1531,7 @@ class SequenceFeature:
         return dict_labels
 
     @staticmethod
-    def get_labels_quantile(targets: Optional[ut.ArrayLike1D] = None,
+    def get_labels_quantile(targets: ut.ArrayLike1D,
                             q: float = 0.5,
                             label_test: int = 1,
                             label_ref: int = 0,
@@ -1599,7 +1599,7 @@ class SequenceFeature:
         return labels
 
     @staticmethod
-    def get_labels_tiered(targets: Optional[ut.ArrayLike1D] = None,
+    def get_labels_tiered(targets: ut.ArrayLike1D,
                           q_pos: float = 0.8,
                           list_q_neg: Sequence[float] = (0.8, 0.5, 0.3),
                           df_parts: Optional[pd.DataFrame] = None,
@@ -1697,7 +1697,7 @@ class SequenceFeature:
         return dict_labels
 
     @staticmethod
-    def get_df_parts_from_windows(dict_parts: Optional[Dict[str, Union[pd.DataFrame, Sequence[str]]]] = None,
+    def get_df_parts_from_windows(dict_parts: Dict[str, Union[pd.DataFrame, Sequence[str]]],
                                   ) -> pd.DataFrame:
         """
         Assemble a ``df_parts`` from per-part window sets (e.g. :class:`AAWindowSampler` outputs).

--- a/aaanalysis/metrics/_metrics.py
+++ b/aaanalysis/metrics/_metrics.py
@@ -25,8 +25,8 @@ def _check_n_classes_n_samples(X=None, labels=None):
 
 
 # Adjusted Area Under the Curve (AUC*)
-def comp_auc_adjusted(X: Optional[ut.ArrayLike2D] = None,
-                      labels: Optional[ut.ArrayLike1D] = None,
+def comp_auc_adjusted(X: ut.ArrayLike2D,
+                      labels: ut.ArrayLike1D,
                       label_test: int = 1,
                       label_ref: int = 0,
                       n_jobs: Optional[int] = None
@@ -81,8 +81,8 @@ def comp_auc_adjusted(X: Optional[ut.ArrayLike2D] = None,
 
 
 # BIC score
-def comp_bic_score(X: Optional[ut.ArrayLike2D] = None,
-                   labels: Optional[ut.ArrayLike1D] = None
+def comp_bic_score(X: ut.ArrayLike2D,
+                   labels: ut.ArrayLike1D
                    ) -> float:
     """
     Compute an adjusted Bayesian Information Criterion (BIC) (-∞, ∞) for assessing clustering quality.
@@ -134,8 +134,8 @@ def comp_bic_score(X: Optional[ut.ArrayLike2D] = None,
 
 
 # Kullback-Leibler Divergence
-def comp_kld(X: Optional[ut.ArrayLike2D] = None,
-             labels: Optional[ut.ArrayLike1D] =None,
+def comp_kld(X: ut.ArrayLike2D,
+             labels: ut.ArrayLike1D,
              label_test: int = 1,
              label_ref: int = 0
              ) -> ut.ArrayLike1D:
@@ -218,8 +218,8 @@ def _check_list_scores_positions(list_scores=None, list_positions=None):
 
 
 # Per-protein average precision (site localization)
-def comp_per_protein_ap(list_scores: Optional[list] = None,
-                        list_positions: Optional[list] = None,
+def comp_per_protein_ap(list_scores: list,
+                        list_positions: list,
                         tolerance: int = 0,
                         ) -> ut.ArrayLike1D:
     """
@@ -265,8 +265,8 @@ def comp_per_protein_ap(list_scores: Optional[list] = None,
 
 
 # Detection metrics at a fixed threshold
-def comp_detection_metrics(list_scores: Optional[list] = None,
-                           list_positions: Optional[list] = None,
+def comp_detection_metrics(list_scores: list,
+                           list_positions: list,
                            threshold: float = 0.5,
                            tolerance: int = 0,
                            ) -> dict:
@@ -318,7 +318,7 @@ def comp_detection_metrics(list_scores: Optional[list] = None,
 
 
 # Bootstrap confidence interval
-def comp_bootstrap_ci(values: Optional[ut.ArrayLike1D] = None,
+def comp_bootstrap_ci(values: ut.ArrayLike1D,
                       n_rounds: int = 1000,
                       ci: float = 0.95,
                       seed: Optional[int] = None,
@@ -370,7 +370,7 @@ def comp_bootstrap_ci(values: Optional[ut.ArrayLike1D] = None,
 
 
 # Peak-preserving score smoothing
-def comp_smooth_scores(scores: Optional[ut.ArrayLike1D] = None,
+def comp_smooth_scores(scores: ut.ArrayLike1D,
                        method: Literal["triangular", "gaussian"] = "triangular",
                        window: int = 2,
                        sigma: Optional[float] = None,

--- a/aaanalysis/plotting/_plot_rank.py
+++ b/aaanalysis/plotting/_plot_rank.py
@@ -45,7 +45,7 @@ def _resolve_group_colors(group_order=None, dict_color=None):
 
 
 # II Main Functions
-def plot_rank(df_rank: Optional[pd.DataFrame] = None,
+def plot_rank(df_rank: pd.DataFrame,
               col_score: str = "score",
               col_group: str = "group",
               group_order: Optional[List[str]] = None,

--- a/aaanalysis/protein_design/_aamut.py
+++ b/aaanalysis/protein_design/_aamut.py
@@ -133,7 +133,7 @@ class AAMut(Tool):
         return df_impact
 
     def eval(self,
-             df_impact: Optional[pd.DataFrame] = None,
+             df_impact: pd.DataFrame,
              ) -> pd.DataFrame:
         """
         Evaluate substitution impact by ranking scales on their mean substitution sensitivity.

--- a/aaanalysis/protein_design/_aamut_plot.py
+++ b/aaanalysis/protein_design/_aamut_plot.py
@@ -52,7 +52,7 @@ class AAMutPlot:
 
     # Main methods
     def substitution_matrix(self,
-                            df_impact: Optional[pd.DataFrame] = None,
+                            df_impact: pd.DataFrame,
                             ax: Optional[Axes] = None,
                             figsize: Tuple[Union[int, float], Union[int, float]] = (7, 6),
                             cmap: str = "viridis",
@@ -97,7 +97,7 @@ class AAMutPlot:
         return ax
 
     def scale_ranking(self,
-                      df_impact: Optional[pd.DataFrame] = None,
+                      df_impact: pd.DataFrame,
                       top_n: int = 20,
                       ax: Optional[Axes] = None,
                       figsize: Tuple[Union[int, float], Union[int, float]] = (6, 5),
@@ -146,9 +146,9 @@ class AAMutPlot:
         return ax
 
     def aa_comparison(self,
-                      df_impact: Optional[pd.DataFrame] = None,
-                      from_aa: Optional[str] = None,
-                      to_aa: Optional[str] = None,
+                      df_impact: pd.DataFrame,
+                      from_aa: str,
+                      to_aa: str,
                       top_n: int = 20,
                       ax: Optional[Axes] = None,
                       figsize: Tuple[Union[int, float], Union[int, float]] = (6, 5),

--- a/aaanalysis/protein_design/_seqmut.py
+++ b/aaanalysis/protein_design/_seqmut.py
@@ -132,8 +132,8 @@ class SeqMut:
 
     # Main methods
     def mutate(self,
-               df_seq: Optional[pd.DataFrame] = None,
-               mutations: Optional[pd.DataFrame] = None,
+               df_seq: pd.DataFrame,
+               mutations: pd.DataFrame,
                df_feat: Optional[pd.DataFrame] = None,
                jmd_n_len: int = 10,
                jmd_c_len: int = 10,
@@ -210,8 +210,8 @@ class SeqMut:
         return df_mut
 
     def scan(self,
-             df_seq: Optional[pd.DataFrame] = None,
-             df_feat: Optional[pd.DataFrame] = None,
+             df_seq: pd.DataFrame,
+             df_feat: pd.DataFrame,
              region: Optional[Union[str, List[int]]] = None,
              to_aa: Optional[List[str]] = None,
              jmd_n_len: int = 10,
@@ -273,8 +273,8 @@ class SeqMut:
         return df_scan
 
     def suggest(self,
-                df_seq: Optional[pd.DataFrame] = None,
-                df_feat: Optional[pd.DataFrame] = None,
+                df_seq: pd.DataFrame,
+                df_feat: pd.DataFrame,
                 n: int = 10,
                 region: Optional[Union[str, List[int]]] = None,
                 to_aa: Optional[List[str]] = None,
@@ -341,7 +341,7 @@ class SeqMut:
         return df_suggest
 
     def eval(self,
-             df_scan: Optional[pd.DataFrame] = None,
+             df_scan: pd.DataFrame,
              th: Optional[float] = None,
              ) -> pd.DataFrame:
         """

--- a/aaanalysis/protein_design/_seqmut_plot.py
+++ b/aaanalysis/protein_design/_seqmut_plot.py
@@ -57,7 +57,7 @@ class SeqMutPlot:
 
     # Main methods
     def mutation_landscape(self,
-                           df_scan: Optional[pd.DataFrame] = None,
+                           df_scan: pd.DataFrame,
                            entry: Optional[str] = None,
                            ax: Optional[Axes] = None,
                            figsize: Tuple[Union[int, float], Union[int, float]] = (10, 5),
@@ -106,9 +106,10 @@ class SeqMutPlot:
         return ax
 
     def residue_mutation_impact(self,
-                                df_scan: Optional[pd.DataFrame] = None,
+                                df_scan: pd.DataFrame,
                                 entry: Optional[str] = None,
-                                pos: Optional[int] = None,
+                                *,
+                                pos: int,
                                 ax: Optional[Axes] = None,
                                 figsize: Tuple[Union[int, float], Union[int, float]] = (6, 5),
                                 color: Optional[str] = None,

--- a/aaanalysis/pu_learning/_dpulearn.py
+++ b/aaanalysis/pu_learning/_dpulearn.py
@@ -214,7 +214,7 @@ class dPULearn(Wrapper):
     # Main method
     def fit(self,
             X: ut.ArrayLike2D,
-            labels: Optional[ut.ArrayLike1D] = None,
+            labels: ut.ArrayLike1D,
             label_pos: int = 1,
             label_unl: int = 2,
             label_neg: Optional[int] = None,
@@ -360,7 +360,7 @@ class dPULearn(Wrapper):
 
     @staticmethod
     def eval(X: ut.ArrayLike2D,
-             list_labels: Optional[ut.ArrayLike2D] = None,
+             list_labels: ut.ArrayLike2D,
              names_datasets: Optional[List[str]] = None,
              X_neg: Optional[ut.ArrayLike2D] = None,
              comp_kld: bool = False,
@@ -446,7 +446,7 @@ class dPULearn(Wrapper):
         return df_eval
 
     @staticmethod
-    def compare_sets_negatives(list_labels: Optional[ut.ArrayLike1D] = None,
+    def compare_sets_negatives(list_labels: ut.ArrayLike1D,
                                names_datasets: Optional[List[str]] = None,
                                df_seq: Optional[pd.DataFrame] = None,
                                remove_non_neg : bool = True,

--- a/aaanalysis/pu_learning/_dpulearn_plot.py
+++ b/aaanalysis/pu_learning/_dpulearn_plot.py
@@ -82,7 +82,7 @@ class dPULearnPlot:
         """
 
     @staticmethod
-    def eval(df_eval: Optional[pd.DataFrame] = None,
+    def eval(df_eval: pd.DataFrame,
              figsize: Tuple[Union[int, float], Union[int, float]] = (6, 4),
              dict_xlims: Optional[dict] = None,
              legend: bool = True,
@@ -167,7 +167,7 @@ class dPULearnPlot:
         return fig, axes
 
     @staticmethod
-    def pca(df_pu: Optional[pd.DataFrame] = None,
+    def pca(df_pu: pd.DataFrame,
             labels=None,
             figsize: Tuple[Union[int, float], Union[int, float]] = (5, 5),
             pc_x: int = 1,

--- a/aaanalysis/seq_analysis/_aa_window_sampler.py
+++ b/aaanalysis/seq_analysis/_aa_window_sampler.py
@@ -427,7 +427,7 @@ class AAWindowSampler:
 
     # Sampling methods
     def sample_same_protein(self,
-                            df_seq: Optional[pd.DataFrame] = None,
+                            df_seq: pd.DataFrame,
                             n: int = 100,
                             window_size: int = 9,
                             pos_col: str = ut.COL_POS,
@@ -601,7 +601,7 @@ class AAWindowSampler:
                                        mark_test=True)
 
     def sample_different_protein(self,
-                                 df_seq: Optional[pd.DataFrame] = None,
+                                 df_seq: pd.DataFrame,
                                  n: int = 100,
                                  window_size: int = 9,
                                  pos_col: str = ut.COL_POS,
@@ -740,7 +740,7 @@ class AAWindowSampler:
                                        mark_test=True)
 
     def sample_synthetic(self,
-                         df_seq: Optional[pd.DataFrame] = None,
+                         df_seq: pd.DataFrame,
                          n: int = 100,
                          window_size: int = 9,
                          generator: Union[Literal["uniform", "global_freq",
@@ -920,11 +920,12 @@ class AAWindowSampler:
         return df[ut.COLS_SEGMENTS].copy()
 
     def sample_motif_matched(self,
-                              df_seq: Optional[pd.DataFrame] = None,
+                              df_seq: pd.DataFrame,
                               n: int = 100,
                               window_size: int = 9,
-                              motif_pwm: Optional[pd.DataFrame] = None,
-                              motif_score_threshold: Optional[float] = None,
+                              *,
+                              motif_pwm: pd.DataFrame,
+                              motif_score_threshold: float,
                               pos_col: str = ut.COL_POS,
                               label_test: Union[int, float] = 1,
                               label_ref: Union[int, float] = 0,
@@ -1056,8 +1057,8 @@ class AAWindowSampler:
                                        mark_test=True)
 
     def sample_benchmark_set(self,
-                             df_seq: Optional[pd.DataFrame] = None,
-                             arms: Optional[Dict[str, Dict]] = None,
+                             df_seq: pd.DataFrame,
+                             arms: Dict[str, Dict],
                              seed: Optional[int] = None,
                              ) -> pd.DataFrame:
         """Run several named sampling arms and concatenate them into one benchmark set.

--- a/aaanalysis/seq_analysis/_aalogo.py
+++ b/aaanalysis/seq_analysis/_aalogo.py
@@ -85,7 +85,7 @@ class AAlogo:
         self._logo_type = logo_type
 
     def get_df_logo(self,
-                    df_parts: Optional[pd.DataFrame] = None,
+                    df_parts: pd.DataFrame,
                     labels: Optional[ut.ArrayLike1D] = None,
                     label_test: int = 1,
                     tmd_len: Optional[int] = None,
@@ -168,7 +168,7 @@ class AAlogo:
         return df_logo
 
     def get_df_logo_info(self,
-                         df_parts: Optional[pd.DataFrame] = None,
+                         df_parts: pd.DataFrame,
                          labels: Optional[ut.ArrayLike1D] = None,
                          label_test: int = 1,
                          tmd_len: Optional[int] = None,
@@ -249,7 +249,7 @@ class AAlogo:
         return df_logo_info
 
     @staticmethod
-    def get_conservation(df_logo_info: Optional[pd.Series] = None,
+    def get_conservation(df_logo_info: pd.Series,
                          value_type: Literal["min", "mean", "median", "max"] = "mean",
                          ) -> float:
         """

--- a/aaanalysis/seq_analysis_pro/_filter_seq.py
+++ b/aaanalysis/seq_analysis_pro/_filter_seq.py
@@ -45,7 +45,7 @@ def check_seq_gaps(df_seq) -> None:
 
 
 # II Main function
-def filter_seq(df_seq: Optional[pd.DataFrame] = None,
+def filter_seq(df_seq: pd.DataFrame,
                method: Literal['cd-hit', 'mmseqs'] = "cd-hit",
                similarity_threshold: float = 0.9,
                word_size: Optional[int] = None,

--- a/aaanalysis/seq_analysis_pro/_scan_motif.py
+++ b/aaanalysis/seq_analysis_pro/_scan_motif.py
@@ -126,11 +126,12 @@ def _run_fimo(motif_path, fasta_path, *, pvalue_threshold,
 
 
 # II Main Function
-def scan_motif(df_seq: Optional[pd.DataFrame] = None,
+def scan_motif(df_seq: pd.DataFrame,
                                   pos_col: str = "pos",
                                   n: int = 100,
                                   window_size: int = 9,
-                                  motif_pwm: Optional[pd.DataFrame] = None,
+                                  *,
+                                  motif_pwm: pd.DataFrame,
                                   pvalue_threshold: float = 1e-4,
                                   label_test: Union[int, float] = 1,
                                   label_ref: Union[int, float] = 0,

--- a/tests/unit/aa_window_sampler_tests/test_aa_window_sampler_motif_matched.py
+++ b/tests/unit/aa_window_sampler_tests/test_aa_window_sampler_motif_matched.py
@@ -256,7 +256,7 @@ class TestSampleMotifMatched:
         aaws = aa.AAWindowSampler()
         with pytest.raises(ValueError, match="motif_pwm"):
             aaws.sample_motif_matched(df_seq=df_seq, pos_col="pos",
-                                       n=5, window_size=3,
+                                       n=5, window_size=3, motif_pwm=None,
                                        motif_score_threshold=2.5, seed=0)
 
     def test_invalid_motif_pwm_shape(self):
@@ -274,7 +274,8 @@ class TestSampleMotifMatched:
         with pytest.raises(ValueError, match="motif_score_threshold"):
             aaws.sample_motif_matched(df_seq=df_seq, pos_col="pos",
                                        n=5, window_size=3,
-                                       motif_pwm=_pwm_for_a(3), seed=0)
+                                       motif_pwm=_pwm_for_a(3),
+                                       motif_score_threshold=None, seed=0)
 
     def test_invalid_role(self):
         df_seq = _df_seq_with_aaa()

--- a/tests/unit/aaclust_tests/test_aaclust_comp_correlation.py
+++ b/tests/unit/aaclust_tests/test_aaclust_comp_correlation.py
@@ -202,7 +202,7 @@ class TestCompCorrelationComplex:
         X_ref = np.random.rand(X.shape[0], X.shape[1])
         names = [f"Sample_{i}" for i in range(X.shape[0])]
         with pytest.raises(ValueError):
-            aa.AAclust.comp_correlation(X, X_ref=X_ref, names=names)
+            aa.AAclust.comp_correlation(X, labels=None, X_ref=X_ref, names=names)
 
     @settings(deadline=None, max_examples=5)
     @given(X=npst.arrays(dtype=np.float64, shape=npst.array_shapes(min_dims=2, max_dims=2),

--- a/tests/unit/aaclust_tests/test_aaclust_eval.py
+++ b/tests/unit/aaclust_tests/test_aaclust_eval.py
@@ -59,7 +59,7 @@ class TestAAclustEvaluate:
         """Test with an invalid 'X' value."""
         X = np.array([[1.0, 2.0], [np.nan, 4.0], [5.0, 6.0]])
         with pytest.raises(ValueError):
-            aa.AAclust().eval(X)
+            aa.AAclust().eval(X, list_labels=np.array([1, 2, 1]))
 
     def test_labels(self):
         """Test the 'labels' parameter."""
@@ -78,7 +78,7 @@ class TestAAclustEvaluate:
         """Test with 'labels' parameter set to None."""
         X = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
         with pytest.raises(ValueError):
-            aa.AAclust().eval(X)
+            aa.AAclust().eval(X, list_labels=None)
 
     @settings(deadline=None)
     @given(X=npst.arrays(dtype=np.float64, shape=npst.array_shapes(min_dims=2, max_dims=2, min_side=10, max_side=50),
@@ -147,4 +147,4 @@ class TestAAclustEvaluateComplex:
     def test_small_X(self, X):
         """Test 'evaluate' with a very small 'X'."""
         with pytest.raises(ValueError):
-            aa.AAclust().eval(X)
+            aa.AAclust().eval(X, list_labels=np.ones(X.shape[0], dtype=int))

--- a/tests/unit/api_tests/test_style_method_spacing.py
+++ b/tests/unit/api_tests/test_style_method_spacing.py
@@ -21,7 +21,7 @@ _PKG_ROOT = pathlib.Path(aaanalysis.__file__).parent
 def _method_spacing_violations():
     violations = []
     for path in sorted(_PKG_ROOT.rglob("*.py")):
-        tree = ast.parse(path.read_text(), filename=str(path))
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         for node in ast.walk(tree):
             if not isinstance(node, ast.ClassDef):
                 continue

--- a/tests/unit/api_tests/test_style_method_spacing.py
+++ b/tests/unit/api_tests/test_style_method_spacing.py
@@ -1,0 +1,47 @@
+"""This is a script to test that consecutive methods are separated by a blank line.
+
+House style (and PEP 8 E301): two methods in a class body must have at least one
+blank line between them. A signature rewrite once removed the blank line before
+``CPP.simplify``, leaving ``return ...`` glued to the next ``def`` — readable code
+review missed it, so this guards it programmatically across the whole package.
+
+The check is intentionally narrow: it flags only a method ``def`` whose immediately
+preceding sibling in the class body is *also* a method (method-to-method). It does
+NOT require a blank line between a class docstring (or the class header) and the
+first method, which is a separate, conventionally-accepted spacing.
+"""
+import ast
+import pathlib
+
+import aaanalysis  # noqa: F401  (anchor the installed/source package root)
+
+_PKG_ROOT = pathlib.Path(aaanalysis.__file__).parent
+
+
+def _method_spacing_violations():
+    violations = []
+    for path in sorted(_PKG_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            body = node.body
+            for prev, cur in zip(body, body[1:]):
+                func_types = (ast.FunctionDef, ast.AsyncFunctionDef)
+                if not (isinstance(cur, func_types) and isinstance(prev, func_types)):
+                    continue
+                start = cur.decorator_list[0].lineno if cur.decorator_list else cur.lineno
+                blank_lines = start - prev.end_lineno - 1
+                if blank_lines < 1:
+                    rel = path.relative_to(_PKG_ROOT.parent)
+                    violations.append(f"{rel}:{start}: '{cur.name}' has no blank line "
+                                      f"after method '{prev.name}'")
+    return violations
+
+
+class TestMethodSpacing:
+    """Every method must be preceded by at least one blank line after the prior method."""
+
+    def test_no_glued_methods(self):
+        violations = _method_spacing_violations()
+        assert not violations, "Methods must be separated by a blank line:\n" + "\n".join(violations)

--- a/tests/unit/cpp_tests/test_run_num_parity.py
+++ b/tests/unit/cpp_tests/test_run_num_parity.py
@@ -66,7 +66,7 @@ class TestRunNumRequiresDictNumParts:
         df_seq, labels, df_parts, df_scales = _build_fixture()
         cpp = aa.CPP(df_parts=df_parts, df_scales=df_scales)
         with pytest.raises(ValueError, match="'dict_num_parts' .* required"):
-            cpp.run_num(labels=labels, n_jobs=1)
+            cpp.run_num(dict_num_parts=None, labels=labels, n_jobs=1)
 
 
 class TestRunNumRoundTrip:

--- a/tests/unit/data_handling_pro_tests/test_structure_preprocessor_branch.py
+++ b/tests/unit/data_handling_pro_tests/test_structure_preprocessor_branch.py
@@ -94,7 +94,7 @@ class TestSeqColumnGuards:
         stp = aa.StructurePreprocessor(verbose=False)
         d = {"P1": np.zeros((8, 1))}
         with pytest.raises(ValueError, match="for build_scales"):
-            stp.build_scales(df_seq=_part_based_df(), dict_num=d)
+            stp.build_scales(df_seq=_part_based_df(), dict_num=d, features=["bfactor"])
 
 
 class TestPaeIoBranches:

--- a/tests/unit/data_handling_pro_tests/test_structure_preprocessor_build_scales.py
+++ b/tests/unit/data_handling_pro_tests/test_structure_preprocessor_build_scales.py
@@ -44,7 +44,7 @@ class TestStpBuildPseudoScales:
     def test_invalid_df_seq_none(self):
         stp = aa.StructurePreprocessor(verbose=False)
         with pytest.raises(ValueError):
-            stp.build_scales(features=["bfactor"])
+            stp.build_scales(df_seq=None, dict_num=None, features=["bfactor"])
 
     def test_invalid_dict_num_none(self):
         df = _df_seq()

--- a/tests/unit/data_handling_tests/test_sp_encode_integer.py
+++ b/tests/unit/data_handling_tests/test_sp_encode_integer.py
@@ -51,11 +51,11 @@ class TestEncodeInteger:
         """Test an invalid 'alphabet' parameter."""
         sp = aa.SequencePreprocessor()
         with pytest.raises(ValueError):
-            sp.encode_integer(alphabet=None)
+            sp.encode_integer(list_seq=["ACDEF"], alphabet=None)
         with pytest.raises(ValueError):
-            sp.encode_integer(alphabet="")
+            sp.encode_integer(list_seq=["ACDEF"], alphabet="")
         with pytest.raises(ValueError):
-            sp.encode_integer(alphabet=123)
+            sp.encode_integer(list_seq=["ACDEF"], alphabet=123)
 
     @settings(max_examples=10, deadline=None)
     @given(gap=st.text(min_size=1, max_size=1).filter(lambda g: g not in "ACDEFGHIKLMNPQRSTVWY"))
@@ -71,11 +71,11 @@ class TestEncodeInteger:
         """Test an invalid 'gap' parameter."""
         sp = aa.SequencePreprocessor()
         with pytest.raises(ValueError):
-            sp.encode_integer(gap=None)
+            sp.encode_integer(list_seq=["ACDEF"], gap=None)
         with pytest.raises(ValueError):
-            sp.encode_integer(gap="")
+            sp.encode_integer(list_seq=["ACDEF"], gap="")
         with pytest.raises(ValueError):
-            sp.encode_integer(gap="INVALID")
+            sp.encode_integer(list_seq=["ACDEF"], gap="INVALID")
 
     @settings(max_examples=10, deadline=None)
     @given(pad_at=st.sampled_from(["N", "C"]))
@@ -91,11 +91,11 @@ class TestEncodeInteger:
         """Test an invalid 'pad_at' parameter."""
         sp = aa.SequencePreprocessor()
         with pytest.raises(ValueError):
-            sp.encode_integer(pad_at=None)
+            sp.encode_integer(list_seq=["ACDEF"], pad_at=None)
         with pytest.raises(ValueError):
-            sp.encode_integer(pad_at="")
+            sp.encode_integer(list_seq=["ACDEF"], pad_at="")
         with pytest.raises(ValueError):
-            sp.encode_integer(pad_at="INVALID")
+            sp.encode_integer(list_seq=["ACDEF"], pad_at="INVALID")
 
 
 # Complex Cases

--- a/tests/unit/data_handling_tests/test_sp_encode_one_hot.py
+++ b/tests/unit/data_handling_tests/test_sp_encode_one_hot.py
@@ -50,11 +50,11 @@ class TestEncodeOneHot:
         """Test an invalid 'alphabet' parameter."""
         sp = aa.SequencePreprocessor()
         with pytest.raises(ValueError):
-            sp.encode_one_hot(alphabet=None)
+            sp.encode_one_hot(list_seq=["ACDEF"], alphabet=None)
         with pytest.raises(ValueError):
-            sp.encode_one_hot(alphabet="")
+            sp.encode_one_hot(list_seq=["ACDEF"], alphabet="")
         with pytest.raises(ValueError):
-            sp.encode_one_hot(alphabet=123)
+            sp.encode_one_hot(list_seq=["ACDEF"], alphabet=123)
 
     @settings(max_examples=10, deadline=None)
     @given(gap=st.text(min_size=1, max_size=1).filter(lambda g: g not in "ACDEFGHIKLMNPQRSTVWY"))
@@ -70,11 +70,11 @@ class TestEncodeOneHot:
         """Test an invalid 'gap' parameter."""
         sp = aa.SequencePreprocessor()
         with pytest.raises(ValueError):
-            sp.encode_one_hot(gap=None)
+            sp.encode_one_hot(list_seq=["ACDEF"], gap=None)
         with pytest.raises(ValueError):
-            sp.encode_one_hot(gap="")
+            sp.encode_one_hot(list_seq=["ACDEF"], gap="")
         with pytest.raises(ValueError):
-            sp.encode_one_hot(gap="INVALID")
+            sp.encode_one_hot(list_seq=["ACDEF"], gap="INVALID")
 
     @settings(max_examples=10, deadline=None)
     @given(pad_at=st.sampled_from(["N", "C"]))
@@ -90,11 +90,11 @@ class TestEncodeOneHot:
         """Test an invalid 'pad_at' parameter."""
         sp = aa.SequencePreprocessor()
         with pytest.raises(ValueError):
-            sp.encode_one_hot(pad_at=None)
+            sp.encode_one_hot(list_seq=["ACDEF"], pad_at=None)
         with pytest.raises(ValueError):
-            sp.encode_one_hot(pad_at="")
+            sp.encode_one_hot(list_seq=["ACDEF"], pad_at="")
         with pytest.raises(ValueError):
-            sp.encode_one_hot(pad_at="INVALID")
+            sp.encode_one_hot(list_seq=["ACDEF"], pad_at="INVALID")
 
 
 # Complex Cases

--- a/tests/unit/seq_analysis_pro_tests/test_scan_motif.py
+++ b/tests/unit/seq_analysis_pro_tests/test_scan_motif.py
@@ -83,7 +83,7 @@ class TestFindMotifMatchedViaFimo:
         with patch(*MOCK_WHICH, return_value="/usr/local/bin/fimo"):
             with pytest.raises(ValueError, match="motif_pwm"):
                 aa.scan_motif(df_seq=_df_seq_with_aaa(), pos_col="pos", n=5,
-                              window_size=5)
+                              window_size=5, motif_pwm=None)
 
     # --- df_seq / pos_col ---
     def test_invalid_df_seq_type(self):


### PR DESCRIPTION
## Problem

Following the type-honesty work in #232, many public parameters were typed
`Optional[T] = None` even though their Validate block **rejects** `None` — the
signature advertised "None is fine" while the call raised. This is misleading to
readers, IDEs, and agents, and contradicts the goal of honest, machine-readable
signatures. The trigger was `CPP.simplify(df_feat=None, labels=None)`, where both
are mandatory.

## What this does

Audited **all 162** required public params typed `Optional[T] = None` (full
per-parameter classification with evidence) and made every signature honest:

- **150 args that lead their signature** → drop the `= None` default and the
  `Optional` wrapper (`df_feat: pd.DataFrame`). **Non-breaking**: keyword *and*
  positional calls still work; only fully *omitting* a required arg now raises
  `TypeError` instead of the old friendly `ValueError`.
- **12 args that sit after a defaulted one** (can't de-default without reorder/`*`):
  - `AAclust.filter_coverage(df_cat)` → now default-loads
    `ut.load_default_scales(scale_cat=True)`, so `Optional` is **honest** (None =
    use default), consistent with every sibling — non-breaking.
  - 11 others (`AAclustPlot.centers`/`medoids` `labels`, `CPPPlot.feature`
    `df_seq`/`labels`, `StructurePreprocessor.encode_dssp`/`encode_domains`
    `features`, `ShapModel.add_sample_mean_dif` `df_feat`,
    `AAWindowSampler.sample_motif_matched` `motif_pwm`/`motif_score_threshold`,
    `scan_motif` `motif_pwm`, `SeqMutPlot.residue_mutation_impact` `pos`) → made
    **keyword-only** via a `*` placed before the stranded required arg. Verified
    no caller passes these positionally, so non-breaking.

Genuinely-optional params (`accept_none=True`, default-substitution,
None-means-skip, `random_state`/`n_jobs`/`ax`/styling) keep `Optional[T] = None`
— unchanged.

Also:
- Fix the missing blank line before `CPP.simplify`; guard method-to-method
  spacing with an AST test (`tests/unit/api_tests/test_style_method_spacing.py`).
- Document the convention in `code-conventions.md` + `frontend-backend.md`
  (required args = no default/no `Optional`; the `*` for a stranded required arg
  is the single sanctioned `*` use).

## Tests

16 tests that asserted a friendly `ValueError` on an *omitted* required arg now
pass the arg explicitly (`None` or invalid) so the `check_*` is still exercised.

- Full unit suite: **4660 passed**, 0 failed.
- Smoke gate (`-m smoke`), utils-barrel test, doc/signature drift (0): green.
- Advisory pyright: ~1091 (down from ~1232).

Rebased onto current master (incl. the #234–#238 stack); 3 plot-file conflicts
with the matplotlib-import burndown resolved keeping both the canonical `Axes`/
`Figure` naming and the honest signatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)