### PR TITLE
feat(pipe): aaanalysis.pipe (aap) convenience API + aap.predict (#241)

### DIFF
--- a/aaanalysis/pipe/__init__.py
+++ b/aaanalysis/pipe/__init__.py
@@ -1,0 +1,27 @@
+"""
+``aaanalysis.pipe`` (aap) — high-level convenience pipelines (golden pipelines).
+
+A second, opt-in API on top of the AAanalysis primitives: stateless, thin wrappers that chain
+the existing classes into one call so users get a result without hand-wiring every step. Import it
+explicitly under the conventional alias::
+
+    import aaanalysis.pipe as aap
+
+The wrappers add no algorithm of their own — their defaults are byte-identical to the explicit
+primitive path (e.g. :meth:`SequenceFeature.feature_matrix` → :class:`TreeModel`), they return plain
+numpy/pandas objects, and they thread ``random_state`` / ``n_jobs`` through. Machine-readable tool
+contracts (MCP, verb/tool schemas) are intentionally **not** here; this layer is human- and
+sklearn-idiomatic convenience only.
+
+Public objects
+--------------
+* :func:`predict` — build the feature matrix from ``df_feat`` and fit + evaluate a :class:`TreeModel`.
+
+See Also
+--------
+* :mod:`aaanalysis.feature_engineering` — the primitives these pipelines wrap.
+* :mod:`aaanalysis.explainable_ai` — :class:`TreeModel`, the predictor used by :func:`predict`.
+"""
+from ._pipelines import predict
+
+__all__ = ["predict"]

--- a/aaanalysis/pipe/_pipelines.py
+++ b/aaanalysis/pipe/_pipelines.py
@@ -1,0 +1,85 @@
+"""
+This is a script for the frontend of the ``aaanalysis.pipe`` (aap) golden pipelines:
+thin, stateless one-call wrappers over the existing AAanalysis primitives.
+"""
+from typing import Optional, List, Type, Tuple, Union
+import pandas as pd
+from sklearn.base import ClassifierMixin, BaseEstimator
+
+import aaanalysis.utils as ut
+from aaanalysis.feature_engineering import SequenceFeature
+from aaanalysis.explainable_ai import TreeModel
+
+
+# I Helper Functions
+
+
+# II Main Functions
+def predict(df_feat: pd.DataFrame,
+            df_parts: pd.DataFrame,
+            labels: ut.ArrayLike1D,
+            list_model_classes: Optional[List[Type[Union[ClassifierMixin, BaseEstimator]]]] = None,
+            n_cv: int = 5,
+            random_state: Optional[int] = None,
+            n_jobs: Optional[int] = None,
+            verbose: bool = False,
+            ) -> Tuple[TreeModel, pd.DataFrame]:
+    """
+    Predict from a feature set in one call: build the feature matrix, fit tree models, and evaluate.
+
+    A thin, stateless facade over the explicit primitive path. It rebuilds the feature matrix ``X``
+    from the feature identifiers in ``df_feat`` (via :meth:`SequenceFeature.feature_matrix`), fits a
+    :class:`TreeModel`, and returns the fitted model together with a cross-validated evaluation. The
+    defaults are byte-identical to writing the three calls by hand.
+
+    Parameters
+    ----------
+    df_feat : pd.DataFrame, shape (n_features, n_feature_info)
+        Feature DataFrame with a ``feature`` column of feature identifiers (e.g. from :meth:`CPP.run`
+        or :func:`load_features`).
+    df_parts : pd.DataFrame, shape (n_samples, n_parts)
+        Sequence parts DataFrame (from :meth:`SequenceFeature.get_df_parts`), row-aligned to ``labels``.
+    labels : array-like, shape (n_samples,)
+        Class labels for the samples (typically, 1=positive, 0=negative).
+    list_model_classes : list of Type, optional
+        Tree-based model classes passed to :class:`TreeModel`. If ``None``, the ``TreeModel`` default is used.
+    n_cv : int, default=5
+        Number of cross-validation folds for the evaluation, must be > 1 and ≤ the smallest class count.
+    random_state : int, optional
+        The seed used by the random number generator. If a positive integer, results of stochastic
+        processes are reproducible.
+    n_jobs : int, optional
+        Number of CPU cores (>=1) for building the feature matrix. If ``None``, the optimized number is used.
+    verbose : bool, default=False
+        If ``True``, verbose progress information is printed.
+
+    Returns
+    -------
+    model : TreeModel
+        The fitted :class:`TreeModel` instance.
+    df_eval : pd.DataFrame
+        Cross-validated evaluation results for the fitted feature selection.
+
+    See Also
+    --------
+    * :meth:`SequenceFeature.feature_matrix` for building ``X`` from feature identifiers.
+    * :class:`TreeModel` for the underlying tree-based prediction and evaluation.
+
+    Examples
+    --------
+    .. include:: examples/aap_predict.rst
+    """
+    # Validate (thin facade: the wrapped primitives validate the rest)
+    df_feat = ut.check_df_feat(df_feat=df_feat)
+    ut.check_df_parts(df_parts=df_parts)
+    ut.check_number_range(name="n_cv", val=n_cv, min_val=2, just_int=True)
+    ut.check_number_range(name="random_state", val=random_state, min_val=0, just_int=True, accept_none=True)
+    ut.check_bool(name="verbose", val=verbose)
+    # Build the feature matrix from the feature identifiers in df_feat
+    sf = SequenceFeature()
+    X = sf.feature_matrix(features=df_feat[ut.COL_FEATURE], df_parts=df_parts, n_jobs=n_jobs)
+    # Fit tree-based models and cross-validated evaluation (byte-identical to the manual chain)
+    tm = TreeModel(list_model_classes=list_model_classes, random_state=random_state, verbose=verbose)
+    tm.fit(X, labels=labels, n_cv=n_cv)
+    df_eval = tm.eval(X, labels=labels, list_is_selected=[tm.is_selected_], n_cv=n_cv)
+    return tm, df_eval

--- a/examples/pipe/aap_predict.ipynb
+++ b/examples/pipe/aap_predict.ipynb
@@ -1,0 +1,490 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "365ed4a6",
+   "metadata": {},
+   "source": [
+    "The ``aaanalysis.pipe`` (``aap``) module provides high-level **golden pipelines** — stateless, one-call wrappers over the AAanalysis primitives. ``aap.predict`` takes a feature set (``df_feat``) and the sequence parts (``df_parts``), rebuilds the feature matrix, fits a ``TreeModel``, and returns the fitted model together with a cross-validated evaluation. Its defaults are byte-identical to writing the explicit ``feature_matrix`` → ``TreeModel.fit`` → ``TreeModel.eval`` chain by hand.\n",
+    "\n",
+    "We first load the ``DOM_GSEC`` example dataset, a small feature set, and the sequence parts (see [Breimann25]_):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "fd759278",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T22:47:09.400665Z",
+     "iopub.status.busy": "2026-06-23T22:47:09.400561Z",
+     "iopub.status.idle": "2026-06-23T22:47:10.677481Z",
+     "shell.execute_reply": "2026-06-23T22:47:10.677280Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DataFrame shape: (8, 15)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "#T_beec9 thead th {\n",
+       "  background-color: white;\n",
+       "  color: black;\n",
+       "}\n",
+       "#T_beec9 tbody tr:nth-child(odd) {\n",
+       "  background-color: #f2f2f2;\n",
+       "}\n",
+       "#T_beec9 tbody tr:nth-child(even) {\n",
+       "  background-color: white;\n",
+       "}\n",
+       "#T_beec9 th {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "#T_beec9  td {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "</style>\n",
+       "<table id=\"T_beec9\" style='display:block; max-height: 300px; max-width: 100%; overflow-x: auto; overflow-y: auto;'>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_beec9_level0_col0\" class=\"col_heading level0 col0\" >feature</th>\n",
+       "      <th id=\"T_beec9_level0_col1\" class=\"col_heading level0 col1\" >category</th>\n",
+       "      <th id=\"T_beec9_level0_col2\" class=\"col_heading level0 col2\" >subcategory</th>\n",
+       "      <th id=\"T_beec9_level0_col3\" class=\"col_heading level0 col3\" >scale_name</th>\n",
+       "      <th id=\"T_beec9_level0_col4\" class=\"col_heading level0 col4\" >scale_description</th>\n",
+       "      <th id=\"T_beec9_level0_col5\" class=\"col_heading level0 col5\" >abs_auc</th>\n",
+       "      <th id=\"T_beec9_level0_col6\" class=\"col_heading level0 col6\" >abs_mean_dif</th>\n",
+       "      <th id=\"T_beec9_level0_col7\" class=\"col_heading level0 col7\" >mean_dif</th>\n",
+       "      <th id=\"T_beec9_level0_col8\" class=\"col_heading level0 col8\" >std_test</th>\n",
+       "      <th id=\"T_beec9_level0_col9\" class=\"col_heading level0 col9\" >std_ref</th>\n",
+       "      <th id=\"T_beec9_level0_col10\" class=\"col_heading level0 col10\" >p_val_mann_whitney</th>\n",
+       "      <th id=\"T_beec9_level0_col11\" class=\"col_heading level0 col11\" >p_val_fdr_bh</th>\n",
+       "      <th id=\"T_beec9_level0_col12\" class=\"col_heading level0 col12\" >positions</th>\n",
+       "      <th id=\"T_beec9_level0_col13\" class=\"col_heading level0 col13\" >feat_importance</th>\n",
+       "      <th id=\"T_beec9_level0_col14\" class=\"col_heading level0 col14\" >feat_importance_std</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_beec9_level0_row0\" class=\"row_heading level0 row0\" >1</th>\n",
+       "      <td id=\"T_beec9_row0_col0\" class=\"data row0 col0\" >TMD_C_JMD_C-Seg...3,4)-KLEP840101</td>\n",
+       "      <td id=\"T_beec9_row0_col1\" class=\"data row0 col1\" >Energy</td>\n",
+       "      <td id=\"T_beec9_row0_col2\" class=\"data row0 col2\" >Charge</td>\n",
+       "      <td id=\"T_beec9_row0_col3\" class=\"data row0 col3\" >Charge</td>\n",
+       "      <td id=\"T_beec9_row0_col4\" class=\"data row0 col4\" >Net charge (Kle...n et al., 1984)</td>\n",
+       "      <td id=\"T_beec9_row0_col5\" class=\"data row0 col5\" >0.244000</td>\n",
+       "      <td id=\"T_beec9_row0_col6\" class=\"data row0 col6\" >0.103666</td>\n",
+       "      <td id=\"T_beec9_row0_col7\" class=\"data row0 col7\" >0.103666</td>\n",
+       "      <td id=\"T_beec9_row0_col8\" class=\"data row0 col8\" >0.106692</td>\n",
+       "      <td id=\"T_beec9_row0_col9\" class=\"data row0 col9\" >0.110506</td>\n",
+       "      <td id=\"T_beec9_row0_col10\" class=\"data row0 col10\" >0.000000</td>\n",
+       "      <td id=\"T_beec9_row0_col11\" class=\"data row0 col11\" >0.000000</td>\n",
+       "      <td id=\"T_beec9_row0_col12\" class=\"data row0 col12\" >31,32,33,34,35</td>\n",
+       "      <td id=\"T_beec9_row0_col13\" class=\"data row0 col13\" >0.970400</td>\n",
+       "      <td id=\"T_beec9_row0_col14\" class=\"data row0 col14\" >1.438918</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_beec9_level0_row1\" class=\"row_heading level0 row1\" >2</th>\n",
+       "      <td id=\"T_beec9_row1_col0\" class=\"data row1 col0\" >TMD_C_JMD_C-Seg...3,4)-FINA910104</td>\n",
+       "      <td id=\"T_beec9_row1_col1\" class=\"data row1 col1\" >Conformation</td>\n",
+       "      <td id=\"T_beec9_row1_col2\" class=\"data row1 col2\" >α-helix (C-cap)</td>\n",
+       "      <td id=\"T_beec9_row1_col3\" class=\"data row1 col3\" >α-helix termination</td>\n",
+       "      <td id=\"T_beec9_row1_col4\" class=\"data row1 col4\" >Helix terminati...n et al., 1991)</td>\n",
+       "      <td id=\"T_beec9_row1_col5\" class=\"data row1 col5\" >0.243000</td>\n",
+       "      <td id=\"T_beec9_row1_col6\" class=\"data row1 col6\" >0.085064</td>\n",
+       "      <td id=\"T_beec9_row1_col7\" class=\"data row1 col7\" >0.085064</td>\n",
+       "      <td id=\"T_beec9_row1_col8\" class=\"data row1 col8\" >0.098774</td>\n",
+       "      <td id=\"T_beec9_row1_col9\" class=\"data row1 col9\" >0.096946</td>\n",
+       "      <td id=\"T_beec9_row1_col10\" class=\"data row1 col10\" >0.000000</td>\n",
+       "      <td id=\"T_beec9_row1_col11\" class=\"data row1 col11\" >0.000000</td>\n",
+       "      <td id=\"T_beec9_row1_col12\" class=\"data row1 col12\" >31,32,33,34,35</td>\n",
+       "      <td id=\"T_beec9_row1_col13\" class=\"data row1 col13\" >0.000000</td>\n",
+       "      <td id=\"T_beec9_row1_col14\" class=\"data row1 col14\" >0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_beec9_level0_row2\" class=\"row_heading level0 row2\" >3</th>\n",
+       "      <td id=\"T_beec9_row2_col0\" class=\"data row2 col0\" >TMD_C_JMD_C-Seg...6,9)-LEVM760105</td>\n",
+       "      <td id=\"T_beec9_row2_col1\" class=\"data row2 col1\" >Shape</td>\n",
+       "      <td id=\"T_beec9_row2_col2\" class=\"data row2 col2\" >Side chain length</td>\n",
+       "      <td id=\"T_beec9_row2_col3\" class=\"data row2 col3\" >Side chain length</td>\n",
+       "      <td id=\"T_beec9_row2_col4\" class=\"data row2 col4\" >Radius of gyrat... (Levitt, 1976)</td>\n",
+       "      <td id=\"T_beec9_row2_col5\" class=\"data row2 col5\" >0.233000</td>\n",
+       "      <td id=\"T_beec9_row2_col6\" class=\"data row2 col6\" >0.137044</td>\n",
+       "      <td id=\"T_beec9_row2_col7\" class=\"data row2 col7\" >0.137044</td>\n",
+       "      <td id=\"T_beec9_row2_col8\" class=\"data row2 col8\" >0.161683</td>\n",
+       "      <td id=\"T_beec9_row2_col9\" class=\"data row2 col9\" >0.176964</td>\n",
+       "      <td id=\"T_beec9_row2_col10\" class=\"data row2 col10\" >0.000000</td>\n",
+       "      <td id=\"T_beec9_row2_col11\" class=\"data row2 col11\" >0.000001</td>\n",
+       "      <td id=\"T_beec9_row2_col12\" class=\"data row2 col12\" >32,33</td>\n",
+       "      <td id=\"T_beec9_row2_col13\" class=\"data row2 col13\" >1.554800</td>\n",
+       "      <td id=\"T_beec9_row2_col14\" class=\"data row2 col14\" >2.109848</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_beec9_level0_row3\" class=\"row_heading level0 row3\" >4</th>\n",
+       "      <td id=\"T_beec9_row3_col0\" class=\"data row3 col0\" >TMD_C_JMD_C-Seg...3,4)-HUTJ700102</td>\n",
+       "      <td id=\"T_beec9_row3_col1\" class=\"data row3 col1\" >Energy</td>\n",
+       "      <td id=\"T_beec9_row3_col2\" class=\"data row3 col2\" >Entropy</td>\n",
+       "      <td id=\"T_beec9_row3_col3\" class=\"data row3 col3\" >Entropy</td>\n",
+       "      <td id=\"T_beec9_row3_col4\" class=\"data row3 col4\" >Absolute entrop...Hutchens, 1970)</td>\n",
+       "      <td id=\"T_beec9_row3_col5\" class=\"data row3 col5\" >0.229000</td>\n",
+       "      <td id=\"T_beec9_row3_col6\" class=\"data row3 col6\" >0.098224</td>\n",
+       "      <td id=\"T_beec9_row3_col7\" class=\"data row3 col7\" >0.098224</td>\n",
+       "      <td id=\"T_beec9_row3_col8\" class=\"data row3 col8\" >0.106865</td>\n",
+       "      <td id=\"T_beec9_row3_col9\" class=\"data row3 col9\" >0.124608</td>\n",
+       "      <td id=\"T_beec9_row3_col10\" class=\"data row3 col10\" >0.000000</td>\n",
+       "      <td id=\"T_beec9_row3_col11\" class=\"data row3 col11\" >0.000001</td>\n",
+       "      <td id=\"T_beec9_row3_col12\" class=\"data row3 col12\" >31,32,33,34,35</td>\n",
+       "      <td id=\"T_beec9_row3_col13\" class=\"data row3 col13\" >3.111200</td>\n",
+       "      <td id=\"T_beec9_row3_col14\" class=\"data row3 col14\" >3.109955</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_beec9_level0_row4\" class=\"row_heading level0 row4\" >5</th>\n",
+       "      <td id=\"T_beec9_row4_col0\" class=\"data row4 col0\" >TMD_C_JMD_C-Seg...6,9)-RADA880106</td>\n",
+       "      <td id=\"T_beec9_row4_col1\" class=\"data row4 col1\" >ASA/Volume</td>\n",
+       "      <td id=\"T_beec9_row4_col2\" class=\"data row4 col2\" >Volume</td>\n",
+       "      <td id=\"T_beec9_row4_col3\" class=\"data row4 col3\" >Accessible surface area (ASA)</td>\n",
+       "      <td id=\"T_beec9_row4_col4\" class=\"data row4 col4\" >Accessible surf...olfenden, 1988)</td>\n",
+       "      <td id=\"T_beec9_row4_col5\" class=\"data row4 col5\" >0.223000</td>\n",
+       "      <td id=\"T_beec9_row4_col6\" class=\"data row4 col6\" >0.095071</td>\n",
+       "      <td id=\"T_beec9_row4_col7\" class=\"data row4 col7\" >0.095071</td>\n",
+       "      <td id=\"T_beec9_row4_col8\" class=\"data row4 col8\" >0.114758</td>\n",
+       "      <td id=\"T_beec9_row4_col9\" class=\"data row4 col9\" >0.132829</td>\n",
+       "      <td id=\"T_beec9_row4_col10\" class=\"data row4 col10\" >0.000000</td>\n",
+       "      <td id=\"T_beec9_row4_col11\" class=\"data row4 col11\" >0.000002</td>\n",
+       "      <td id=\"T_beec9_row4_col12\" class=\"data row4 col12\" >32,33</td>\n",
+       "      <td id=\"T_beec9_row4_col13\" class=\"data row4 col13\" >0.000000</td>\n",
+       "      <td id=\"T_beec9_row4_col14\" class=\"data row4 col14\" >0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_beec9_level0_row5\" class=\"row_heading level0 row5\" >6</th>\n",
+       "      <td id=\"T_beec9_row5_col0\" class=\"data row5 col0\" >TMD_C_JMD_C-Seg...2,3)-KLEP840101</td>\n",
+       "      <td id=\"T_beec9_row5_col1\" class=\"data row5 col1\" >Energy</td>\n",
+       "      <td id=\"T_beec9_row5_col2\" class=\"data row5 col2\" >Charge</td>\n",
+       "      <td id=\"T_beec9_row5_col3\" class=\"data row5 col3\" >Charge</td>\n",
+       "      <td id=\"T_beec9_row5_col4\" class=\"data row5 col4\" >Net charge (Kle...n et al., 1984)</td>\n",
+       "      <td id=\"T_beec9_row5_col5\" class=\"data row5 col5\" >0.222000</td>\n",
+       "      <td id=\"T_beec9_row5_col6\" class=\"data row5 col6\" >0.058671</td>\n",
+       "      <td id=\"T_beec9_row5_col7\" class=\"data row5 col7\" >0.058671</td>\n",
+       "      <td id=\"T_beec9_row5_col8\" class=\"data row5 col8\" >0.064895</td>\n",
+       "      <td id=\"T_beec9_row5_col9\" class=\"data row5 col9\" >0.069547</td>\n",
+       "      <td id=\"T_beec9_row5_col10\" class=\"data row5 col10\" >0.000000</td>\n",
+       "      <td id=\"T_beec9_row5_col11\" class=\"data row5 col11\" >0.000001</td>\n",
+       "      <td id=\"T_beec9_row5_col12\" class=\"data row5 col12\" >27,28,29,30,31,32,33</td>\n",
+       "      <td id=\"T_beec9_row5_col13\" class=\"data row5 col13\" >0.000000</td>\n",
+       "      <td id=\"T_beec9_row5_col14\" class=\"data row5 col14\" >0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_beec9_level0_row6\" class=\"row_heading level0 row6\" >7</th>\n",
+       "      <td id=\"T_beec9_row6_col0\" class=\"data row6 col0\" >TMD_C_JMD_C-Seg...4,5)-FAUJ880109</td>\n",
+       "      <td id=\"T_beec9_row6_col1\" class=\"data row6 col1\" >Energy</td>\n",
+       "      <td id=\"T_beec9_row6_col2\" class=\"data row6 col2\" >Isoelectric point</td>\n",
+       "      <td id=\"T_beec9_row6_col3\" class=\"data row6 col3\" >Number hydrogen bond donors</td>\n",
+       "      <td id=\"T_beec9_row6_col4\" class=\"data row6 col4\" >Number of hydro...e et al., 1988)</td>\n",
+       "      <td id=\"T_beec9_row6_col5\" class=\"data row6 col5\" >0.215000</td>\n",
+       "      <td id=\"T_beec9_row6_col6\" class=\"data row6 col6\" >0.146661</td>\n",
+       "      <td id=\"T_beec9_row6_col7\" class=\"data row6 col7\" >0.146661</td>\n",
+       "      <td id=\"T_beec9_row6_col8\" class=\"data row6 col8\" >0.174609</td>\n",
+       "      <td id=\"T_beec9_row6_col9\" class=\"data row6 col9\" >0.188034</td>\n",
+       "      <td id=\"T_beec9_row6_col10\" class=\"data row6 col10\" >0.000000</td>\n",
+       "      <td id=\"T_beec9_row6_col11\" class=\"data row6 col11\" >0.000004</td>\n",
+       "      <td id=\"T_beec9_row6_col12\" class=\"data row6 col12\" >33,34,35,36</td>\n",
+       "      <td id=\"T_beec9_row6_col13\" class=\"data row6 col13\" >1.032400</td>\n",
+       "      <td id=\"T_beec9_row6_col14\" class=\"data row6 col14\" >1.510722</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_beec9_level0_row7\" class=\"row_heading level0 row7\" >8</th>\n",
+       "      <td id=\"T_beec9_row7_col0\" class=\"data row7 col0\" >TMD_C_JMD_C-Seg...3,4)-JANJ780101</td>\n",
+       "      <td id=\"T_beec9_row7_col1\" class=\"data row7 col1\" >ASA/Volume</td>\n",
+       "      <td id=\"T_beec9_row7_col2\" class=\"data row7 col2\" >Accessible surface area (ASA)</td>\n",
+       "      <td id=\"T_beec9_row7_col3\" class=\"data row7 col3\" >ASA (folded protein)</td>\n",
+       "      <td id=\"T_beec9_row7_col4\" class=\"data row7 col4\" >Average accessi...n et al., 1978)</td>\n",
+       "      <td id=\"T_beec9_row7_col5\" class=\"data row7 col5\" >0.215000</td>\n",
+       "      <td id=\"T_beec9_row7_col6\" class=\"data row7 col6\" >0.124317</td>\n",
+       "      <td id=\"T_beec9_row7_col7\" class=\"data row7 col7\" >0.124317</td>\n",
+       "      <td id=\"T_beec9_row7_col8\" class=\"data row7 col8\" >0.166309</td>\n",
+       "      <td id=\"T_beec9_row7_col9\" class=\"data row7 col9\" >0.153364</td>\n",
+       "      <td id=\"T_beec9_row7_col10\" class=\"data row7 col10\" >0.000000</td>\n",
+       "      <td id=\"T_beec9_row7_col11\" class=\"data row7 col11\" >0.000004</td>\n",
+       "      <td id=\"T_beec9_row7_col12\" class=\"data row7 col12\" >31,32,33,34,35</td>\n",
+       "      <td id=\"T_beec9_row7_col13\" class=\"data row7 col13\" >1.080400</td>\n",
+       "      <td id=\"T_beec9_row7_col14\" class=\"data row7 col14\" >1.296094</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import aaanalysis as aa\n",
+    "import aaanalysis.pipe as aap\n",
+    "aa.options[\"verbose\"] = False\n",
+    "\n",
+    "df_seq = aa.load_dataset(name=\"DOM_GSEC\", n=20)\n",
+    "labels = df_seq[\"label\"].to_list()\n",
+    "df_feat = aa.load_features().head(8)\n",
+    "sf = aa.SequenceFeature()\n",
+    "df_parts = sf.get_df_parts(df_seq=df_seq)\n",
+    "\n",
+    "aa.display_df(df_feat, n_rows=10, show_shape=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f365d38",
+   "metadata": {},
+   "source": [
+    "A single call returns the fitted ``model`` and the evaluation ``df_eval``. Use ``random_state`` for reproducibility:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1d977444",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T22:47:10.678577Z",
+     "iopub.status.busy": "2026-06-23T22:47:10.678510Z",
+     "iopub.status.idle": "2026-06-23T22:47:16.552416Z",
+     "shell.execute_reply": "2026-06-23T22:47:16.552192Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/stephanbreimann/Programming/1Packages/aa-wt-pipe/aaanalysis/feature_engineering/_backend/cpp_run.py:163: UserWarning: CPP is using the Python kernel fallback — the compiled Cython extension is not available in this install. Output is bit-exact with the Cython path but ~2x slower. Reinstall via `pip install --force-reinstall aaanalysis` to fetch a prebuilt wheel.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DataFrame shape: (1, 5)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "#T_44e89 thead th {\n",
+       "  background-color: white;\n",
+       "  color: black;\n",
+       "}\n",
+       "#T_44e89 tbody tr:nth-child(odd) {\n",
+       "  background-color: #f2f2f2;\n",
+       "}\n",
+       "#T_44e89 tbody tr:nth-child(even) {\n",
+       "  background-color: white;\n",
+       "}\n",
+       "#T_44e89 th {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "#T_44e89  td {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "</style>\n",
+       "<table id=\"T_44e89\" style='display:block; max-height: 300px; max-width: 100%; overflow-x: auto; overflow-y: auto;'>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_44e89_level0_col0\" class=\"col_heading level0 col0\" >name</th>\n",
+       "      <th id=\"T_44e89_level0_col1\" class=\"col_heading level0 col1\" >accuracy</th>\n",
+       "      <th id=\"T_44e89_level0_col2\" class=\"col_heading level0 col2\" >precision</th>\n",
+       "      <th id=\"T_44e89_level0_col3\" class=\"col_heading level0 col3\" >recall</th>\n",
+       "      <th id=\"T_44e89_level0_col4\" class=\"col_heading level0 col4\" >f1</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_44e89_level0_row0\" class=\"row_heading level0 row0\" >1</th>\n",
+       "      <td id=\"T_44e89_row0_col0\" class=\"data row0 col0\" >Set 1</td>\n",
+       "      <td id=\"T_44e89_row0_col1\" class=\"data row0 col1\" >0.737500</td>\n",
+       "      <td id=\"T_44e89_row0_col2\" class=\"data row0 col2\" >0.815000</td>\n",
+       "      <td id=\"T_44e89_row0_col3\" class=\"data row0 col3\" >0.650000</td>\n",
+       "      <td id=\"T_44e89_row0_col4\" class=\"data row0 col4\" >0.699600</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "model, df_eval = aap.predict(df_feat, df_parts, labels=labels, random_state=42)\n",
+    "\n",
+    "aa.display_df(df_eval, n_rows=10, show_shape=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ec902c2",
+   "metadata": {},
+   "source": [
+    "The tree-based models (``list_model_classes``), the number of cross-validation folds (``n_cv``), the CPU cores for building the feature matrix (``n_jobs``), and verbosity (``verbose``) can all be set explicitly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ccb505e5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T22:47:16.553564Z",
+     "iopub.status.busy": "2026-06-23T22:47:16.553473Z",
+     "iopub.status.idle": "2026-06-23T22:47:21.337921Z",
+     "shell.execute_reply": "2026-06-23T22:47:21.337696Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DataFrame shape: (1, 5)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "#T_54fa1 thead th {\n",
+       "  background-color: white;\n",
+       "  color: black;\n",
+       "}\n",
+       "#T_54fa1 tbody tr:nth-child(odd) {\n",
+       "  background-color: #f2f2f2;\n",
+       "}\n",
+       "#T_54fa1 tbody tr:nth-child(even) {\n",
+       "  background-color: white;\n",
+       "}\n",
+       "#T_54fa1 th {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "#T_54fa1  td {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "</style>\n",
+       "<table id=\"T_54fa1\" style='display:block; max-height: 300px; max-width: 100%; overflow-x: auto; overflow-y: auto;'>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_54fa1_level0_col0\" class=\"col_heading level0 col0\" >name</th>\n",
+       "      <th id=\"T_54fa1_level0_col1\" class=\"col_heading level0 col1\" >accuracy</th>\n",
+       "      <th id=\"T_54fa1_level0_col2\" class=\"col_heading level0 col2\" >precision</th>\n",
+       "      <th id=\"T_54fa1_level0_col3\" class=\"col_heading level0 col3\" >recall</th>\n",
+       "      <th id=\"T_54fa1_level0_col4\" class=\"col_heading level0 col4\" >f1</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_54fa1_level0_row0\" class=\"row_heading level0 row0\" >1</th>\n",
+       "      <td id=\"T_54fa1_row0_col0\" class=\"data row0 col0\" >Set 1</td>\n",
+       "      <td id=\"T_54fa1_row0_col1\" class=\"data row0 col1\" >0.762500</td>\n",
+       "      <td id=\"T_54fa1_row0_col2\" class=\"data row0 col2\" >0.878600</td>\n",
+       "      <td id=\"T_54fa1_row0_col3\" class=\"data row0 col3\" >0.675000</td>\n",
+       "      <td id=\"T_54fa1_row0_col4\" class=\"data row0 col4\" >0.716400</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from sklearn.ensemble import RandomForestClassifier, ExtraTreesClassifier\n",
+    "\n",
+    "model, df_eval = aap.predict(df_feat, df_parts, labels=labels,\n",
+    "                             list_model_classes=[RandomForestClassifier, ExtraTreesClassifier],\n",
+    "                             n_cv=4, random_state=42, n_jobs=1, verbose=False)\n",
+    "\n",
+    "aa.display_df(df_eval, n_rows=10, show_shape=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fe5e648",
+   "metadata": {},
+   "source": [
+    "The returned ``model`` is a fitted ``TreeModel``, so its feature importances (and any other ``TreeModel`` method) are available for downstream use:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e38b1590",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T22:47:21.339051Z",
+     "iopub.status.busy": "2026-06-23T22:47:21.338968Z",
+     "iopub.status.idle": "2026-06-23T22:47:21.340661Z",
+     "shell.execute_reply": "2026-06-23T22:47:21.340437Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TreeModel fitted with 8 feature importances\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"{type(model).__name__} fitted with {len(model.feat_importance)} feature importances\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/unit/pipe_tests/test_aap_predict.py
+++ b/tests/unit/pipe_tests/test_aap_predict.py
@@ -1,0 +1,140 @@
+"""This script tests the aaanalysis.pipe.predict() golden pipeline."""
+import numpy as np
+import pandas as pd
+import pytest
+from hypothesis import given, settings
+import hypothesis.strategies as st
+from sklearn.ensemble import RandomForestClassifier, ExtraTreesClassifier
+
+import aaanalysis as aa
+import aaanalysis.pipe as aap
+
+settings.register_profile("ci", deadline=None)
+settings.load_profile("ci")
+
+aa.options["verbose"] = False
+
+
+# Shared seeded fixture data (small DOM_GSEC slice)
+df_seq = aa.load_dataset(name="DOM_GSEC", n=20)
+labels = df_seq["label"].to_list()
+df_feat = aa.load_features().head(8)
+sf = aa.SequenceFeature()
+df_parts = sf.get_df_parts(df_seq=df_seq)
+
+
+def _manual_predict(random_state=1, n_cv=5, list_model_classes=None):
+    """The explicit primitive chain aap.predict is supposed to mirror byte-for-byte."""
+    X = sf.feature_matrix(features=df_feat["feature"], df_parts=df_parts)
+    tm = aa.TreeModel(list_model_classes=list_model_classes, random_state=random_state, verbose=False)
+    tm.fit(X, labels=labels, n_cv=n_cv)
+    df_eval = tm.eval(X, labels=labels, list_is_selected=[tm.is_selected_], n_cv=n_cv)
+    return tm, df_eval
+
+
+class TestPredict:
+    """Positive and negative tests for aap.predict(), one parameter per test."""
+
+    # Positive tests
+    def test_returns_treemodel_and_df_eval(self):
+        model, df_eval = aap.predict(df_feat, df_parts, labels, random_state=0)
+        assert isinstance(model, aa.TreeModel)
+        assert isinstance(df_eval, pd.DataFrame)
+        assert len(df_eval) == 1
+
+    def test_df_eval_has_metric_columns(self):
+        _, df_eval = aap.predict(df_feat, df_parts, labels, random_state=0)
+        for col in ("name", "accuracy", "precision", "recall", "f1"):
+            assert col in df_eval.columns
+
+    @settings(max_examples=3, deadline=None)
+    @given(random_state=st.integers(min_value=0, max_value=50))
+    def test_random_state_parameter(self, random_state):
+        model, df_eval = aap.predict(df_feat, df_parts, labels, random_state=random_state)
+        assert model.is_selected_ is not None
+        assert np.isfinite(df_eval["accuracy"]).all()
+
+    @settings(max_examples=3, deadline=None)
+    @given(n_cv=st.integers(min_value=2, max_value=5))
+    def test_n_cv_parameter(self, n_cv):
+        _, df_eval = aap.predict(df_feat, df_parts, labels, n_cv=n_cv, random_state=0)
+        assert np.isfinite(df_eval["accuracy"]).all()
+
+    def test_list_model_classes_parameter(self):
+        model, _ = aap.predict(df_feat, df_parts, labels,
+                               list_model_classes=[RandomForestClassifier, ExtraTreesClassifier],
+                               random_state=0)
+        assert isinstance(model, aa.TreeModel)
+
+    def test_n_jobs_parameter(self):
+        for n_jobs in [None, 1]:
+            _, df_eval = aap.predict(df_feat, df_parts, labels, n_jobs=n_jobs, random_state=0)
+            assert np.isfinite(df_eval["accuracy"]).all()
+
+    def test_verbose_parameter(self):
+        for verbose in [True, False]:
+            model, _ = aap.predict(df_feat, df_parts, labels, verbose=verbose, random_state=0)
+            assert isinstance(model, aa.TreeModel)
+
+    # Negative tests
+    def test_invalid_df_feat(self):
+        with pytest.raises(ValueError):
+            aap.predict("invalid", df_parts, labels)
+        with pytest.raises(ValueError):
+            aap.predict(pd.DataFrame({"not_feature": [1, 2]}), df_parts, labels)
+
+    def test_invalid_df_parts(self):
+        with pytest.raises(ValueError):
+            aap.predict(df_feat, "invalid", labels)
+
+    def test_invalid_n_cv(self):
+        for n_cv in [1, 0, -1, "invalid"]:
+            with pytest.raises(ValueError):
+                aap.predict(df_feat, df_parts, labels, n_cv=n_cv)
+
+    def test_invalid_random_state(self):
+        for random_state in [-1, "invalid", 1.5]:
+            with pytest.raises(ValueError):
+                aap.predict(df_feat, df_parts, labels, random_state=random_state)
+
+    def test_invalid_verbose(self):
+        with pytest.raises(ValueError):
+            aap.predict(df_feat, df_parts, labels, verbose="invalid")
+
+    def test_invalid_labels_length(self):
+        with pytest.raises(ValueError):
+            aap.predict(df_feat, df_parts, labels[:-1])
+
+
+class TestPredictComplex:
+    """Combinations and the byte-identical parity contract."""
+
+    def test_byte_identical_to_manual_chain(self):
+        model_m, df_eval_m = _manual_predict(random_state=1, n_cv=5)
+        model_a, df_eval_a = aap.predict(df_feat, df_parts, labels, random_state=1, n_cv=5)
+        assert df_eval_m.equals(df_eval_a)
+        assert np.array_equal(np.asarray(model_m.is_selected_), np.asarray(model_a.is_selected_))
+        assert np.array_equal(np.asarray(model_m.feat_importance), np.asarray(model_a.feat_importance))
+
+    def test_byte_identical_with_explicit_models(self):
+        models = [RandomForestClassifier, ExtraTreesClassifier]
+        model_m, df_eval_m = _manual_predict(random_state=3, n_cv=4, list_model_classes=models)
+        model_a, df_eval_a = aap.predict(df_feat, df_parts, labels, list_model_classes=models,
+                                         random_state=3, n_cv=4)
+        assert df_eval_m.equals(df_eval_a)
+
+    def test_reproducible_same_seed(self):
+        _, df_eval_1 = aap.predict(df_feat, df_parts, labels, random_state=7)
+        _, df_eval_2 = aap.predict(df_feat, df_parts, labels, random_state=7)
+        assert df_eval_1.equals(df_eval_2)
+
+    def test_combined_valid_parameters(self):
+        model, df_eval = aap.predict(df_feat, df_parts, labels,
+                                     list_model_classes=[RandomForestClassifier],
+                                     n_cv=3, random_state=2, n_jobs=1, verbose=False)
+        assert isinstance(model, aa.TreeModel)
+        assert np.isfinite(df_eval["accuracy"]).all()
+
+    def test_combined_invalid_parameters(self):
+        with pytest.raises(ValueError):
+            aap.predict(df_feat, df_parts, labels, n_cv=-5, random_state="bad")


### PR DESCRIPTION
## What

First slice of the `aaanalysis.pipe` convenience API (#241) — a second, opt-in,
mpl/`pyplot`-style namespace of stateless **golden pipelines** that thinly wrap the
existing primitives. Usage:

```python
import aaanalysis.pipe as aap
model, df_eval = aap.predict(df_feat, df_parts, labels, random_state=0)
```

## `aap.predict`

`predict(df_feat, df_parts, labels, list_model_classes=None, n_cv=5, random_state=None, n_jobs=None, verbose=False) -> (TreeModel, df_eval)`

Rebuilds the feature matrix from `df_feat`'s feature ids via
`SequenceFeature.feature_matrix`, fits a `TreeModel`, and returns the fitted model +
cross-validated `df_eval`. **No algorithm of its own** — defaults are byte-identical to
the explicit `feature_matrix → TreeModel.fit → TreeModel.eval` chain (asserted by a
parity test).

## Changes (purely additive)
- `aaanalysis/pipe/` — front-door `__init__` + `_pipelines.py`.
- `tests/unit/pipe_tests/test_aap_predict.py` — per-parameter positive/negative,
  byte-identical parity, reproducibility (same seed → same `df_eval`). 18 passing.
- `examples/pipe/aap_predict.ipynb` — executed, outputs embedded.

No existing files touched; `import aaanalysis.pipe as aap` works as a submodule, so **no
top-level `__init__`/`__all__` change** (no CONFIRM-FIRST surface).

## Scope
First slice of #241. Follow-ups: `aap.cpp_feature_map`, `aap.explain` (pro), and the
sklearn-compliant `SequenceFeatureTransformer`; later, top-level `aa.pipe` exposure +
API-doc autosummary (CONFIRM-FIRST). Addresses #241 (kept open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)