### PR TITLE
docs(adr): add ADR-0038 refining the agentic-readiness boundary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -588,6 +588,45 @@ Distinct from a numerical *value*: a value may drift within tolerance, a decisio
 may not (under T2) without escalating to T3.
 _Avoid_: result (overloaded), output (overloaded).
 
+### Agentic-readiness & package-boundary vocabulary
+
+These name the scope of the **agentic-readiness** program and the line between
+AAanalysis and **ProtXplain** (the downstream agent-integration package). See
+ADR-0035 (the original boundary) and ADR-0038 (the refinement below).
+
+**agentic readiness**:
+Making the OSS primitives maximally **legible, typed, contracted, and
+improvable** — for human users *and* for the coding agents that *improve* the
+package (consistent class templates, documented data contracts like `df_feat` /
+`DICT_DF_SCHEMAS`, honest type hints, tests). It is **not** an in-package
+agent-tool framework: the layer where external agents call AAanalysis *as a
+tool* is withheld to ProtXplain. Science/product work (structure-XAI, XAI-eval,
+the design bridge) is a separate track, **not** part of agentic readiness.
+_Avoid_: "agent support" (overloaded — conflates the two audiences below).
+
+**two agent audiences**:
+The distinction that resolves the word "agent". Agents that *improve* AAanalysis
+are served **in** AAanalysis (types, contracts, tests, templates). Agents that
+*use* AAanalysis as a tool are served by **ProtXplain** (the MCP /
+machine-readable tool contract). Usability + improvability stay here;
+tool-integration goes downstream.
+
+**machine-readable tool contract (boundary)**:
+The border between the two packages. The MCP server, JSON/tool schemas, verb
+orchestration, and selection/ranking/decision/OOD logic are **ProtXplain**;
+human- and sklearn-idiomatic convenience is **AAanalysis**. A boundary, like the
+**relational / interaction (scope boundary)** — not a feature AAanalysis is
+missing. See ADR-0038.
+
+**convenience facade / golden pipeline**:
+A user-facing one-call wrapper over the existing primitives, planned as the
+stateless `aaanalysis.pipe` (`aap`) namespace. Thin (no own algorithm),
+opt-in, with defaults byte-identical to the explicit primitive path; emits plain
+numpy/pandas that feed sklearn and torch equally (torch stays the `[embed]`
+extra). It is **AAanalysis**, not ProtXplain — convenience is on our side of the
+boundary.
+_Avoid_: "verb" / "tool" (those name the ProtXplain agent-integration layer).
+
 ## Relationships
 
 - A **df_seq** row contains one **entry** and one sequence; optionally a **pos column** cell of 1-based positions.

