### PR TITLE
docs(api): document canonical label parameter names (#132)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -149,6 +149,21 @@ labels per tier. Lets a regression target be profiled at increasing positive-vs-
 separation. `SequenceFeature.get_labels_tiered`.
 _Avoid_: banded regression (reserved for the deferred banded-regression task), graded labels.
 
+**label parameter names (canonical)**:
+Four *distinct* labeling concepts, each with one canonical parameter name — similar
+spellings name different things, so they are kept separate rather than unified:
+- **`label_test` / `label_ref`** — the two groups of a **contrast** (positive/test vs
+  reference): `CPP.run`/`eval`, `AAlogo.get_df_logo`.
+- **`labels`** — a **single** 1D per-sample class-label vector `(n_samples,)`:
+  `CPP.run`, `TreeModel.fit`/`eval`, `ShapModel.fit`, `dPULearn.fit`.
+- **`list_labels`** — a **2D list of labelings** `(n_datasets, n_samples)` with
+  `names_datasets`: `AAclust.eval`, `dPULearn.eval`. Plural on purpose.
+- **`label_target_class`** — a **single target class to attribute** in SHAP
+  (`ShapModel.fit`); can be *any* class (positive, negative, or a multi-class index),
+  so it is **not** `label_test` and keeps its own name.
+_Avoid_: renaming `label_target_class` to `label_test` (conflates a general target-class
+selector with the test-vs-reference contrast); collapsing `list_labels` into `labels`.
+
 ### Window sampling vocabulary
 
 **window**:

--- a/docs/source/index/docstring_guide.rst
+++ b/docs/source/index/docstring_guide.rst
@@ -399,6 +399,41 @@ the *class-instance* names above are checked).
 ``df_top15``) — used **only when you actually have a variant**, not stamped onto
 every example. Class instances stay the bare abbreviation (see above).
 
+Label parameter names
+---------------------
+
+Each labeling **concept** has one canonical parameter name, used consistently
+across the classes a user combines in one workflow. Several names look similar
+but name *different* concepts — keep them distinct rather than collapsing them.
+
+.. list-table:: Canonical label parameter names
+   :header-rows: 1
+   :widths: 28 20 52
+
+   * - Concept
+     - Canonical name
+     - Notes
+   * - Contrast markers (the two groups being compared)
+     - ``label_test`` / ``label_ref``
+     - The positive/test group vs the reference group of a *contrast* —
+       ``CPP.run`` / ``CPP.eval``, ``AAlogo.get_df_logo``.
+   * - Single labeling (1D)
+     - ``labels``
+     - One per-sample class-label vector, shape ``(n_samples,)`` — e.g.
+       ``CPP.run``, ``TreeModel.fit`` / ``eval``, ``ShapModel.fit``,
+       ``dPULearn.fit``.
+   * - List of labelings (2D, multi-dataset)
+     - ``list_labels``
+     - Several labelings stacked, shape ``(n_datasets, n_samples)``, paired with
+       ``names_datasets`` — ``AAclust.eval``, ``dPULearn.eval``. Distinct from
+       ``labels`` **on purpose**: the plural marks a list of datasets, not one.
+   * - Target-class selector (a single class to attribute)
+     - ``label_target_class``
+     - ``ShapModel.fit`` — the one class whose model prediction the SHAP values
+       explain. It can be **any** class (the positive, the negative/reference,
+       or any index in a multi-class model), so it is **not** the same concept as
+       ``label_test`` and deliberately keeps its own name.
+
 Examples & verification
 -----------------------
 


### PR DESCRIPTION
## What

Resolves the legibility concern in #132 by **documenting** the canonical label
parameter vocabulary — without renaming any parameter.

## Why no rename

#132 proposed unifying `ShapModel.fit`'s `label_target_class` to the canonical
`label_test`, and possibly `list_labels` → `labels`. Inspection (and a maintainer
review) showed these are **genuinely distinct concepts**, not inconsistent names:

- `label_target_class` (`ShapModel.fit`) selects the **single class whose model
  prediction the SHAP values explain** — it can be *any* class (positive, the
  negative/reference, or a multi-class index). `label_test` specifically means the
  positive/test group of a **contrast** (`CPP`). Renaming would mislabel a general
  target-class selector, e.g. `label_test=0` (the negative class) is self-contradictory.
- `list_labels` (2D, `(n_datasets, n_samples)`, paired with `names_datasets`) on
  `AAclust.eval` / `dPULearn.eval` is a **list of labelings**, distinct from the 1D
  single `labels` on `TreeModel.eval`. The plural is meaningful.

So the right fix is to **document** the four concepts and their canonical names, not
to collapse them.

## Changes
- `docs/source/index/docstring_guide.rst` — new "Label parameter names" table
  (concept → canonical name → notes).
- `CONTEXT.md` — matching "label parameter names (canonical)" glossary term.

Docs-only; no `aaanalysis/**` or test changes; no CONFIRM-FIRST surface touched.

Addresses #132 (kept open for the maintainer to confirm the document-don't-rename outcome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)