### PR TITLE
doc: section nav pillars + landing-page routing; wire tutorial6

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -1,0 +1,33 @@
+..
+   Developer Notes:
+   The paths to notebooks are relative to ensure compatibility with the Sphinx referencing system
+   used throughout the documentation. Getting Started is the onboarding pillar: only the first
+   success belongs here (install + first result + publication-ready plots), no deep theory — that
+   is what the Tutorials and Protocols pillars are for.
+..
+
+
+.. _getting_started:
+
+Getting Started
+===============
+New to AAanalysis? Start here. The **A minimal CPP analysis** notebook is the
+shortest complete loop — load a dataset, run CPP, read out the signature — and
+pairs with the :ref:`Prediction tasks <prediction_tasks>` concept page. For a
+fuller introduction, explore our **Quick start** and **Slow start** tutorials,
+both offering the same examples, with the latter explaining the conceptual
+background. The **Plotting Prelude** tutorial can help you create
+publication-ready plots.
+
+Once you have a first result, learn individual tools in the
+:ref:`Tutorials <tutorials>`, design a valid analysis with the
+:ref:`Protocols <protocols>`, and look up exact parameters in the
+:doc:`API <api>`.
+
+.. toctree::
+   :maxdepth: 1
+
+   generated/tutorial0_minimal
+   generated/tutorial1_quick_start
+   generated/tutorial1_slow_start
+   generated/plotting_prelude

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,10 +15,12 @@ The documentation is organized into pillars, each answering one question:
 
 - **Getting Started** — *How do I install AAanalysis and get a first result?* Fast
   onboarding, no deep theory.
-- **Tutorials** — *How does this one tool work?* Function-level teaching: parameters
-  and outputs, one tool at a time.
+- **Tutorials** — *How does this tool work?* Tool-level teaching of the AAanalysis
+  building blocks — each tool, its parameters, and its outputs. The *mechanics*;
+  Protocols reuse these and link back rather than repeating them.
 - **Protocols** — *How do I design a valid, end-to-end analysis?* Concept-level
-  workflow teaching that builds the mental model for when and why to reach for each tool.
+  workflow teaching that builds the mental model for when and why to reach for each
+  tool — linking to the Tutorials for the mechanics, so the two never overlap.
 - **Use Cases** — *How do I adapt a full biological analysis?* End-to-end biological
   case studies *(coming soon)*.
 - **API** — *What is the exact signature or parameter?* Technical reference only, no

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,47 @@ Welcome to the AAanalysis documentation!
 .. include:: index/badges.rst
 .. include:: index/overview.rst
 
+Find Your Way Around
+====================
+The documentation is organized into pillars, each answering one question:
+
+- **Getting Started** — *How do I install AAanalysis and get a first result?* Fast
+  onboarding, no deep theory.
+- **Tutorials** — *How does this one tool work?* Function-level teaching: parameters
+  and outputs, one tool at a time.
+- **Protocols** — *How do I design a valid, end-to-end analysis?* Concept-level
+  workflow teaching that builds the mental model for when and why to reach for each tool.
+- **Use Cases** — *How do I adapt a full biological analysis?* End-to-end biological
+  case studies *(coming soon)*.
+- **API** — *What is the exact signature or parameter?* Technical reference only, no
+  teaching narrative.
+
+.. admonition:: Which section do I want?
+   :class: tip
+
+   - You are **new** and want a first result → **Getting Started**.
+   - You want to learn **one specific tool** (its parameters and outputs) → **Tutorials**.
+   - You want to **design a valid workflow** for a biological question → **Protocols**.
+   - You want to **adapt a complete biological analysis** → **Use Cases** *(coming soon)*.
+   - You want **exact technical details** of a function or class → **API**.
+
+.. list-table:: You want to… / Go to
+   :header-rows: 1
+   :widths: 60 40
+
+   * - You want to…
+     - Go to
+   * - Install AAanalysis and run a first CPP analysis
+     - :ref:`Getting Started <getting_started>`
+   * - Learn what a specific function does and how to call it
+     - :ref:`Tutorials <tutorials>`
+   * - Design a valid, end-to-end analysis for a biological question
+     - :ref:`Protocols <protocols>`
+   * - Adapt a full biological case study to your own data
+     - Use Cases *(coming soon)*
+   * - Look up the exact signature, parameters, or return value
+     - :doc:`API <api>`
+
 Install
 =======
 **AAanalysis** can be installed from `PyPi <https://pypi.org/project/aaanalysis>`_:
@@ -69,6 +110,13 @@ classes grouped by capability, the prediction levels (residue / domain / protein
 .. toctree::
    :maxdepth: 1
    :hidden:
+   :caption: GETTING STARTED
+
+   getting_started.rst
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
    :caption: EXAMPLES
 
    tutorials.rst
@@ -77,7 +125,7 @@ classes grouped by capability, the prediction levels (residue / domain / protein
 .. toctree::
    :maxdepth: 2
    :hidden:
-   :caption: REFERENCES
+   :caption: API
 
    api.rst
 

--- a/docs/source/index/release_notes.rst
+++ b/docs/source/index/release_notes.rst
@@ -175,6 +175,12 @@ Added
 - **A minimal CPP analysis** tutorial (``tutorial0_minimal``): the shortest
   end-to-end loop — load a dataset, run CPP, read out the signature — paired with
   the new concept page.
+- **Documentation navigation + routing landing page**: *Getting Started* is now a
+  top-level pillar (alongside *Examples* → Tutorials · Protocols and *API*), and
+  the landing page gains a section explainer, a "which section do I want?" box, and
+  a "You want to… / Go to" routing table. The previously unwired
+  **Comparison Harness** tutorial (``tutorial6_comparison_harness``) is now
+  reachable from the Tutorials toctree.
 
 Changed
 ~~~~~~~

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -9,23 +9,10 @@
 
 Tutorials
 =========
-
-Getting Started
----------------
-The **A minimal CPP analysis** notebook is the shortest complete loop — load a
-dataset, run CPP, read out the signature — and pairs with the
-:ref:`Prediction tasks <prediction_tasks>` concept page. For a fuller introduction,
-explore our **Quick start** and **Slow start** tutorials, both offering the same examples
-with the latter explaining the conceptual background. The **Plotting Prelude** tutorial can help you to create publication-ready plots.
-
-
-.. toctree::
-   :maxdepth: 1
-
-   generated/tutorial0_minimal
-   generated/tutorial1_quick_start
-   generated/tutorial1_slow_start
-   generated/plotting_prelude
+Tutorials teach **one tool at a time** — what a function does, its parameters,
+and the outputs it returns. New to AAanalysis? Begin with
+:ref:`Getting Started <getting_started>` for your first result, then return here
+to go deeper on each tool.
 
 Data Handling
 -------------
@@ -69,3 +56,14 @@ Explaining sample level predictions at single-residue resolution is introduced i
    :maxdepth: 1
 
    generated/tutorial5a_shap_model
+
+Evaluation & Comparison
+-----------------------
+Assemble the building blocks into one honest small-N evaluation in the **Comparison Harness**
+tutorial: sweep CPP configurations with **CPPGrid**, score per-protein site-localization
+metrics, and rank configurations fairly under cross-validation.
+
+.. toctree::
+   :maxdepth: 1
+
+   generated/tutorial6_comparison_harness

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -9,10 +9,12 @@
 
 Tutorials
 =========
-Tutorials teach **one tool at a time** — what a function does, its parameters,
-and the outputs it returns. New to AAanalysis? Begin with
-:ref:`Getting Started <getting_started>` for your first result, then return here
-to go deeper on each tool.
+Tutorials teach the AAanalysis **tools** — what each one does, its parameters, and
+the outputs it returns. They cover the *mechanics*; for how to combine tools into a
+valid end-to-end analysis, see the :ref:`Protocols <protocols>`, which link back
+here for the mechanics instead of repeating them — so the two stay distinct with no
+overlap. New to AAanalysis? Begin with :ref:`Getting Started <getting_started>` for
+your first result, then return here to go deeper on each tool.
 
 Data Handling
 -------------
@@ -59,9 +61,10 @@ Explaining sample level predictions at single-residue resolution is introduced i
 
 Evaluation & Comparison
 -----------------------
-Assemble the building blocks into one honest small-N evaluation in the **Comparison Harness**
-tutorial: sweep CPP configurations with **CPPGrid**, score per-protein site-localization
-metrics, and rank configurations fairly under cross-validation.
+Learn the evaluation tools — **CPPGrid** configuration sweeps, per-protein
+site-localization metrics, and fair ranking under cross-validation — in the
+**Comparison Harness** tutorial. These are the mechanics that the *P10: Validation*
+protocol puts to work end to end.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Closes #107 (child of epic #106; #108 TUT + #109 UC remain open).

Docs-only reorganization — promote **Getting Started** to a top-level navigation pillar and add a routing landing page so visitors can tell which section answers their question.

## Changes
- **New `docs/source/getting_started.rst`** pillar (caption `GETTING STARTED`) holding the minimal / quick-start / slow-start / plotting-prelude notebooks, moved out of the Tutorials "Getting Started" subsection.
- **Landing page (`index.rst`)** gains a "Find Your Way Around" section explainer, a "Which section do I want?" distinction box, and a "You want to… / Go to" routing table covering Getting Started, Tutorials, Protocols, Use Cases *(coming soon)*, and API.
- **Rename** the `REFERENCES` toctree caption to `API` so the sidebar shows the pillar.
- **Wire `tutorial6_comparison_harness`** into the Tutorials toctree under a new "Evaluation & Comparison" subsection — clears its "isn't included in any toctree" Sphinx warning.
- **Release notes**: Documentation entry under v1.1.0 (Unreleased).

## Acceptance criteria
- [x] `make html` renders with **zero net-new Sphinx warnings** (normalized warning diff vs master; the single relocated `plotting_prelude` no-title warning is pre-existing and just moves source file).
- [x] Sidebar shows Getting Started, Examples→{Tutorials, Protocols, (Use Cases via #109)}, API; each reachable in ≤2 clicks.
- [x] Landing page contains the explainer, the distinction box, and the routing table (verified in rendered HTML).
- [x] `tutorial6_comparison_harness` reachable from the Tutorials toctree.

## Scope notes
- Docs-only: no `aaanalysis/__init__.py` / public API change.
- **Use Cases** toctree wiring is deliberately left to child #109 — a placeholder reference would be a broken-link Sphinx warning. The routing table lists Use Cases as "(coming soon)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)