--- a/docs/adr/0038-agentic-readiness-boundary.md
+++ b/docs/adr/0038-agentic-readiness-boundary.md
@@ -1,0 +1,76 @@
+# ADR-0038 — Agentic-readiness boundary: usability/improvability is ours, agent integration is ProtXplain's
+
+Status: Accepted — 2026-06-23
+
+Refines [ADR-0035](0035-validation-ut-check-not-pydantic.md) — it does **not**
+supersede it. ADR-0035's decisions (D1 input validation stays `ut.check_*`; D2 no
+Pydantic/pandera dependency; D3 agent-typed contracts live in ProtXplain) stand
+unchanged. This ADR sharpens *which* layer is withheld from AAanalysis, because a
+later review read ADR-0035 as withholding all agent-facing work — including
+user-facing convenience — which was never the intent.
+
+## Context
+
+ADR-0035 placed typed I/O contracts, a "verb" facade, and the MCP / JSON-schema
+tool layer in ProtXplain, keeping AAanalysis to interpretable primitives plus a
+documented `df_feat` contract. A follow-up agentic-readiness review (a
+grill-with-docs session over external feedback) surfaced two genuinely
+uncaptured needs that ADR-0035's wording did not clearly place:
+
+1. A second, high-level **convenience API** so *users* get results in one call
+   (an mpl/`pyplot`-style facade over the existing primitives), and a
+   sklearn-compliant transformer so CPP composes in `sklearn.pipeline.Pipeline`.
+2. A clarified statement of **what "agentic readiness" means for this package**,
+   so improvability/usability work is not mistaken for the withheld
+   agent-integration layer.
+
+The ambiguity was the word "agent": ADR-0035 withholds the layer where *external
+agents call in as a tool*, not the work that makes the package legible, usable,
+and improvable — which serves both human users and the coding agents that
+*improve* the package.
+
+## Decision
+
+**D1. The withheld layer is *agent integration*, not usability or
+improvability.** ADR-0035 keeps the machine-readable tool contract, MCP server,
+verb/tool schemas, and selection/ranking/decision/OOD logic in ProtXplain. It
+does **not** withhold user-facing convenience or internal legibility from
+AAanalysis.
+
+**D2. Two agent audiences, drawn explicitly.** Agents that *improve* AAanalysis
+are served **in** AAanalysis — through type hints, documented data contracts,
+consistent class templates, tests, and legible primitives. Agents that *use*
+AAanalysis as a tool are served by **ProtXplain** — through the MCP /
+machine-readable tool contract. Usability and improvability stay here;
+tool-integration goes downstream.
+
+**D3. The border is the machine-readable tool contract.** Human- and
+sklearn-idiomatic convenience (a stateless `aaanalysis.pipe` facade of "golden
+pipelines"; a sklearn-compliant `SequenceFeatureTransformer`) is **AAanalysis**.
+The MCP server, JSON/tool schemas, and verb orchestration are **ProtXplain**.
+
+**D4. Ownership split.**
+- **AAanalysis owns:** legible scientific primitives; user-facing convenience
+  facades / golden pipelines (`aaanalysis.pipe`); plain numpy/pandas outputs that
+  feed sklearn and torch equally; maximal improvability for coding agents.
+- **ProtXplain owns:** the machine-readable tool contract; the MCP server;
+  verb/tool schemas; selection, ranking, decision, and OOD/uncertainty logic.
+
+## Consequences
+
+- A new `aaanalysis.pipe` (`aap`) convenience namespace and a
+  `SequenceFeatureTransformer` are **in scope** for AAanalysis, as a stateless,
+  thin facade whose defaults are byte-identical to the explicit primitive path
+  (no new algorithm, no new required dependency; torch stays the `[embed]`
+  extra). They are tracked as their own feature work, not built here.
+- "Agentic readiness" for AAanalysis means: legible/typed/contracted/**improvable**
+  primitives plus user-facing convenience — **not** an in-package agent-tool
+  framework, which remains ProtXplain's.
+- Science/product tracks (structure-XAI, XAI-eval, the design bridge) are a
+  separate roadmap, unaffected by this boundary.
+
+## Out of scope
+
+- The `aaanalysis.pipe` API and transformer implementation (tracked separately).
+- Anything ADR-0035 already placed in ProtXplain (typed request/result models,
+  MCP/tool schemas, ranking/decision/OOD) — unchanged.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -45,4 +45,5 @@ Regenerate this table with:
 | [0035](0035-validation-ut-check-not-pydantic.md) | Input validation stays `ut.check_*`; no Pydantic; agent-typed contracts live in ProtXplain | Accepted | 2026-06-22 |  |
 | [0036](0036-type-hints-contract-checker-deferred-pyright.md) | Ship `py.typed` and adopt pyright (non-blocking) now; type hints are the contract | Accepted | 2026-06-22 |  |
 | [0037](0037-perf-ab-gate.md) | Same-runner A/B vs the latest PyPI release makes wall-clock a merge gate | Accepted | 2026-06-22 |  |
+| [0038](0038-agentic-readiness-boundary.md) | Agentic-readiness boundary: usability/improvability is ours, agent integration is ProtXplain's | Accepted | 2026-06-23 |  |
 <!-- ADR-INDEX:END -->


### PR DESCRIPTION
## What

Adds **ADR-0038** refining (not superseding) ADR-0035, and a matching **CONTEXT.md** glossary subsection.

The earlier ADR-0035 was read by a later review as withholding *all* agent-facing work to ProtXplain — including user-facing convenience. That was never the intent. ADR-0038 sharpens *which* layer is withheld:

- **AAanalysis owns:** legible primitives; user-facing convenience facades / golden pipelines (`aaanalysis.pipe`); improvability for coding agents.
- **ProtXplain owns:** the machine-readable tool contract, the MCP server, verb/tool schemas, selection/ranking/decision/OOD.
- **Border = the machine-readable tool contract.**

ADR-0035's D1–D3 are untouched (immutable-once-Accepted convention honored by writing a new refining ADR rather than editing in place).

## Changes
- `docs/adr/0038-agentic-readiness-boundary.md` (new; Status: Accepted)
- `CONTEXT.md` — new "Agentic-readiness & package-boundary vocabulary" subsection (agentic readiness, two agent audiences, the tool-contract boundary, convenience facade)
- `docs/adr/INDEX.md` — regenerated (37 ADRs)

## Verification
- `check_adrs.py`: **0 defects** (2 pre-existing advisories on ADR-0005/0009, untouched).
- Docs-only; no `aaanalysis/**` or test changes; no CONFIRM-FIRST surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)