### PR TITLE
doc: revert REFERENCES caption rename to API (avoid API › API)

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -127,7 +127,7 @@ classes grouped by capability, the prediction levels (residue / domain / protein
 .. toctree::
    :maxdepth: 2
    :hidden:
-   :caption: API
+   :caption: REFERENCES
 
    api.rst
 


### PR DESCRIPTION
Follow-up to #256 (nav routing, child of epic #106). Does **not** reopen/close #107.

## Problem
#256 renamed the `REFERENCES` toctree caption to `API`. But:
- `api.rst`'s own page title is already **API**, and
- the caption-less toctree (Tables / Glossary / References / Release notes) renders under the *preceding* caption.

So the rendered sidebar became **API › API** (caption duplicating its single child) and mislabeled the Tables/Glossary/References/Release-notes pages under an "API" heading.

## Fix
Revert that one caption line to `REFERENCES`. It is the correct umbrella for all reference material, and the **API** pillar stays visible as its first entry (1-click), which is what the nav goal asked for.

Sidebar after fix: **OVERVIEW · GETTING STARTED · EXAMPLES · REFERENCES** (API as the first entry under REFERENCES).

## Verification
- `make html` renders with zero net-new Sphinx warnings.
- Rendered sidebar confirmed: captions OVERVIEW / GETTING STARTED / EXAMPLES / REFERENCES; no "API › API" duplication.

Docs-only; no public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)