### PR TITLE
feat(load_dataset): report entry-removal counts via verbose flag

### DIFF
--- a/aaanalysis/data_handling/_load_dataset.py
+++ b/aaanalysis/data_handling/_load_dataset.py
@@ -146,6 +146,7 @@ def load_dataset(name: str = "Overview",
                  min_len: Optional[int] = None,
                  max_len: Optional[int] = None,
                  aa_window_size: Union[int, None] = 9,
+                 verbose: bool = False,
                  ) -> DataFrame:
     """
     Load protein benchmarking datasets.
@@ -154,6 +155,11 @@ def load_dataset(name: str = "Overview",
     By default, an overview table is provided (``name='Overview'``). For in-depth details, refer to [Breimann24a]_.
 
     .. versionadded:: 0.1.0
+
+    .. versionchanged:: 1.1.0
+        Added the ``verbose`` parameter, which reports how many entries each
+        removal step (``min_len``, ``max_len``, and ``non_canonical_aa='remove'``)
+        dropped. The returned data is unchanged.
 
     Parameters
     ----------
@@ -168,17 +174,25 @@ def load_dataset(name: str = "Overview",
     non_canonical_aa : {'remove', 'keep', 'gap'}, default='remove'
         Options for handling non-canonical amino acids:
 
-        * ``remove``: Remove sequences containing non-canonical amino acids.
+        * ``remove``: Remove sequences containing non-canonical amino acids
+          (the count removed is reported when ``verbose=True``). To retain every
+          entry (e.g. for inspection), use ``keep``.
         * ``keep``: Don't remove sequences containing non-canonical amino acids.
         * ``gap``: Non-canonical amino acids are replaced by the gap symbol ('-').
 
     min_len : int, optional
-        Minimum length of sequences for filtering.
+        Minimum length of sequences for filtering. The number of entries removed
+        is reported when ``verbose=True``.
     max_len : int, optional
-        Maximum length of sequences for filtering.
+        Maximum length of sequences for filtering. The number of entries removed
+        is reported when ``verbose=True``.
     aa_window_size : int, default=9
         Length of amino acid window, only used for the amino acid dataset level (``name='AA_'``). Disabled if ``None``.
         Must be odd, except for cleavage site datasets (e.g., 'AA_CASPASE3', 'AA_FURIN', 'AA_MMP2').
+    verbose : bool, default=False
+        If ``True``, report how many entries each removal step (``min_len``,
+        ``max_len``, and ``non_canonical_aa='remove'``) dropped. Does not change
+        the returned data.
 
     Returns
     -------
@@ -237,6 +251,7 @@ def load_dataset(name: str = "Overview",
     check_min_max_val(min_len=min_len, max_len=max_len)
     is_cs_dataset = _is_cleavage_site_dataset(name=name)
     check_aa_window_size(aa_window_size=aa_window_size, is_cs_dataset=is_cs_dataset)
+    verbose = ut.check_verbose(verbose)
 
     # Load overview table
     if name == "Overview":
@@ -244,17 +259,29 @@ def load_dataset(name: str = "Overview",
     df = ut.read_csv_cached(FOLDER_BENCHMARKS + name + f".{ut.STR_FILE_TYPE}")
     # Filter data
     if min_len is not None:
+        n_before = len(df)
         mask = [len(x) >= min_len for x in df[ut.COL_SEQ]]
         df = df[mask]
         if len(df) == 0:
             raise ValueError(f"'min_len' ({min_len}) is too high and removed all sequences.")
+        n_removed = n_before - len(df)
+        if verbose and n_removed > 0:
+            ut.print_out(f"'{name}': removed {n_removed} sequence(s) shorter than 'min_len' ({min_len}).")
     if max_len is not None:
+        n_before = len(df)
         mask = [len(x) <= max_len for x in df[ut.COL_SEQ]]
         df = df[mask]
         if len(df) == 0:
             raise ValueError(f"'max_len' ({max_len}) is too low and removed all sequences.")
+        n_removed = n_before - len(df)
+        if verbose and n_removed > 0:
+            ut.print_out(f"'{name}': removed {n_removed} sequence(s) longer than 'max_len' ({max_len}).")
     # Adjust non-canonical amino acid (keep, remove, or replace by gap)
+    n_before = len(df)
     df_seq = _adjust_non_canonical_aa(df=df, non_canonical_aa=non_canonical_aa)
+    n_removed = n_before - len(df_seq)
+    if verbose and non_canonical_aa == "remove" and n_removed > 0:
+        ut.print_out(f"'{name}': removed {n_removed} sequence(s) containing non-canonical amino acids.")
     # Adjust amino acid windows for 'AA' datasets
     if _is_aa_level(name=name):
         # Special case that unfiltered df_seq is returned

--- a/docs/source/index/release_notes.rst
+++ b/docs/source/index/release_notes.rst
@@ -229,6 +229,11 @@ Changed
 - **CPPPlot.feature**: Titles the plot with the feature's human-readable description,
   line-wrapped via ``show_title`` (default ``True``) and ``title_wrap_width`` (default
   ``45``).
+- **load_dataset verbose reporting**: New ``verbose`` parameter (default ``False``)
+  reports how many entries each removal step (``min_len``, ``max_len``, and
+  ``non_canonical_aa='remove'``) drops, making the previously silent filtering
+  observable. The returned data is unchanged; to retain every entry use
+  ``non_canonical_aa='keep'``.
 - **Docstring discoverability**: Surfaced previously implicit API contracts at the
   docstrings users read (no behavior change) — the ``get_parts`` → ``run_num`` call order
   and ``[0, 1]`` normalization contract, and a ``[pro]`` install marker on the pro

--- a/examples/data_handling/load_dataset.ipynb
+++ b/examples/data_handling/load_dataset.ipynb
@@ -2,17 +2,31 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "source": [
-    "An overview dataset table is provided as default, where the suffix in the 'Dataset' ('AA', 'SEQ', and 'DOM') column corresponds to the 'Level' values ('Amino acid', 'Sequence', and 'Domain' level). Load datasets using the ``load_dataset()`` function:"
-   ],
+   "id": "d64f6a126f1e115d",
    "metadata": {
     "collapsed": false
    },
-   "id": "d64f6a126f1e115d"
+   "source": [
+    "An overview dataset table is provided as default, where the suffix in the 'Dataset' ('AA', 'SEQ', and 'DOM') column corresponds to the 'Level' values ('Amino acid', 'Sequence', and 'Domain' level). Load datasets using the ``load_dataset()`` function:"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "initial_id",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-06-17T00:32:05.361207317Z",
+     "start_time": "2025-06-17T00:32:02.122928999Z"
+    },
+    "collapsed": false,
+    "execution": {
+     "iopub.execute_input": "2026-06-25T16:43:31.286305Z",
+     "iopub.status.busy": "2026-06-25T16:43:31.286122Z",
+     "iopub.status.idle": "2026-06-25T16:43:32.690007Z",
+     "shell.execute_reply": "2026-06-25T16:43:32.689777Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -23,8 +37,247 @@
     },
     {
      "data": {
-      "text/plain": "<IPython.core.display.HTML object>",
-      "text/html": "<style type=\"text/css\">\n#T_a28ed thead th {\n  background-color: white;\n  color: black;\n}\n#T_a28ed tbody tr:nth-child(odd) {\n  background-color: #f2f2f2;\n}\n#T_a28ed tbody tr:nth-child(even) {\n  background-color: white;\n}\n#T_a28ed th {\n  padding: 5px;\n  white-space: nowrap;\n}\n#T_a28ed  td {\n  padding: 5px;\n  white-space: nowrap;\n}\n</style>\n<table id=\"T_a28ed\" style='display:block; max-height: 600px; max-width: 100%; overflow-x: auto; overflow-y: auto;'>\n  <thead>\n    <tr>\n      <th class=\"blank level0\" >&nbsp;</th>\n      <th id=\"T_a28ed_level0_col0\" class=\"col_heading level0 col0\" >Level</th>\n      <th id=\"T_a28ed_level0_col1\" class=\"col_heading level0 col1\" >Dataset</th>\n      <th id=\"T_a28ed_level0_col2\" class=\"col_heading level0 col2\" ># Sequences</th>\n      <th id=\"T_a28ed_level0_col3\" class=\"col_heading level0 col3\" >Avg length</th>\n      <th id=\"T_a28ed_level0_col4\" class=\"col_heading level0 col4\" ># Amino acids</th>\n      <th id=\"T_a28ed_level0_col5\" class=\"col_heading level0 col5\" ># Positives</th>\n      <th id=\"T_a28ed_level0_col6\" class=\"col_heading level0 col6\" ># Negatives</th>\n      <th id=\"T_a28ed_level0_col7\" class=\"col_heading level0 col7\" >Predictor</th>\n      <th id=\"T_a28ed_level0_col8\" class=\"col_heading level0 col8\" >Description</th>\n      <th id=\"T_a28ed_level0_col9\" class=\"col_heading level0 col9\" >Reference</th>\n      <th id=\"T_a28ed_level0_col10\" class=\"col_heading level0 col10\" >Label</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th id=\"T_a28ed_level0_row0\" class=\"row_heading level0 row0\" >1</th>\n      <td id=\"T_a28ed_row0_col0\" class=\"data row0 col0\" >Amino acid</td>\n      <td id=\"T_a28ed_row0_col1\" class=\"data row0 col1\" >AA_CASPASE3</td>\n      <td id=\"T_a28ed_row0_col2\" class=\"data row0 col2\" >233</td>\n      <td id=\"T_a28ed_row0_col3\" class=\"data row0 col3\" >796.587983</td>\n      <td id=\"T_a28ed_row0_col4\" class=\"data row0 col4\" >185605</td>\n      <td id=\"T_a28ed_row0_col5\" class=\"data row0 col5\" >705</td>\n      <td id=\"T_a28ed_row0_col6\" class=\"data row0 col6\" >184900</td>\n      <td id=\"T_a28ed_row0_col7\" class=\"data row0 col7\" >PROSPERous</td>\n      <td id=\"T_a28ed_row0_col8\" class=\"data row0 col8\" >Prediction of c...3 cleavage site</td>\n      <td id=\"T_a28ed_row0_col9\" class=\"data row0 col9\" >Song et al., 2018</td>\n      <td id=\"T_a28ed_row0_col10\" class=\"data row0 col10\" >1 (adjacent to ... cleavage site)</td>\n    </tr>\n    <tr>\n      <th id=\"T_a28ed_level0_row1\" class=\"row_heading level0 row1\" >2</th>\n      <td id=\"T_a28ed_row1_col0\" class=\"data row1 col0\" >Amino acid</td>\n      <td id=\"T_a28ed_row1_col1\" class=\"data row1 col1\" >AA_FURIN</td>\n      <td id=\"T_a28ed_row1_col2\" class=\"data row1 col2\" >71</td>\n      <td id=\"T_a28ed_row1_col3\" class=\"data row1 col3\" >831.028169</td>\n      <td id=\"T_a28ed_row1_col4\" class=\"data row1 col4\" >59003</td>\n      <td id=\"T_a28ed_row1_col5\" class=\"data row1 col5\" >163</td>\n      <td id=\"T_a28ed_row1_col6\" class=\"data row1 col6\" >58840</td>\n      <td id=\"T_a28ed_row1_col7\" class=\"data row1 col7\" >PROSPERous</td>\n      <td id=\"T_a28ed_row1_col8\" class=\"data row1 col8\" >Prediction of f...n cleavage site</td>\n      <td id=\"T_a28ed_row1_col9\" class=\"data row1 col9\" >Song et al., 2018</td>\n      <td id=\"T_a28ed_row1_col10\" class=\"data row1 col10\" >1 (adjacent to ... cleavage site)</td>\n    </tr>\n    <tr>\n      <th id=\"T_a28ed_level0_row2\" class=\"row_heading level0 row2\" >3</th>\n      <td id=\"T_a28ed_row2_col0\" class=\"data row2 col0\" >Amino acid</td>\n      <td id=\"T_a28ed_row2_col1\" class=\"data row2 col1\" >AA_LDR</td>\n      <td id=\"T_a28ed_row2_col2\" class=\"data row2 col2\" >342</td>\n      <td id=\"T_a28ed_row2_col3\" class=\"data row2 col3\" >345.754386</td>\n      <td id=\"T_a28ed_row2_col4\" class=\"data row2 col4\" >118248</td>\n      <td id=\"T_a28ed_row2_col5\" class=\"data row2 col5\" >35469</td>\n      <td id=\"T_a28ed_row2_col6\" class=\"data row2 col6\" >82779</td>\n      <td id=\"T_a28ed_row2_col7\" class=\"data row2 col7\" >IDP-Seq2Seq</td>\n      <td id=\"T_a28ed_row2_col8\" class=\"data row2 col8\" >Prediction of l...d regions (LDR)</td>\n      <td id=\"T_a28ed_row2_col9\" class=\"data row2 col9\" >Tang et al., 2020</td>\n      <td id=\"T_a28ed_row2_col10\" class=\"data row2 col10\" >1 (disordered), 0 (ordered)</td>\n    </tr>\n    <tr>\n      <th id=\"T_a28ed_level0_row3\" class=\"row_heading level0 row3\" >4</th>\n      <td id=\"T_a28ed_row3_col0\" class=\"data row3 col0\" >Amino acid</td>\n      <td id=\"T_a28ed_row3_col1\" class=\"data row3 col1\" >AA_MMP2</td>\n      <td id=\"T_a28ed_row3_col2\" class=\"data row3 col2\" >573</td>\n      <td id=\"T_a28ed_row3_col3\" class=\"data row3 col3\" >546.205934</td>\n      <td id=\"T_a28ed_row3_col4\" class=\"data row3 col4\" >312976</td>\n      <td id=\"T_a28ed_row3_col5\" class=\"data row3 col5\" >2416</td>\n      <td id=\"T_a28ed_row3_col6\" class=\"data row3 col6\" >310560</td>\n      <td id=\"T_a28ed_row3_col7\" class=\"data row3 col7\" >PROSPERous</td>\n      <td id=\"T_a28ed_row3_col8\" class=\"data row3 col8\" >Prediction of M...) cleavage site</td>\n      <td id=\"T_a28ed_row3_col9\" class=\"data row3 col9\" >Song et al., 2018</td>\n      <td id=\"T_a28ed_row3_col10\" class=\"data row3 col10\" >1 (adjacent to ... cleavage site)</td>\n    </tr>\n    <tr>\n      <th id=\"T_a28ed_level0_row4\" class=\"row_heading level0 row4\" >5</th>\n      <td id=\"T_a28ed_row4_col0\" class=\"data row4 col0\" >Amino acid</td>\n      <td id=\"T_a28ed_row4_col1\" class=\"data row4 col1\" >AA_RNABIND</td>\n      <td id=\"T_a28ed_row4_col2\" class=\"data row4 col2\" >221</td>\n      <td id=\"T_a28ed_row4_col3\" class=\"data row4 col3\" >248.873303</td>\n      <td id=\"T_a28ed_row4_col4\" class=\"data row4 col4\" >55001</td>\n      <td id=\"T_a28ed_row4_col5\" class=\"data row4 col5\" >6492</td>\n      <td id=\"T_a28ed_row4_col6\" class=\"data row4 col6\" >48509</td>\n      <td id=\"T_a28ed_row4_col7\" class=\"data row4 col7\" >GMKSVM-RU</td>\n      <td id=\"T_a28ed_row4_col8\" class=\"data row4 col8\" >Prediction of R...(RBP60 dataset)</td>\n      <td id=\"T_a28ed_row4_col9\" class=\"data row4 col9\" >Yang et al., 2021</td>\n      <td id=\"T_a28ed_row4_col10\" class=\"data row4 col10\" >1 (binding), 0 (non-binding)</td>\n    </tr>\n    <tr>\n      <th id=\"T_a28ed_level0_row5\" class=\"row_heading level0 row5\" >6</th>\n      <td id=\"T_a28ed_row5_col0\" class=\"data row5 col0\" >Amino acid</td>\n      <td id=\"T_a28ed_row5_col1\" class=\"data row5 col1\" >AA_SA</td>\n      <td id=\"T_a28ed_row5_col2\" class=\"data row5 col2\" >233</td>\n      <td id=\"T_a28ed_row5_col3\" class=\"data row5 col3\" >796.587983</td>\n      <td id=\"T_a28ed_row5_col4\" class=\"data row5 col4\" >185605</td>\n      <td id=\"T_a28ed_row5_col5\" class=\"data row5 col5\" >101082</td>\n      <td id=\"T_a28ed_row5_col6\" class=\"data row5 col6\" >84523</td>\n      <td id=\"T_a28ed_row5_col7\" class=\"data row5 col7\" >PROSPERous</td>\n      <td id=\"T_a28ed_row5_col8\" class=\"data row5 col8\" >Prediction of s...PASE3 data set)</td>\n      <td id=\"T_a28ed_row5_col9\" class=\"data row5 col9\" >Song et al., 2018</td>\n      <td id=\"T_a28ed_row5_col10\" class=\"data row5 col10\" >1 (exposed/acce...non-accessible)</td>\n    </tr>\n    <tr>\n      <th id=\"T_a28ed_level0_row6\" class=\"row_heading level0 row6\" >7</th>\n      <td id=\"T_a28ed_row6_col0\" class=\"data row6 col0\" >Sequence</td>\n      <td id=\"T_a28ed_row6_col1\" class=\"data row6 col1\" >SEQ_AMYLO</td>\n      <td id=\"T_a28ed_row6_col2\" class=\"data row6 col2\" >1414</td>\n      <td id=\"T_a28ed_row6_col3\" class=\"data row6 col3\" >6.000000</td>\n      <td id=\"T_a28ed_row6_col4\" class=\"data row6 col4\" >8484</td>\n      <td id=\"T_a28ed_row6_col5\" class=\"data row6 col5\" >511</td>\n      <td id=\"T_a28ed_row6_col6\" class=\"data row6 col6\" >903</td>\n      <td id=\"T_a28ed_row6_col7\" class=\"data row6 col7\" >ReRF-Pred</td>\n      <td id=\"T_a28ed_row6_col8\" class=\"data row6 col8\" >Prediction of a...ognenic regions</td>\n      <td id=\"T_a28ed_row6_col9\" class=\"data row6 col9\" >Teng et al. 2021</td>\n      <td id=\"T_a28ed_row6_col10\" class=\"data row6 col10\" >1 (amyloidogeni...-amyloidogenic)</td>\n    </tr>\n    <tr>\n      <th id=\"T_a28ed_level0_row7\" class=\"row_heading level0 row7\" >8</th>\n      <td id=\"T_a28ed_row7_col0\" class=\"data row7 col0\" >Sequence</td>\n      <td id=\"T_a28ed_row7_col1\" class=\"data row7 col1\" >SEQ_CAPSID</td>\n      <td id=\"T_a28ed_row7_col2\" class=\"data row7 col2\" >7935</td>\n      <td id=\"T_a28ed_row7_col3\" class=\"data row7 col3\" >424.030246</td>\n      <td id=\"T_a28ed_row7_col4\" class=\"data row7 col4\" >3364680</td>\n      <td id=\"T_a28ed_row7_col5\" class=\"data row7 col5\" >3864</td>\n      <td id=\"T_a28ed_row7_col6\" class=\"data row7 col6\" >4071</td>\n      <td id=\"T_a28ed_row7_col7\" class=\"data row7 col7\" >VIRALpro</td>\n      <td id=\"T_a28ed_row7_col8\" class=\"data row7 col8\" >Prediction of capdsid proteins</td>\n      <td id=\"T_a28ed_row7_col9\" class=\"data row7 col9\" >Galiez et al., 2016</td>\n      <td id=\"T_a28ed_row7_col10\" class=\"data row7 col10\" >1 (capsid prote...capsid protein)</td>\n    </tr>\n    <tr>\n      <th id=\"T_a28ed_level0_row8\" class=\"row_heading level0 row8\" >9</th>\n      <td id=\"T_a28ed_row8_col0\" class=\"data row8 col0\" >Sequence</td>\n      <td id=\"T_a28ed_row8_col1\" class=\"data row8 col1\" >SEQ_DISULFIDE</td>\n      <td id=\"T_a28ed_row8_col2\" class=\"data row8 col2\" >2547</td>\n      <td id=\"T_a28ed_row8_col3\" class=\"data row8 col3\" >241.252454</td>\n      <td id=\"T_a28ed_row8_col4\" class=\"data row8 col4\" >614470</td>\n      <td id=\"T_a28ed_row8_col5\" class=\"data row8 col5\" >897</td>\n      <td id=\"T_a28ed_row8_col6\" class=\"data row8 col6\" >1650</td>\n      <td id=\"T_a28ed_row8_col7\" class=\"data row8 col7\" >Dipro</td>\n      <td id=\"T_a28ed_row8_col8\" class=\"data row8 col8\" >Prediction of d...es in sequences</td>\n      <td id=\"T_a28ed_row8_col9\" class=\"data row8 col9\" >Cheng et al., 2006</td>\n      <td id=\"T_a28ed_row8_col10\" class=\"data row8 col10\" >1 (sequence wit...ithout SS bond)</td>\n    </tr>\n    <tr>\n      <th id=\"T_a28ed_level0_row9\" class=\"row_heading level0 row9\" >10</th>\n      <td id=\"T_a28ed_row9_col0\" class=\"data row9 col0\" >Sequence</td>\n      <td id=\"T_a28ed_row9_col1\" class=\"data row9 col1\" >SEQ_LOCATION</td>\n      <td id=\"T_a28ed_row9_col2\" class=\"data row9 col2\" >1835</td>\n      <td id=\"T_a28ed_row9_col3\" class=\"data row9 col3\" >399.126975</td>\n      <td id=\"T_a28ed_row9_col4\" class=\"data row9 col4\" >732398</td>\n      <td id=\"T_a28ed_row9_col5\" class=\"data row9 col5\" >1045</td>\n      <td id=\"T_a28ed_row9_col6\" class=\"data row9 col6\" >790</td>\n      <td id=\"T_a28ed_row9_col7\" class=\"data row9 col7\" >nan</td>\n      <td id=\"T_a28ed_row9_col8\" class=\"data row9 col8\" >Prediction of s...lasma membrane)</td>\n      <td id=\"T_a28ed_row9_col9\" class=\"data row9 col9\" >Shen et al., 2019</td>\n      <td id=\"T_a28ed_row9_col10\" class=\"data row9 col10\" >1 (protein in c...asma membrane) </td>\n    </tr>\n    <tr>\n      <th id=\"T_a28ed_level0_row10\" class=\"row_heading level0 row10\" >11</th>\n      <td id=\"T_a28ed_row10_col0\" class=\"data row10 col0\" >Sequence</td>\n      <td id=\"T_a28ed_row10_col1\" class=\"data row10 col1\" >SEQ_SOLUBLE</td>\n      <td id=\"T_a28ed_row10_col2\" class=\"data row10 col2\" >17408</td>\n      <td id=\"T_a28ed_row10_col3\" class=\"data row10 col3\" >254.611041</td>\n      <td id=\"T_a28ed_row10_col4\" class=\"data row10 col4\" >4432269</td>\n      <td id=\"T_a28ed_row10_col5\" class=\"data row10 col5\" >8704</td>\n      <td id=\"T_a28ed_row10_col6\" class=\"data row10 col6\" >8704</td>\n      <td id=\"T_a28ed_row10_col7\" class=\"data row10 col7\" >SOLpro</td>\n      <td id=\"T_a28ed_row10_col8\" class=\"data row10 col8\" >Prediction of s...oluble proteins</td>\n      <td id=\"T_a28ed_row10_col9\" class=\"data row10 col9\" >Magnan et al., 2009</td>\n      <td id=\"T_a28ed_row10_col10\" class=\"data row10 col10\" >1 (soluble), 0 (insoluble)</td>\n    </tr>\n    <tr>\n      <th id=\"T_a28ed_level0_row11\" class=\"row_heading level0 row11\" >12</th>\n      <td id=\"T_a28ed_row11_col0\" class=\"data row11 col0\" >Sequence</td>\n      <td id=\"T_a28ed_row11_col1\" class=\"data row11 col1\" >SEQ_TAIL</td>\n      <td id=\"T_a28ed_row11_col2\" class=\"data row11 col2\" >6668</td>\n      <td id=\"T_a28ed_row11_col3\" class=\"data row11 col3\" >400.673365</td>\n      <td id=\"T_a28ed_row11_col4\" class=\"data row11 col4\" >2671690</td>\n      <td id=\"T_a28ed_row11_col5\" class=\"data row11 col5\" >2574</td>\n      <td id=\"T_a28ed_row11_col6\" class=\"data row11 col6\" >4094</td>\n      <td id=\"T_a28ed_row11_col7\" class=\"data row11 col7\" >VIRALpro</td>\n      <td id=\"T_a28ed_row11_col8\" class=\"data row11 col8\" >Prediction of tail proteins</td>\n      <td id=\"T_a28ed_row11_col9\" class=\"data row11 col9\" >Galiez et al., 2016</td>\n      <td id=\"T_a28ed_row11_col10\" class=\"data row11 col10\" >1 (tail protein...n-tail protein)</td>\n    </tr>\n    <tr>\n      <th id=\"T_a28ed_level0_row12\" class=\"row_heading level0 row12\" >13</th>\n      <td id=\"T_a28ed_row12_col0\" class=\"data row12 col0\" >Domain</td>\n      <td id=\"T_a28ed_row12_col1\" class=\"data row12 col1\" >DOM_GSEC</td>\n      <td id=\"T_a28ed_row12_col2\" class=\"data row12 col2\" >126</td>\n      <td id=\"T_a28ed_row12_col3\" class=\"data row12 col3\" >737.809524</td>\n      <td id=\"T_a28ed_row12_col4\" class=\"data row12 col4\" >92964</td>\n      <td id=\"T_a28ed_row12_col5\" class=\"data row12 col5\" >63</td>\n      <td id=\"T_a28ed_row12_col6\" class=\"data row12 col6\" >63</td>\n      <td id=\"T_a28ed_row12_col7\" class=\"data row12 col7\" >nan</td>\n      <td id=\"T_a28ed_row12_col8\" class=\"data row12 col8\" >Prediction of g...tase substrates</td>\n      <td id=\"T_a28ed_row12_col9\" class=\"data row12 col9\" >Breimann et al, 2024c</td>\n      <td id=\"T_a28ed_row12_col10\" class=\"data row12 col10\" >1 (substrate), ...(non-substrate)</td>\n    </tr>\n    <tr>\n      <th id=\"T_a28ed_level0_row13\" class=\"row_heading level0 row13\" >14</th>\n      <td id=\"T_a28ed_row13_col0\" class=\"data row13 col0\" >Domain</td>\n      <td id=\"T_a28ed_row13_col1\" class=\"data row13 col1\" >DOM_GSEC_PU</td>\n      <td id=\"T_a28ed_row13_col2\" class=\"data row13 col2\" >694</td>\n      <td id=\"T_a28ed_row13_col3\" class=\"data row13 col3\" >712.570605</td>\n      <td id=\"T_a28ed_row13_col4\" class=\"data row13 col4\" >494524</td>\n      <td id=\"T_a28ed_row13_col5\" class=\"data row13 col5\" >63</td>\n      <td id=\"T_a28ed_row13_col6\" class=\"data row13 col6\" >0</td>\n      <td id=\"T_a28ed_row13_col7\" class=\"data row13 col7\" >nan</td>\n      <td id=\"T_a28ed_row13_col8\" class=\"data row13 col8\" >Prediction of g...es (PU dataset)</td>\n      <td id=\"T_a28ed_row13_col9\" class=\"data row13 col9\" >Breimann et al, 2024c</td>\n      <td id=\"T_a28ed_row13_col10\" class=\"data row13 col10\" >1 (substrate), ...bstrate status)</td>\n    </tr>\n  </tbody>\n</table>\n"
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "#T_8199e thead th {\n",
+       "  background-color: white;\n",
+       "  color: black;\n",
+       "}\n",
+       "#T_8199e tbody tr:nth-child(odd) {\n",
+       "  background-color: #f2f2f2;\n",
+       "}\n",
+       "#T_8199e tbody tr:nth-child(even) {\n",
+       "  background-color: white;\n",
+       "}\n",
+       "#T_8199e th {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "#T_8199e  td {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "</style>\n",
+       "<table id=\"T_8199e\" style='display:block; max-height: 600px; max-width: 100%; overflow-x: auto; overflow-y: auto;'>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_8199e_level0_col0\" class=\"col_heading level0 col0\" >Level</th>\n",
+       "      <th id=\"T_8199e_level0_col1\" class=\"col_heading level0 col1\" >Dataset</th>\n",
+       "      <th id=\"T_8199e_level0_col2\" class=\"col_heading level0 col2\" ># Sequences</th>\n",
+       "      <th id=\"T_8199e_level0_col3\" class=\"col_heading level0 col3\" >Avg length</th>\n",
+       "      <th id=\"T_8199e_level0_col4\" class=\"col_heading level0 col4\" ># Amino acids</th>\n",
+       "      <th id=\"T_8199e_level0_col5\" class=\"col_heading level0 col5\" ># Positives</th>\n",
+       "      <th id=\"T_8199e_level0_col6\" class=\"col_heading level0 col6\" ># Negatives</th>\n",
+       "      <th id=\"T_8199e_level0_col7\" class=\"col_heading level0 col7\" >Predictor</th>\n",
+       "      <th id=\"T_8199e_level0_col8\" class=\"col_heading level0 col8\" >Description</th>\n",
+       "      <th id=\"T_8199e_level0_col9\" class=\"col_heading level0 col9\" >Reference</th>\n",
+       "      <th id=\"T_8199e_level0_col10\" class=\"col_heading level0 col10\" >Label</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_8199e_level0_row0\" class=\"row_heading level0 row0\" >1</th>\n",
+       "      <td id=\"T_8199e_row0_col0\" class=\"data row0 col0\" >Amino acid</td>\n",
+       "      <td id=\"T_8199e_row0_col1\" class=\"data row0 col1\" >AA_CASPASE3</td>\n",
+       "      <td id=\"T_8199e_row0_col2\" class=\"data row0 col2\" >233</td>\n",
+       "      <td id=\"T_8199e_row0_col3\" class=\"data row0 col3\" >796.587983</td>\n",
+       "      <td id=\"T_8199e_row0_col4\" class=\"data row0 col4\" >185605</td>\n",
+       "      <td id=\"T_8199e_row0_col5\" class=\"data row0 col5\" >705</td>\n",
+       "      <td id=\"T_8199e_row0_col6\" class=\"data row0 col6\" >184900</td>\n",
+       "      <td id=\"T_8199e_row0_col7\" class=\"data row0 col7\" >PROSPERous</td>\n",
+       "      <td id=\"T_8199e_row0_col8\" class=\"data row0 col8\" >Prediction of c...3 cleavage site</td>\n",
+       "      <td id=\"T_8199e_row0_col9\" class=\"data row0 col9\" >Song et al., 2018</td>\n",
+       "      <td id=\"T_8199e_row0_col10\" class=\"data row0 col10\" >1 (adjacent to ... cleavage site)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_8199e_level0_row1\" class=\"row_heading level0 row1\" >2</th>\n",
+       "      <td id=\"T_8199e_row1_col0\" class=\"data row1 col0\" >Amino acid</td>\n",
+       "      <td id=\"T_8199e_row1_col1\" class=\"data row1 col1\" >AA_FURIN</td>\n",
+       "      <td id=\"T_8199e_row1_col2\" class=\"data row1 col2\" >71</td>\n",
+       "      <td id=\"T_8199e_row1_col3\" class=\"data row1 col3\" >831.028169</td>\n",
+       "      <td id=\"T_8199e_row1_col4\" class=\"data row1 col4\" >59003</td>\n",
+       "      <td id=\"T_8199e_row1_col5\" class=\"data row1 col5\" >163</td>\n",
+       "      <td id=\"T_8199e_row1_col6\" class=\"data row1 col6\" >58840</td>\n",
+       "      <td id=\"T_8199e_row1_col7\" class=\"data row1 col7\" >PROSPERous</td>\n",
+       "      <td id=\"T_8199e_row1_col8\" class=\"data row1 col8\" >Prediction of f...n cleavage site</td>\n",
+       "      <td id=\"T_8199e_row1_col9\" class=\"data row1 col9\" >Song et al., 2018</td>\n",
+       "      <td id=\"T_8199e_row1_col10\" class=\"data row1 col10\" >1 (adjacent to ... cleavage site)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_8199e_level0_row2\" class=\"row_heading level0 row2\" >3</th>\n",
+       "      <td id=\"T_8199e_row2_col0\" class=\"data row2 col0\" >Amino acid</td>\n",
+       "      <td id=\"T_8199e_row2_col1\" class=\"data row2 col1\" >AA_LDR</td>\n",
+       "      <td id=\"T_8199e_row2_col2\" class=\"data row2 col2\" >342</td>\n",
+       "      <td id=\"T_8199e_row2_col3\" class=\"data row2 col3\" >345.754386</td>\n",
+       "      <td id=\"T_8199e_row2_col4\" class=\"data row2 col4\" >118248</td>\n",
+       "      <td id=\"T_8199e_row2_col5\" class=\"data row2 col5\" >35469</td>\n",
+       "      <td id=\"T_8199e_row2_col6\" class=\"data row2 col6\" >82779</td>\n",
+       "      <td id=\"T_8199e_row2_col7\" class=\"data row2 col7\" >IDP-Seq2Seq</td>\n",
+       "      <td id=\"T_8199e_row2_col8\" class=\"data row2 col8\" >Prediction of l...d regions (LDR)</td>\n",
+       "      <td id=\"T_8199e_row2_col9\" class=\"data row2 col9\" >Tang et al., 2020</td>\n",
+       "      <td id=\"T_8199e_row2_col10\" class=\"data row2 col10\" >1 (disordered), 0 (ordered)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_8199e_level0_row3\" class=\"row_heading level0 row3\" >4</th>\n",
+       "      <td id=\"T_8199e_row3_col0\" class=\"data row3 col0\" >Amino acid</td>\n",
+       "      <td id=\"T_8199e_row3_col1\" class=\"data row3 col1\" >AA_MMP2</td>\n",
+       "      <td id=\"T_8199e_row3_col2\" class=\"data row3 col2\" >573</td>\n",
+       "      <td id=\"T_8199e_row3_col3\" class=\"data row3 col3\" >546.205934</td>\n",
+       "      <td id=\"T_8199e_row3_col4\" class=\"data row3 col4\" >312976</td>\n",
+       "      <td id=\"T_8199e_row3_col5\" class=\"data row3 col5\" >2416</td>\n",
+       "      <td id=\"T_8199e_row3_col6\" class=\"data row3 col6\" >310560</td>\n",
+       "      <td id=\"T_8199e_row3_col7\" class=\"data row3 col7\" >PROSPERous</td>\n",
+       "      <td id=\"T_8199e_row3_col8\" class=\"data row3 col8\" >Prediction of M...) cleavage site</td>\n",
+       "      <td id=\"T_8199e_row3_col9\" class=\"data row3 col9\" >Song et al., 2018</td>\n",
+       "      <td id=\"T_8199e_row3_col10\" class=\"data row3 col10\" >1 (adjacent to ... cleavage site)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_8199e_level0_row4\" class=\"row_heading level0 row4\" >5</th>\n",
+       "      <td id=\"T_8199e_row4_col0\" class=\"data row4 col0\" >Amino acid</td>\n",
+       "      <td id=\"T_8199e_row4_col1\" class=\"data row4 col1\" >AA_RNABIND</td>\n",
+       "      <td id=\"T_8199e_row4_col2\" class=\"data row4 col2\" >221</td>\n",
+       "      <td id=\"T_8199e_row4_col3\" class=\"data row4 col3\" >248.873303</td>\n",
+       "      <td id=\"T_8199e_row4_col4\" class=\"data row4 col4\" >55001</td>\n",
+       "      <td id=\"T_8199e_row4_col5\" class=\"data row4 col5\" >6492</td>\n",
+       "      <td id=\"T_8199e_row4_col6\" class=\"data row4 col6\" >48509</td>\n",
+       "      <td id=\"T_8199e_row4_col7\" class=\"data row4 col7\" >GMKSVM-RU</td>\n",
+       "      <td id=\"T_8199e_row4_col8\" class=\"data row4 col8\" >Prediction of R...(RBP60 dataset)</td>\n",
+       "      <td id=\"T_8199e_row4_col9\" class=\"data row4 col9\" >Yang et al., 2021</td>\n",
+       "      <td id=\"T_8199e_row4_col10\" class=\"data row4 col10\" >1 (binding), 0 (non-binding)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_8199e_level0_row5\" class=\"row_heading level0 row5\" >6</th>\n",
+       "      <td id=\"T_8199e_row5_col0\" class=\"data row5 col0\" >Amino acid</td>\n",
+       "      <td id=\"T_8199e_row5_col1\" class=\"data row5 col1\" >AA_SA</td>\n",
+       "      <td id=\"T_8199e_row5_col2\" class=\"data row5 col2\" >233</td>\n",
+       "      <td id=\"T_8199e_row5_col3\" class=\"data row5 col3\" >796.587983</td>\n",
+       "      <td id=\"T_8199e_row5_col4\" class=\"data row5 col4\" >185605</td>\n",
+       "      <td id=\"T_8199e_row5_col5\" class=\"data row5 col5\" >101082</td>\n",
+       "      <td id=\"T_8199e_row5_col6\" class=\"data row5 col6\" >84523</td>\n",
+       "      <td id=\"T_8199e_row5_col7\" class=\"data row5 col7\" >PROSPERous</td>\n",
+       "      <td id=\"T_8199e_row5_col8\" class=\"data row5 col8\" >Prediction of s...PASE3 data set)</td>\n",
+       "      <td id=\"T_8199e_row5_col9\" class=\"data row5 col9\" >Song et al., 2018</td>\n",
+       "      <td id=\"T_8199e_row5_col10\" class=\"data row5 col10\" >1 (exposed/acce...non-accessible)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_8199e_level0_row6\" class=\"row_heading level0 row6\" >7</th>\n",
+       "      <td id=\"T_8199e_row6_col0\" class=\"data row6 col0\" >Sequence</td>\n",
+       "      <td id=\"T_8199e_row6_col1\" class=\"data row6 col1\" >SEQ_AMYLO</td>\n",
+       "      <td id=\"T_8199e_row6_col2\" class=\"data row6 col2\" >1414</td>\n",
+       "      <td id=\"T_8199e_row6_col3\" class=\"data row6 col3\" >6.000000</td>\n",
+       "      <td id=\"T_8199e_row6_col4\" class=\"data row6 col4\" >8484</td>\n",
+       "      <td id=\"T_8199e_row6_col5\" class=\"data row6 col5\" >511</td>\n",
+       "      <td id=\"T_8199e_row6_col6\" class=\"data row6 col6\" >903</td>\n",
+       "      <td id=\"T_8199e_row6_col7\" class=\"data row6 col7\" >ReRF-Pred</td>\n",
+       "      <td id=\"T_8199e_row6_col8\" class=\"data row6 col8\" >Prediction of a...ognenic regions</td>\n",
+       "      <td id=\"T_8199e_row6_col9\" class=\"data row6 col9\" >Teng et al. 2021</td>\n",
+       "      <td id=\"T_8199e_row6_col10\" class=\"data row6 col10\" >1 (amyloidogeni...-amyloidogenic)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_8199e_level0_row7\" class=\"row_heading level0 row7\" >8</th>\n",
+       "      <td id=\"T_8199e_row7_col0\" class=\"data row7 col0\" >Sequence</td>\n",
+       "      <td id=\"T_8199e_row7_col1\" class=\"data row7 col1\" >SEQ_CAPSID</td>\n",
+       "      <td id=\"T_8199e_row7_col2\" class=\"data row7 col2\" >7935</td>\n",
+       "      <td id=\"T_8199e_row7_col3\" class=\"data row7 col3\" >424.030246</td>\n",
+       "      <td id=\"T_8199e_row7_col4\" class=\"data row7 col4\" >3364680</td>\n",
+       "      <td id=\"T_8199e_row7_col5\" class=\"data row7 col5\" >3864</td>\n",
+       "      <td id=\"T_8199e_row7_col6\" class=\"data row7 col6\" >4071</td>\n",
+       "      <td id=\"T_8199e_row7_col7\" class=\"data row7 col7\" >VIRALpro</td>\n",
+       "      <td id=\"T_8199e_row7_col8\" class=\"data row7 col8\" >Prediction of capdsid proteins</td>\n",
+       "      <td id=\"T_8199e_row7_col9\" class=\"data row7 col9\" >Galiez et al., 2016</td>\n",
+       "      <td id=\"T_8199e_row7_col10\" class=\"data row7 col10\" >1 (capsid prote...capsid protein)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_8199e_level0_row8\" class=\"row_heading level0 row8\" >9</th>\n",
+       "      <td id=\"T_8199e_row8_col0\" class=\"data row8 col0\" >Sequence</td>\n",
+       "      <td id=\"T_8199e_row8_col1\" class=\"data row8 col1\" >SEQ_DISULFIDE</td>\n",
+       "      <td id=\"T_8199e_row8_col2\" class=\"data row8 col2\" >2547</td>\n",
+       "      <td id=\"T_8199e_row8_col3\" class=\"data row8 col3\" >241.252454</td>\n",
+       "      <td id=\"T_8199e_row8_col4\" class=\"data row8 col4\" >614470</td>\n",
+       "      <td id=\"T_8199e_row8_col5\" class=\"data row8 col5\" >897</td>\n",
+       "      <td id=\"T_8199e_row8_col6\" class=\"data row8 col6\" >1650</td>\n",
+       "      <td id=\"T_8199e_row8_col7\" class=\"data row8 col7\" >Dipro</td>\n",
+       "      <td id=\"T_8199e_row8_col8\" class=\"data row8 col8\" >Prediction of d...es in sequences</td>\n",
+       "      <td id=\"T_8199e_row8_col9\" class=\"data row8 col9\" >Cheng et al., 2006</td>\n",
+       "      <td id=\"T_8199e_row8_col10\" class=\"data row8 col10\" >1 (sequence wit...ithout SS bond)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_8199e_level0_row9\" class=\"row_heading level0 row9\" >10</th>\n",
+       "      <td id=\"T_8199e_row9_col0\" class=\"data row9 col0\" >Sequence</td>\n",
+       "      <td id=\"T_8199e_row9_col1\" class=\"data row9 col1\" >SEQ_LOCATION</td>\n",
+       "      <td id=\"T_8199e_row9_col2\" class=\"data row9 col2\" >1835</td>\n",
+       "      <td id=\"T_8199e_row9_col3\" class=\"data row9 col3\" >399.126975</td>\n",
+       "      <td id=\"T_8199e_row9_col4\" class=\"data row9 col4\" >732398</td>\n",
+       "      <td id=\"T_8199e_row9_col5\" class=\"data row9 col5\" >1045</td>\n",
+       "      <td id=\"T_8199e_row9_col6\" class=\"data row9 col6\" >790</td>\n",
+       "      <td id=\"T_8199e_row9_col7\" class=\"data row9 col7\" >nan</td>\n",
+       "      <td id=\"T_8199e_row9_col8\" class=\"data row9 col8\" >Prediction of s...lasma membrane)</td>\n",
+       "      <td id=\"T_8199e_row9_col9\" class=\"data row9 col9\" >Shen et al., 2019</td>\n",
+       "      <td id=\"T_8199e_row9_col10\" class=\"data row9 col10\" >1 (protein in c...asma membrane) </td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_8199e_level0_row10\" class=\"row_heading level0 row10\" >11</th>\n",
+       "      <td id=\"T_8199e_row10_col0\" class=\"data row10 col0\" >Sequence</td>\n",
+       "      <td id=\"T_8199e_row10_col1\" class=\"data row10 col1\" >SEQ_SOLUBLE</td>\n",
+       "      <td id=\"T_8199e_row10_col2\" class=\"data row10 col2\" >17408</td>\n",
+       "      <td id=\"T_8199e_row10_col3\" class=\"data row10 col3\" >254.611041</td>\n",
+       "      <td id=\"T_8199e_row10_col4\" class=\"data row10 col4\" >4432269</td>\n",
+       "      <td id=\"T_8199e_row10_col5\" class=\"data row10 col5\" >8704</td>\n",
+       "      <td id=\"T_8199e_row10_col6\" class=\"data row10 col6\" >8704</td>\n",
+       "      <td id=\"T_8199e_row10_col7\" class=\"data row10 col7\" >SOLpro</td>\n",
+       "      <td id=\"T_8199e_row10_col8\" class=\"data row10 col8\" >Prediction of s...oluble proteins</td>\n",
+       "      <td id=\"T_8199e_row10_col9\" class=\"data row10 col9\" >Magnan et al., 2009</td>\n",
+       "      <td id=\"T_8199e_row10_col10\" class=\"data row10 col10\" >1 (soluble), 0 (insoluble)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_8199e_level0_row11\" class=\"row_heading level0 row11\" >12</th>\n",
+       "      <td id=\"T_8199e_row11_col0\" class=\"data row11 col0\" >Sequence</td>\n",
+       "      <td id=\"T_8199e_row11_col1\" class=\"data row11 col1\" >SEQ_TAIL</td>\n",
+       "      <td id=\"T_8199e_row11_col2\" class=\"data row11 col2\" >6668</td>\n",
+       "      <td id=\"T_8199e_row11_col3\" class=\"data row11 col3\" >400.673365</td>\n",
+       "      <td id=\"T_8199e_row11_col4\" class=\"data row11 col4\" >2671690</td>\n",
+       "      <td id=\"T_8199e_row11_col5\" class=\"data row11 col5\" >2574</td>\n",
+       "      <td id=\"T_8199e_row11_col6\" class=\"data row11 col6\" >4094</td>\n",
+       "      <td id=\"T_8199e_row11_col7\" class=\"data row11 col7\" >VIRALpro</td>\n",
+       "      <td id=\"T_8199e_row11_col8\" class=\"data row11 col8\" >Prediction of tail proteins</td>\n",
+       "      <td id=\"T_8199e_row11_col9\" class=\"data row11 col9\" >Galiez et al., 2016</td>\n",
+       "      <td id=\"T_8199e_row11_col10\" class=\"data row11 col10\" >1 (tail protein...n-tail protein)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_8199e_level0_row12\" class=\"row_heading level0 row12\" >13</th>\n",
+       "      <td id=\"T_8199e_row12_col0\" class=\"data row12 col0\" >Domain</td>\n",
+       "      <td id=\"T_8199e_row12_col1\" class=\"data row12 col1\" >DOM_GSEC</td>\n",
+       "      <td id=\"T_8199e_row12_col2\" class=\"data row12 col2\" >126</td>\n",
+       "      <td id=\"T_8199e_row12_col3\" class=\"data row12 col3\" >737.809524</td>\n",
+       "      <td id=\"T_8199e_row12_col4\" class=\"data row12 col4\" >92964</td>\n",
+       "      <td id=\"T_8199e_row12_col5\" class=\"data row12 col5\" >63</td>\n",
+       "      <td id=\"T_8199e_row12_col6\" class=\"data row12 col6\" >63</td>\n",
+       "      <td id=\"T_8199e_row12_col7\" class=\"data row12 col7\" >nan</td>\n",
+       "      <td id=\"T_8199e_row12_col8\" class=\"data row12 col8\" >Prediction of g...tase substrates</td>\n",
+       "      <td id=\"T_8199e_row12_col9\" class=\"data row12 col9\" >Breimann et al, 2024c</td>\n",
+       "      <td id=\"T_8199e_row12_col10\" class=\"data row12 col10\" >1 (substrate), ...(non-substrate)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_8199e_level0_row13\" class=\"row_heading level0 row13\" >14</th>\n",
+       "      <td id=\"T_8199e_row13_col0\" class=\"data row13 col0\" >Domain</td>\n",
+       "      <td id=\"T_8199e_row13_col1\" class=\"data row13 col1\" >DOM_GSEC_PU</td>\n",
+       "      <td id=\"T_8199e_row13_col2\" class=\"data row13 col2\" >694</td>\n",
+       "      <td id=\"T_8199e_row13_col3\" class=\"data row13 col3\" >712.570605</td>\n",
+       "      <td id=\"T_8199e_row13_col4\" class=\"data row13 col4\" >494524</td>\n",
+       "      <td id=\"T_8199e_row13_col5\" class=\"data row13 col5\" >63</td>\n",
+       "      <td id=\"T_8199e_row13_col6\" class=\"data row13 col6\" >0</td>\n",
+       "      <td id=\"T_8199e_row13_col7\" class=\"data row13 col7\" >nan</td>\n",
+       "      <td id=\"T_8199e_row13_col8\" class=\"data row13 col8\" >Prediction of g...es (PU dataset)</td>\n",
+       "      <td id=\"T_8199e_row13_col9\" class=\"data row13 col9\" >Breimann et al, 2024c</td>\n",
+       "      <td id=\"T_8199e_row13_col10\" class=\"data row13 col10\" >1 (substrate), ...bstrate status)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -34,34 +287,99 @@
     "import aaanalysis as aa\n",
     "df_info = aa.load_dataset()\n",
     "aa.display_df(df=df_info, show_shape=True, max_height=600)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-06-17T00:32:05.361207317Z",
-     "start_time": "2025-06-17T00:32:02.122928999Z"
-    }
-   },
-   "id": "initial_id"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Load one of the datasets from the overview table by using a name from the 'Dataset' column (e.g., ``name='SEQ_CAPSID'``). The number of proteins per class can be adjusted by the ``n`` parameter:"
-   ],
+   "id": "c8cf5ba416584c24",
    "metadata": {
     "collapsed": false
    },
-   "id": "c8cf5ba416584c24"
+   "source": [
+    "Load one of the datasets from the overview table by using a name from the 'Dataset' column (e.g., ``name='SEQ_CAPSID'``). The number of proteins per class can be adjusted by the ``n`` parameter:"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "29441ff404197ad8",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-06-17T00:32:05.623843318Z",
+     "start_time": "2025-06-17T00:32:05.340088605Z"
+    },
+    "collapsed": false,
+    "execution": {
+     "iopub.execute_input": "2026-06-25T16:43:32.691075Z",
+     "iopub.status.busy": "2026-06-25T16:43:32.691015Z",
+     "iopub.status.idle": "2026-06-25T16:43:32.741653Z",
+     "shell.execute_reply": "2026-06-25T16:43:32.741428Z"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": "<IPython.core.display.HTML object>",
-      "text/html": "<style type=\"text/css\">\n#T_94605 thead th {\n  background-color: white;\n  color: black;\n}\n#T_94605 tbody tr:nth-child(odd) {\n  background-color: #f2f2f2;\n}\n#T_94605 tbody tr:nth-child(even) {\n  background-color: white;\n}\n#T_94605 th {\n  padding: 5px;\n  white-space: nowrap;\n}\n#T_94605  td {\n  padding: 5px;\n  white-space: nowrap;\n}\n</style>\n<table id=\"T_94605\" style='display:block; max-height: 300px; max-width: 100%; overflow-x: auto; overflow-y: auto;'>\n  <thead>\n    <tr>\n      <th class=\"blank level0\" >&nbsp;</th>\n      <th id=\"T_94605_level0_col0\" class=\"col_heading level0 col0\" >entry</th>\n      <th id=\"T_94605_level0_col1\" class=\"col_heading level0 col1\" >sequence</th>\n      <th id=\"T_94605_level0_col2\" class=\"col_heading level0 col2\" >label</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th id=\"T_94605_level0_row0\" class=\"row_heading level0 row0\" >1</th>\n      <td id=\"T_94605_row0_col0\" class=\"data row0 col0\" >CAPSID_1</td>\n      <td id=\"T_94605_row0_col1\" class=\"data row0 col1\" >MVTHNVKINKHVTRR...DTPRIPATKLDEENV</td>\n      <td id=\"T_94605_row0_col2\" class=\"data row0 col2\" >0</td>\n    </tr>\n    <tr>\n      <th id=\"T_94605_level0_row1\" class=\"row_heading level0 row1\" >2</th>\n      <td id=\"T_94605_row1_col0\" class=\"data row1 col0\" >CAPSID_2</td>\n      <td id=\"T_94605_row1_col1\" class=\"data row1 col1\" >MKKRQKKMTLSNFTD...AMLEAVINARHFGEE</td>\n      <td id=\"T_94605_row1_col2\" class=\"data row1 col2\" >0</td>\n    </tr>\n    <tr>\n      <th id=\"T_94605_level0_row2\" class=\"row_heading level0 row2\" >3</th>\n      <td id=\"T_94605_row2_col0\" class=\"data row2 col0\" >CAPSID_4072</td>\n      <td id=\"T_94605_row2_col1\" class=\"data row2 col1\" >MALTTNDVITEDFVR...AWKAIFPEAAVKVDA</td>\n      <td id=\"T_94605_row2_col2\" class=\"data row2 col2\" >1</td>\n    </tr>\n    <tr>\n      <th id=\"T_94605_level0_row3\" class=\"row_heading level0 row3\" >4</th>\n      <td id=\"T_94605_row3_col0\" class=\"data row3 col0\" >CAPSID_4073</td>\n      <td id=\"T_94605_row3_col1\" class=\"data row3 col1\" >MGELTDNGVQLAKAQ...TCTNPAAHAKIRDLK</td>\n      <td id=\"T_94605_row3_col2\" class=\"data row3 col2\" >1</td>\n    </tr>\n  </tbody>\n</table>\n"
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "#T_7eda6 thead th {\n",
+       "  background-color: white;\n",
+       "  color: black;\n",
+       "}\n",
+       "#T_7eda6 tbody tr:nth-child(odd) {\n",
+       "  background-color: #f2f2f2;\n",
+       "}\n",
+       "#T_7eda6 tbody tr:nth-child(even) {\n",
+       "  background-color: white;\n",
+       "}\n",
+       "#T_7eda6 th {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "#T_7eda6  td {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "</style>\n",
+       "<table id=\"T_7eda6\" style='display:block; max-height: 300px; max-width: 100%; overflow-x: auto; overflow-y: auto;'>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_7eda6_level0_col0\" class=\"col_heading level0 col0\" >entry</th>\n",
+       "      <th id=\"T_7eda6_level0_col1\" class=\"col_heading level0 col1\" >sequence</th>\n",
+       "      <th id=\"T_7eda6_level0_col2\" class=\"col_heading level0 col2\" >label</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_7eda6_level0_row0\" class=\"row_heading level0 row0\" >1</th>\n",
+       "      <td id=\"T_7eda6_row0_col0\" class=\"data row0 col0\" >CAPSID_1</td>\n",
+       "      <td id=\"T_7eda6_row0_col1\" class=\"data row0 col1\" >MVTHNVKINKHVTRR...DTPRIPATKLDEENV</td>\n",
+       "      <td id=\"T_7eda6_row0_col2\" class=\"data row0 col2\" >0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_7eda6_level0_row1\" class=\"row_heading level0 row1\" >2</th>\n",
+       "      <td id=\"T_7eda6_row1_col0\" class=\"data row1 col0\" >CAPSID_2</td>\n",
+       "      <td id=\"T_7eda6_row1_col1\" class=\"data row1 col1\" >MKKRQKKMTLSNFTD...AMLEAVINARHFGEE</td>\n",
+       "      <td id=\"T_7eda6_row1_col2\" class=\"data row1 col2\" >0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_7eda6_level0_row2\" class=\"row_heading level0 row2\" >3</th>\n",
+       "      <td id=\"T_7eda6_row2_col0\" class=\"data row2 col0\" >CAPSID_4072</td>\n",
+       "      <td id=\"T_7eda6_row2_col1\" class=\"data row2 col1\" >MALTTNDVITEDFVR...AWKAIFPEAAVKVDA</td>\n",
+       "      <td id=\"T_7eda6_row2_col2\" class=\"data row2 col2\" >1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_7eda6_level0_row3\" class=\"row_heading level0 row3\" >4</th>\n",
+       "      <td id=\"T_7eda6_row3_col0\" class=\"data row3 col0\" >CAPSID_4073</td>\n",
+       "      <td id=\"T_7eda6_row3_col1\" class=\"data row3 col1\" >MGELTDNGVQLAKAQ...TCTNPAAHAKIRDLK</td>\n",
+       "      <td id=\"T_7eda6_row3_col2\" class=\"data row3 col2\" >1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -70,34 +388,99 @@
    "source": [
     "df_seq = aa.load_dataset(name=\"SEQ_CAPSID\", n=2)\n",
     "aa.display_df(df=df_seq)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-06-17T00:32:05.623843318Z",
-     "start_time": "2025-06-17T00:32:05.340088605Z"
-    }
-   },
-   "id": "29441ff404197ad8"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "The sampling can be performed randomly by setting ``random=True``: "
-   ],
+   "id": "4a1a9e5a2592113c",
    "metadata": {
     "collapsed": false
    },
-   "id": "4a1a9e5a2592113c"
+   "source": [
+    "The sampling can be performed randomly by setting ``random=True``: "
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "117de37987631b8d",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-06-17T00:32:05.906304271Z",
+     "start_time": "2025-06-17T00:32:05.616979021Z"
+    },
+    "collapsed": false,
+    "execution": {
+     "iopub.execute_input": "2026-06-25T16:43:32.742754Z",
+     "iopub.status.busy": "2026-06-25T16:43:32.742691Z",
+     "iopub.status.idle": "2026-06-25T16:43:32.779555Z",
+     "shell.execute_reply": "2026-06-25T16:43:32.779343Z"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": "<IPython.core.display.HTML object>",
-      "text/html": "<style type=\"text/css\">\n#T_99cfd thead th {\n  background-color: white;\n  color: black;\n}\n#T_99cfd tbody tr:nth-child(odd) {\n  background-color: #f2f2f2;\n}\n#T_99cfd tbody tr:nth-child(even) {\n  background-color: white;\n}\n#T_99cfd th {\n  padding: 5px;\n  white-space: nowrap;\n}\n#T_99cfd  td {\n  padding: 5px;\n  white-space: nowrap;\n}\n</style>\n<table id=\"T_99cfd\" style='display:block; max-height: 300px; max-width: 100%; overflow-x: auto; overflow-y: auto;'>\n  <thead>\n    <tr>\n      <th class=\"blank level0\" >&nbsp;</th>\n      <th id=\"T_99cfd_level0_col0\" class=\"col_heading level0 col0\" >entry</th>\n      <th id=\"T_99cfd_level0_col1\" class=\"col_heading level0 col1\" >sequence</th>\n      <th id=\"T_99cfd_level0_col2\" class=\"col_heading level0 col2\" >label</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th id=\"T_99cfd_level0_row0\" class=\"row_heading level0 row0\" >1</th>\n      <td id=\"T_99cfd_row0_col0\" class=\"data row0 col0\" >CAPSID_1080</td>\n      <td id=\"T_99cfd_row0_col1\" class=\"data row0 col1\" >MKFTQFGEKFTRYSG...GINIIAEEVLKAYSE</td>\n      <td id=\"T_99cfd_row0_col2\" class=\"data row0 col2\" >0</td>\n    </tr>\n    <tr>\n      <th id=\"T_99cfd_level0_row1\" class=\"row_heading level0 row1\" >2</th>\n      <td id=\"T_99cfd_row1_col0\" class=\"data row1 col0\" >CAPSID_3847</td>\n      <td id=\"T_99cfd_row1_col1\" class=\"data row1 col1\" >MLAELLSTFRRRPPE...KRAATGYGEGGRRRG</td>\n      <td id=\"T_99cfd_row1_col2\" class=\"data row1 col2\" >0</td>\n    </tr>\n    <tr>\n      <th id=\"T_99cfd_level0_row2\" class=\"row_heading level0 row2\" >3</th>\n      <td id=\"T_99cfd_row2_col0\" class=\"data row2 col0\" >CAPSID_6263</td>\n      <td id=\"T_99cfd_row2_col1\" class=\"data row2 col1\" >MANYQDIAVEFAGDL...QNVVAAARVFRGTGV</td>\n      <td id=\"T_99cfd_row2_col2\" class=\"data row2 col2\" >1</td>\n    </tr>\n    <tr>\n      <th id=\"T_99cfd_level0_row3\" class=\"row_heading level0 row3\" >4</th>\n      <td id=\"T_99cfd_row3_col0\" class=\"data row3 col0\" >CAPSID_5423</td>\n      <td id=\"T_99cfd_row3_col1\" class=\"data row3 col1\" >MGALLAVIAEVAEVS...TTPHRSSKTYSKRRH</td>\n      <td id=\"T_99cfd_row3_col2\" class=\"data row3 col2\" >1</td>\n    </tr>\n  </tbody>\n</table>\n"
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "#T_ce159 thead th {\n",
+       "  background-color: white;\n",
+       "  color: black;\n",
+       "}\n",
+       "#T_ce159 tbody tr:nth-child(odd) {\n",
+       "  background-color: #f2f2f2;\n",
+       "}\n",
+       "#T_ce159 tbody tr:nth-child(even) {\n",
+       "  background-color: white;\n",
+       "}\n",
+       "#T_ce159 th {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "#T_ce159  td {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "</style>\n",
+       "<table id=\"T_ce159\" style='display:block; max-height: 300px; max-width: 100%; overflow-x: auto; overflow-y: auto;'>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_ce159_level0_col0\" class=\"col_heading level0 col0\" >entry</th>\n",
+       "      <th id=\"T_ce159_level0_col1\" class=\"col_heading level0 col1\" >sequence</th>\n",
+       "      <th id=\"T_ce159_level0_col2\" class=\"col_heading level0 col2\" >label</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_ce159_level0_row0\" class=\"row_heading level0 row0\" >1</th>\n",
+       "      <td id=\"T_ce159_row0_col0\" class=\"data row0 col0\" >CAPSID_2288</td>\n",
+       "      <td id=\"T_ce159_row0_col1\" class=\"data row0 col1\" >MWSLHSAYGINMVSQ...KKSKQQDKTGPAYFG</td>\n",
+       "      <td id=\"T_ce159_row0_col2\" class=\"data row0 col2\" >0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_ce159_level0_row1\" class=\"row_heading level0 row1\" >2</th>\n",
+       "      <td id=\"T_ce159_row1_col0\" class=\"data row1 col0\" >CAPSID_623</td>\n",
+       "      <td id=\"T_ce159_row1_col1\" class=\"data row1 col1\" >MSYVVDAVDNALKLL...LQACSRAISAEFEYM</td>\n",
+       "      <td id=\"T_ce159_row1_col2\" class=\"data row1 col2\" >0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_ce159_level0_row2\" class=\"row_heading level0 row2\" >3</th>\n",
+       "      <td id=\"T_ce159_row2_col0\" class=\"data row2 col0\" >CAPSID_5322</td>\n",
+       "      <td id=\"T_ce159_row2_col1\" class=\"data row2 col1\" >MADAKLSRLGAIKGD...MEVLRAECCARIIHS</td>\n",
+       "      <td id=\"T_ce159_row2_col2\" class=\"data row2 col2\" >1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_ce159_level0_row3\" class=\"row_heading level0 row3\" >4</th>\n",
+       "      <td id=\"T_ce159_row3_col0\" class=\"data row3 col0\" >CAPSID_7455</td>\n",
+       "      <td id=\"T_ce159_row3_col1\" class=\"data row3 col1\" >MSTVLSTLKASKHGK...NQALDGETEKSTLDL</td>\n",
+       "      <td id=\"T_ce159_row3_col2\" class=\"data row3 col2\" >1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -106,29 +489,35 @@
    "source": [
     "df_seq = aa.load_dataset(name=\"SEQ_CAPSID\", n=2, random=True)\n",
     "aa.display_df(df=df_seq)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-06-17T00:32:05.906304271Z",
-     "start_time": "2025-06-17T00:32:05.616979021Z"
-    }
-   },
-   "id": "117de37987631b8d"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Sequences with non-canonical amino acids are by default removed, which can be disabled by setting ``non_canonical_aa='keep'`` or ``non_canonical_aa='gap'``: "
-   ],
+   "id": "6967245ac7a62253",
    "metadata": {
     "collapsed": false
    },
-   "id": "6967245ac7a62253"
+   "source": [
+    "Sequences with non-canonical amino acids are by default removed, which can be disabled by setting ``non_canonical_aa='keep'`` or ``non_canonical_aa='gap'``: "
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "9e706ce1a55dc432",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-06-17T00:32:05.977757660Z",
+     "start_time": "2025-06-17T00:32:05.904223105Z"
+    },
+    "collapsed": false,
+    "execution": {
+     "iopub.execute_input": "2026-06-25T16:43:32.780589Z",
+     "iopub.status.busy": "2026-06-25T16:43:32.780531Z",
+     "iopub.status.idle": "2026-06-25T16:43:32.792717Z",
+     "shell.execute_reply": "2026-06-25T16:43:32.792513Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -142,29 +531,35 @@
     "n_unfiltered = len(aa.load_dataset(name='SEQ_DISULFIDE', non_canonical_aa=\"keep\"))\n",
     "n = len(aa.load_dataset(name='SEQ_DISULFIDE'))\n",
     "print(f\"'SEQ_DISULFIDE' contain {n_unfiltered} proteins and {n} after filtering.\")    "
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-06-17T00:32:05.977757660Z",
-     "start_time": "2025-06-17T00:32:05.904223105Z"
-    }
-   },
-   "id": "9e706ce1a55dc432"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Datasets can be filtered for the minimum and maximum sequence length using ``min_len`` and ``max_len``:"
-   ],
+   "id": "233639c1f00a80b5",
    "metadata": {
     "collapsed": false
    },
-   "id": "233639c1f00a80b5"
+   "source": [
+    "Datasets can be filtered for the minimum and maximum sequence length using ``min_len`` and ``max_len``:"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "c509510217042c3e",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-06-17T00:32:06.019322297Z",
+     "start_time": "2025-06-17T00:32:05.977334328Z"
+    },
+    "collapsed": false,
+    "execution": {
+     "iopub.execute_input": "2026-06-25T16:43:32.793818Z",
+     "iopub.status.busy": "2026-06-25T16:43:32.793752Z",
+     "iopub.status.idle": "2026-06-25T16:43:32.798589Z",
+     "shell.execute_reply": "2026-06-25T16:43:32.798363Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -177,34 +572,134 @@
    "source": [
     "n_len_filtered = len(aa.load_dataset(name='SEQ_DISULFIDE', min_len=100, max_len=200))\n",
     "print(f\"'SEQ_DISULFIDE' contain {n_unfiltered} proteins, of which {n_len_filtered} have a length between 100 and 200 residues.\")   \n"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-06-17T00:32:06.019322297Z",
-     "start_time": "2025-06-17T00:32:05.977334328Z"
-    }
-   },
-   "id": "c509510217042c3e"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "b1a62b04",
+   "metadata": {},
    "source": [
-    "For the 'Amino acid level' datasets, the size of the amino acid window can be adjusted using the ``aa_window_size`` parameter:"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "ff705f6c6c7332be"
+    "Set ``verbose=True`` to report how many entries each removal step (``min_len``, ``max_len``, and ``non_canonical_aa='remove'``) drops. This only reports counts and does not change the returned data:"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "85ac404f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-25T16:43:32.799546Z",
+     "iopub.status.busy": "2026-06-25T16:43:32.799487Z",
+     "iopub.status.idle": "2026-06-25T16:43:32.803915Z",
+     "shell.execute_reply": "2026-06-25T16:43:32.803720Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[94m'SEQ_DISULFIDE': removed 550 sequence(s) shorter than 'min_len' (100).\u001b[0m\n",
+      "\u001b[94m'SEQ_DISULFIDE': removed 1273 sequence(s) longer than 'max_len' (200).\u001b[0m\n",
+      "\u001b[94m'SEQ_DISULFIDE': removed 80 sequence(s) containing non-canonical amino acids.\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "df_seq = aa.load_dataset(name=\"SEQ_DISULFIDE\", min_len=100, max_len=200, verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff705f6c6c7332be",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "For the 'Amino acid level' datasets, the size of the amino acid window can be adjusted using the ``aa_window_size`` parameter:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9429cb6eb0a0e028",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-06-17T00:32:06.567619706Z",
+     "start_time": "2025-06-17T00:32:06.018843441Z"
+    },
+    "collapsed": false,
+    "execution": {
+     "iopub.execute_input": "2026-06-25T16:43:32.804988Z",
+     "iopub.status.busy": "2026-06-25T16:43:32.804923Z",
+     "iopub.status.idle": "2026-06-25T16:43:32.905375Z",
+     "shell.execute_reply": "2026-06-25T16:43:32.905164Z"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": "<IPython.core.display.HTML object>",
-      "text/html": "<style type=\"text/css\">\n#T_a99a7 thead th {\n  background-color: white;\n  color: black;\n}\n#T_a99a7 tbody tr:nth-child(odd) {\n  background-color: #f2f2f2;\n}\n#T_a99a7 tbody tr:nth-child(even) {\n  background-color: white;\n}\n#T_a99a7 th {\n  padding: 5px;\n  white-space: nowrap;\n}\n#T_a99a7  td {\n  padding: 5px;\n  white-space: nowrap;\n}\n</style>\n<table id=\"T_a99a7\" style='display:block; max-height: 300px; max-width: 100%; overflow-x: auto; overflow-y: auto;'>\n  <thead>\n    <tr>\n      <th class=\"blank level0\" >&nbsp;</th>\n      <th id=\"T_a99a7_level0_col0\" class=\"col_heading level0 col0\" >entry</th>\n      <th id=\"T_a99a7_level0_col1\" class=\"col_heading level0 col1\" >sequence</th>\n      <th id=\"T_a99a7_level0_col2\" class=\"col_heading level0 col2\" >label</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th id=\"T_a99a7_level0_row0\" class=\"row_heading level0 row0\" >1</th>\n      <td id=\"T_a99a7_row0_col0\" class=\"data row0 col0\" >CASPASE3_1_pos126</td>\n      <td id=\"T_a99a7_row0_col1\" class=\"data row0 col1\" >LRDSM</td>\n      <td id=\"T_a99a7_row0_col2\" class=\"data row0 col2\" >1</td>\n    </tr>\n    <tr>\n      <th id=\"T_a99a7_level0_row1\" class=\"row_heading level0 row1\" >2</th>\n      <td id=\"T_a99a7_row1_col0\" class=\"data row1 col0\" >CASPASE3_1_pos127</td>\n      <td id=\"T_a99a7_row1_col1\" class=\"data row1 col1\" >RDSML</td>\n      <td id=\"T_a99a7_row1_col2\" class=\"data row1 col2\" >1</td>\n    </tr>\n    <tr>\n      <th id=\"T_a99a7_level0_row2\" class=\"row_heading level0 row2\" >3</th>\n      <td id=\"T_a99a7_row2_col0\" class=\"data row2 col0\" >CASPASE3_1_pos2</td>\n      <td id=\"T_a99a7_row2_col1\" class=\"data row2 col1\" >MSLFD</td>\n      <td id=\"T_a99a7_row2_col2\" class=\"data row2 col2\" >0</td>\n    </tr>\n    <tr>\n      <th id=\"T_a99a7_level0_row3\" class=\"row_heading level0 row3\" >4</th>\n      <td id=\"T_a99a7_row3_col0\" class=\"data row3 col0\" >CASPASE3_1_pos3</td>\n      <td id=\"T_a99a7_row3_col1\" class=\"data row3 col1\" >SLFDL</td>\n      <td id=\"T_a99a7_row3_col2\" class=\"data row3 col2\" >0</td>\n    </tr>\n  </tbody>\n</table>\n"
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "#T_fda80 thead th {\n",
+       "  background-color: white;\n",
+       "  color: black;\n",
+       "}\n",
+       "#T_fda80 tbody tr:nth-child(odd) {\n",
+       "  background-color: #f2f2f2;\n",
+       "}\n",
+       "#T_fda80 tbody tr:nth-child(even) {\n",
+       "  background-color: white;\n",
+       "}\n",
+       "#T_fda80 th {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "#T_fda80  td {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "</style>\n",
+       "<table id=\"T_fda80\" style='display:block; max-height: 300px; max-width: 100%; overflow-x: auto; overflow-y: auto;'>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_fda80_level0_col0\" class=\"col_heading level0 col0\" >entry</th>\n",
+       "      <th id=\"T_fda80_level0_col1\" class=\"col_heading level0 col1\" >sequence</th>\n",
+       "      <th id=\"T_fda80_level0_col2\" class=\"col_heading level0 col2\" >label</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_fda80_level0_row0\" class=\"row_heading level0 row0\" >1</th>\n",
+       "      <td id=\"T_fda80_row0_col0\" class=\"data row0 col0\" >CASPASE3_1_pos2</td>\n",
+       "      <td id=\"T_fda80_row0_col1\" class=\"data row0 col1\" >MSLFD</td>\n",
+       "      <td id=\"T_fda80_row0_col2\" class=\"data row0 col2\" >0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_fda80_level0_row1\" class=\"row_heading level0 row1\" >2</th>\n",
+       "      <td id=\"T_fda80_row1_col0\" class=\"data row1 col0\" >CASPASE3_1_pos3</td>\n",
+       "      <td id=\"T_fda80_row1_col1\" class=\"data row1 col1\" >SLFDL</td>\n",
+       "      <td id=\"T_fda80_row1_col2\" class=\"data row1 col2\" >0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_fda80_level0_row2\" class=\"row_heading level0 row2\" >3</th>\n",
+       "      <td id=\"T_fda80_row2_col0\" class=\"data row2 col0\" >CASPASE3_1_pos126</td>\n",
+       "      <td id=\"T_fda80_row2_col1\" class=\"data row2 col1\" >LRDSM</td>\n",
+       "      <td id=\"T_fda80_row2_col2\" class=\"data row2 col2\" >1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_fda80_level0_row3\" class=\"row_heading level0 row3\" >4</th>\n",
+       "      <td id=\"T_fda80_row3_col0\" class=\"data row3 col0\" >CASPASE3_1_pos127</td>\n",
+       "      <td id=\"T_fda80_row3_col1\" class=\"data row3 col1\" >RDSML</td>\n",
+       "      <td id=\"T_fda80_row3_col2\" class=\"data row3 col2\" >1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -213,34 +708,146 @@
    "source": [
     "df_aa = aa.load_dataset(name=\"AA_CASPASE3\", n=2, aa_window_size=5)\n",
     "aa.display_df(df=df_aa)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-06-17T00:32:06.567619706Z",
-     "start_time": "2025-06-17T00:32:06.018843441Z"
-    }
-   },
-   "id": "9429cb6eb0a0e028"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "For Positive-Unlabeled (PU) learning, datasets are provided containing only positive (labeled by '1') and unlabeled data ('2'), indicated by a 'PU' suffix in the 'Dataset' column name:"
-   ],
+   "id": "fc40fc211c4d5dfe",
    "metadata": {
     "collapsed": false
    },
-   "id": "fc40fc211c4d5dfe"
+   "source": [
+    "For Positive-Unlabeled (PU) learning, datasets are provided containing only positive (labeled by '1') and unlabeled data ('2'), indicated by a 'PU' suffix in the 'Dataset' column name:"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
+   "id": "6af074b2cefe5480",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-06-17T00:32:06.629147642Z",
+     "start_time": "2025-06-17T00:32:06.566274755Z"
+    },
+    "collapsed": false,
+    "execution": {
+     "iopub.execute_input": "2026-06-25T16:43:32.906508Z",
+     "iopub.status.busy": "2026-06-25T16:43:32.906443Z",
+     "iopub.status.idle": "2026-06-25T16:43:32.917920Z",
+     "shell.execute_reply": "2026-06-25T16:43:32.917711Z"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": "<IPython.core.display.HTML object>",
-      "text/html": "<style type=\"text/css\">\n#T_92936 thead th {\n  background-color: white;\n  color: black;\n}\n#T_92936 tbody tr:nth-child(odd) {\n  background-color: #f2f2f2;\n}\n#T_92936 tbody tr:nth-child(even) {\n  background-color: white;\n}\n#T_92936 th {\n  padding: 5px;\n  white-space: nowrap;\n}\n#T_92936  td {\n  padding: 5px;\n  white-space: nowrap;\n}\n</style>\n<table id=\"T_92936\" style='display:block; max-height: 300px; max-width: 100%; overflow-x: auto; overflow-y: auto;'>\n  <thead>\n    <tr>\n      <th class=\"blank level0\" >&nbsp;</th>\n      <th id=\"T_92936_level0_col0\" class=\"col_heading level0 col0\" >entry</th>\n      <th id=\"T_92936_level0_col1\" class=\"col_heading level0 col1\" >sequence</th>\n      <th id=\"T_92936_level0_col2\" class=\"col_heading level0 col2\" >label</th>\n      <th id=\"T_92936_level0_col3\" class=\"col_heading level0 col3\" >tmd_start</th>\n      <th id=\"T_92936_level0_col4\" class=\"col_heading level0 col4\" >tmd_stop</th>\n      <th id=\"T_92936_level0_col5\" class=\"col_heading level0 col5\" >jmd_n</th>\n      <th id=\"T_92936_level0_col6\" class=\"col_heading level0 col6\" >tmd</th>\n      <th id=\"T_92936_level0_col7\" class=\"col_heading level0 col7\" >jmd_c</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th id=\"T_92936_level0_row0\" class=\"row_heading level0 row0\" >1</th>\n      <td id=\"T_92936_row0_col0\" class=\"data row0 col0\" >P05067</td>\n      <td id=\"T_92936_row0_col1\" class=\"data row0 col1\" >MLPGLALLLLAAWTA...GYENPTYKFFEQMQN</td>\n      <td id=\"T_92936_row0_col2\" class=\"data row0 col2\" >1</td>\n      <td id=\"T_92936_row0_col3\" class=\"data row0 col3\" >701</td>\n      <td id=\"T_92936_row0_col4\" class=\"data row0 col4\" >723</td>\n      <td id=\"T_92936_row0_col5\" class=\"data row0 col5\" >FAEDVGSNKG</td>\n      <td id=\"T_92936_row0_col6\" class=\"data row0 col6\" >AIIGLMVGGVVIATVIVITLVML</td>\n      <td id=\"T_92936_row0_col7\" class=\"data row0 col7\" >KKKQYTSIHH</td>\n    </tr>\n    <tr>\n      <th id=\"T_92936_level0_row1\" class=\"row_heading level0 row1\" >2</th>\n      <td id=\"T_92936_row1_col0\" class=\"data row1 col0\" >P14925</td>\n      <td id=\"T_92936_row1_col1\" class=\"data row1 col1\" >MAGRARSGLLLLLLG...EEEYSAPLPKPAPSS</td>\n      <td id=\"T_92936_row1_col2\" class=\"data row1 col2\" >1</td>\n      <td id=\"T_92936_row1_col3\" class=\"data row1 col3\" >868</td>\n      <td id=\"T_92936_row1_col4\" class=\"data row1 col4\" >890</td>\n      <td id=\"T_92936_row1_col5\" class=\"data row1 col5\" >KLSTEPGSGV</td>\n      <td id=\"T_92936_row1_col6\" class=\"data row1 col6\" >SVVLITTLLVIPVLVLLAIVMFI</td>\n      <td id=\"T_92936_row1_col7\" class=\"data row1 col7\" >RWKKSRAFGD</td>\n    </tr>\n    <tr>\n      <th id=\"T_92936_level0_row2\" class=\"row_heading level0 row2\" >3</th>\n      <td id=\"T_92936_row2_col0\" class=\"data row2 col0\" >P70180</td>\n      <td id=\"T_92936_row2_col1\" class=\"data row2 col1\" >MRSLLLFTFSACVLL...RELREDSIRSHFSVA</td>\n      <td id=\"T_92936_row2_col2\" class=\"data row2 col2\" >1</td>\n      <td id=\"T_92936_row2_col3\" class=\"data row2 col3\" >477</td>\n      <td id=\"T_92936_row2_col4\" class=\"data row2 col4\" >499</td>\n      <td id=\"T_92936_row2_col5\" class=\"data row2 col5\" >PCKSSGGLEE</td>\n      <td id=\"T_92936_row2_col6\" class=\"data row2 col6\" >SAVTGIVVGALLGAGLLMAFYFF</td>\n      <td id=\"T_92936_row2_col7\" class=\"data row2 col7\" >RKKYRITIER</td>\n    </tr>\n    <tr>\n      <th id=\"T_92936_level0_row3\" class=\"row_heading level0 row3\" >4</th>\n      <td id=\"T_92936_row3_col0\" class=\"data row3 col0\" >P12821</td>\n      <td id=\"T_92936_row3_col1\" class=\"data row3 col1\" >MGAASGRRGPGLLLP...SHGPQFGSEVELRHS</td>\n      <td id=\"T_92936_row3_col2\" class=\"data row3 col2\" >2</td>\n      <td id=\"T_92936_row3_col3\" class=\"data row3 col3\" >1257</td>\n      <td id=\"T_92936_row3_col4\" class=\"data row3 col4\" >1276</td>\n      <td id=\"T_92936_row3_col5\" class=\"data row3 col5\" >GLDLDAQQAR</td>\n      <td id=\"T_92936_row3_col6\" class=\"data row3 col6\" >VGQWLLLFLGIALLVATLGL</td>\n      <td id=\"T_92936_row3_col7\" class=\"data row3 col7\" >SQRLFSIRHR</td>\n    </tr>\n    <tr>\n      <th id=\"T_92936_level0_row4\" class=\"row_heading level0 row4\" >5</th>\n      <td id=\"T_92936_row4_col0\" class=\"data row4 col0\" >P36896</td>\n      <td id=\"T_92936_row4_col1\" class=\"data row4 col1\" >MAESAGASSFFPLVV...KKTLSQLSVQEDVKI</td>\n      <td id=\"T_92936_row4_col2\" class=\"data row4 col2\" >2</td>\n      <td id=\"T_92936_row4_col3\" class=\"data row4 col3\" >127</td>\n      <td id=\"T_92936_row4_col4\" class=\"data row4 col4\" >149</td>\n      <td id=\"T_92936_row4_col5\" class=\"data row4 col5\" >EHPSMWGPVE</td>\n      <td id=\"T_92936_row4_col6\" class=\"data row4 col6\" >LVGIIAGPVFLLFLIIIIVFLVI</td>\n      <td id=\"T_92936_row4_col7\" class=\"data row4 col7\" >NYHQRVYHNR</td>\n    </tr>\n    <tr>\n      <th id=\"T_92936_level0_row5\" class=\"row_heading level0 row5\" >6</th>\n      <td id=\"T_92936_row5_col0\" class=\"data row5 col0\" >Q8NER5</td>\n      <td id=\"T_92936_row5_col1\" class=\"data row5 col1\" >MTRALCSALRQALLL...KKTISQLCVKEDCKA</td>\n      <td id=\"T_92936_row5_col2\" class=\"data row5 col2\" >2</td>\n      <td id=\"T_92936_row5_col3\" class=\"data row5 col3\" >114</td>\n      <td id=\"T_92936_row5_col4\" class=\"data row5 col4\" >136</td>\n      <td id=\"T_92936_row5_col5\" class=\"data row5 col5\" >PNAPKLGPME</td>\n      <td id=\"T_92936_row5_col6\" class=\"data row5 col6\" >LAIIITVPVCLLSIAAMLTVWAC</td>\n      <td id=\"T_92936_row5_col7\" class=\"data row5 col7\" >QGRQCSYRKK</td>\n    </tr>\n  </tbody>\n</table>\n"
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "#T_5881e thead th {\n",
+       "  background-color: white;\n",
+       "  color: black;\n",
+       "}\n",
+       "#T_5881e tbody tr:nth-child(odd) {\n",
+       "  background-color: #f2f2f2;\n",
+       "}\n",
+       "#T_5881e tbody tr:nth-child(even) {\n",
+       "  background-color: white;\n",
+       "}\n",
+       "#T_5881e th {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "#T_5881e  td {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "</style>\n",
+       "<table id=\"T_5881e\" style='display:block; max-height: 300px; max-width: 100%; overflow-x: auto; overflow-y: auto;'>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_5881e_level0_col0\" class=\"col_heading level0 col0\" >entry</th>\n",
+       "      <th id=\"T_5881e_level0_col1\" class=\"col_heading level0 col1\" >sequence</th>\n",
+       "      <th id=\"T_5881e_level0_col2\" class=\"col_heading level0 col2\" >label</th>\n",
+       "      <th id=\"T_5881e_level0_col3\" class=\"col_heading level0 col3\" >tmd_start</th>\n",
+       "      <th id=\"T_5881e_level0_col4\" class=\"col_heading level0 col4\" >tmd_stop</th>\n",
+       "      <th id=\"T_5881e_level0_col5\" class=\"col_heading level0 col5\" >jmd_n</th>\n",
+       "      <th id=\"T_5881e_level0_col6\" class=\"col_heading level0 col6\" >tmd</th>\n",
+       "      <th id=\"T_5881e_level0_col7\" class=\"col_heading level0 col7\" >jmd_c</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_5881e_level0_row0\" class=\"row_heading level0 row0\" >1</th>\n",
+       "      <td id=\"T_5881e_row0_col0\" class=\"data row0 col0\" >P05067</td>\n",
+       "      <td id=\"T_5881e_row0_col1\" class=\"data row0 col1\" >MLPGLALLLLAAWTA...GYENPTYKFFEQMQN</td>\n",
+       "      <td id=\"T_5881e_row0_col2\" class=\"data row0 col2\" >1</td>\n",
+       "      <td id=\"T_5881e_row0_col3\" class=\"data row0 col3\" >701</td>\n",
+       "      <td id=\"T_5881e_row0_col4\" class=\"data row0 col4\" >723</td>\n",
+       "      <td id=\"T_5881e_row0_col5\" class=\"data row0 col5\" >FAEDVGSNKG</td>\n",
+       "      <td id=\"T_5881e_row0_col6\" class=\"data row0 col6\" >AIIGLMVGGVVIATVIVITLVML</td>\n",
+       "      <td id=\"T_5881e_row0_col7\" class=\"data row0 col7\" >KKKQYTSIHH</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_5881e_level0_row1\" class=\"row_heading level0 row1\" >2</th>\n",
+       "      <td id=\"T_5881e_row1_col0\" class=\"data row1 col0\" >P14925</td>\n",
+       "      <td id=\"T_5881e_row1_col1\" class=\"data row1 col1\" >MAGRARSGLLLLLLG...EEEYSAPLPKPAPSS</td>\n",
+       "      <td id=\"T_5881e_row1_col2\" class=\"data row1 col2\" >1</td>\n",
+       "      <td id=\"T_5881e_row1_col3\" class=\"data row1 col3\" >868</td>\n",
+       "      <td id=\"T_5881e_row1_col4\" class=\"data row1 col4\" >890</td>\n",
+       "      <td id=\"T_5881e_row1_col5\" class=\"data row1 col5\" >KLSTEPGSGV</td>\n",
+       "      <td id=\"T_5881e_row1_col6\" class=\"data row1 col6\" >SVVLITTLLVIPVLVLLAIVMFI</td>\n",
+       "      <td id=\"T_5881e_row1_col7\" class=\"data row1 col7\" >RWKKSRAFGD</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_5881e_level0_row2\" class=\"row_heading level0 row2\" >3</th>\n",
+       "      <td id=\"T_5881e_row2_col0\" class=\"data row2 col0\" >P70180</td>\n",
+       "      <td id=\"T_5881e_row2_col1\" class=\"data row2 col1\" >MRSLLLFTFSACVLL...RELREDSIRSHFSVA</td>\n",
+       "      <td id=\"T_5881e_row2_col2\" class=\"data row2 col2\" >1</td>\n",
+       "      <td id=\"T_5881e_row2_col3\" class=\"data row2 col3\" >477</td>\n",
+       "      <td id=\"T_5881e_row2_col4\" class=\"data row2 col4\" >499</td>\n",
+       "      <td id=\"T_5881e_row2_col5\" class=\"data row2 col5\" >PCKSSGGLEE</td>\n",
+       "      <td id=\"T_5881e_row2_col6\" class=\"data row2 col6\" >SAVTGIVVGALLGAGLLMAFYFF</td>\n",
+       "      <td id=\"T_5881e_row2_col7\" class=\"data row2 col7\" >RKKYRITIER</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_5881e_level0_row3\" class=\"row_heading level0 row3\" >4</th>\n",
+       "      <td id=\"T_5881e_row3_col0\" class=\"data row3 col0\" >P12821</td>\n",
+       "      <td id=\"T_5881e_row3_col1\" class=\"data row3 col1\" >MGAASGRRGPGLLLP...SHGPQFGSEVELRHS</td>\n",
+       "      <td id=\"T_5881e_row3_col2\" class=\"data row3 col2\" >2</td>\n",
+       "      <td id=\"T_5881e_row3_col3\" class=\"data row3 col3\" >1257</td>\n",
+       "      <td id=\"T_5881e_row3_col4\" class=\"data row3 col4\" >1276</td>\n",
+       "      <td id=\"T_5881e_row3_col5\" class=\"data row3 col5\" >GLDLDAQQAR</td>\n",
+       "      <td id=\"T_5881e_row3_col6\" class=\"data row3 col6\" >VGQWLLLFLGIALLVATLGL</td>\n",
+       "      <td id=\"T_5881e_row3_col7\" class=\"data row3 col7\" >SQRLFSIRHR</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_5881e_level0_row4\" class=\"row_heading level0 row4\" >5</th>\n",
+       "      <td id=\"T_5881e_row4_col0\" class=\"data row4 col0\" >P36896</td>\n",
+       "      <td id=\"T_5881e_row4_col1\" class=\"data row4 col1\" >MAESAGASSFFPLVV...KKTLSQLSVQEDVKI</td>\n",
+       "      <td id=\"T_5881e_row4_col2\" class=\"data row4 col2\" >2</td>\n",
+       "      <td id=\"T_5881e_row4_col3\" class=\"data row4 col3\" >127</td>\n",
+       "      <td id=\"T_5881e_row4_col4\" class=\"data row4 col4\" >149</td>\n",
+       "      <td id=\"T_5881e_row4_col5\" class=\"data row4 col5\" >EHPSMWGPVE</td>\n",
+       "      <td id=\"T_5881e_row4_col6\" class=\"data row4 col6\" >LVGIIAGPVFLLFLIIIIVFLVI</td>\n",
+       "      <td id=\"T_5881e_row4_col7\" class=\"data row4 col7\" >NYHQRVYHNR</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_5881e_level0_row5\" class=\"row_heading level0 row5\" >6</th>\n",
+       "      <td id=\"T_5881e_row5_col0\" class=\"data row5 col0\" >Q8NER5</td>\n",
+       "      <td id=\"T_5881e_row5_col1\" class=\"data row5 col1\" >MTRALCSALRQALLL...KKTISQLCVKEDCKA</td>\n",
+       "      <td id=\"T_5881e_row5_col2\" class=\"data row5 col2\" >2</td>\n",
+       "      <td id=\"T_5881e_row5_col3\" class=\"data row5 col3\" >114</td>\n",
+       "      <td id=\"T_5881e_row5_col4\" class=\"data row5 col4\" >136</td>\n",
+       "      <td id=\"T_5881e_row5_col5\" class=\"data row5 col5\" >PNAPKLGPME</td>\n",
+       "      <td id=\"T_5881e_row5_col6\" class=\"data row5 col6\" >LAIIITVPVCLLSIAAMLTVWAC</td>\n",
+       "      <td id=\"T_5881e_row5_col7\" class=\"data row5 col7\" >QGRQCSYRKK</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -249,15 +856,7 @@
    "source": [
     "df_seq = aa.load_dataset(name=\"DOM_GSEC_PU\", n=3)\n",
     "aa.display_df(df=df_seq)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-06-17T00:32:06.629147642Z",
-     "start_time": "2025-06-17T00:32:06.566274755Z"
-    }
-   },
-   "id": "6af074b2cefe5480"
+   ]
   }
  ],
  "metadata": {
@@ -269,14 +868,14 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.13.11"
   }
  },
  "nbformat": 4,

--- a/tests/unit/data_handling_tests/test_load_dataset.py
+++ b/tests/unit/data_handling_tests/test_load_dataset.py
@@ -4,6 +4,7 @@ This is a script for testing the aa.load_dataset function.
 from hypothesis import given, example, settings
 import hypothesis.strategies as some
 import numpy as np
+import pandas as pd
 import aaanalysis.utils as ut
 import aaanalysis as aa
 import pytest
@@ -96,6 +97,23 @@ class TestLoadDataset:
         if non_canonical_aa not in ["remove", "keep", "gap"]:
             with pytest.raises(ValueError):
                 aa.load_dataset(name="SEQ_LOCATION", non_canonical_aa=non_canonical_aa)
+
+    @settings(max_examples=5, deadline=None)
+    @given(verbose=some.booleans())
+    def test_load_dataset_verbose_bool(self, verbose):
+        """Test the 'verbose' parameter accepts booleans without changing the result."""
+        df = aa.load_dataset(name="SEQ_CAPSID", verbose=verbose)
+        assert set(ut.COLS_SEQ_INFO).issubset(set(df))
+
+    @settings(max_examples=10, deadline=None)
+    @given(verbose=some.one_of(some.integers(), some.text(), some.floats()))
+    @example(verbose="yes")
+    @example(verbose=1)
+    def test_load_dataset_invalid_verbose(self, verbose):
+        """Test with an invalid (non-boolean) 'verbose' value."""
+        if not isinstance(verbose, bool):
+            with pytest.raises(ValueError):
+                aa.load_dataset(name="SEQ_CAPSID", verbose=verbose)
 
 
 class TestLoadDatasetComplex:
@@ -211,6 +229,68 @@ class TestLoadDatasetComplex:
         df = aa.load_dataset(name="SEQ_LOCATION", n=5, random=True)
         assert len(df) == 5 * 2
         assert set(df[ut.COL_LABEL]) == {0, 1}
+
+
+# SEQ_CAPSID has both non-canonical sequences and a wide length spread, so each
+# removal step (non-canonical / min_len / max_len) drops a non-zero, verifiable count.
+DATASET_WITH_NON_CANONICAL = "SEQ_CAPSID"
+
+
+class TestLoadDatasetVerbose:
+    """Test that verbose reporting counts every entry-removal step exactly (issue #76)."""
+
+    def test_verbose_reports_non_canonical_removal_exact_count(self, capsys):
+        """verbose=True reports the non-canonical drop count == n_keep - n_remove exactly."""
+        n_keep = len(aa.load_dataset(name=DATASET_WITH_NON_CANONICAL, non_canonical_aa="keep"))
+        df = aa.load_dataset(name=DATASET_WITH_NON_CANONICAL, verbose=True)
+        n_removed = n_keep - len(df)
+        assert n_removed > 0
+        out = capsys.readouterr().out
+        assert "non-canonical" in out
+        assert f"removed {n_removed} sequence" in out
+
+    def test_verbose_reports_min_len_removal_exact_count(self, capsys):
+        """verbose=True reports the min_len drop count == n_before - n_after exactly."""
+        n_before = len(aa.load_dataset(name=DATASET_WITH_NON_CANONICAL, non_canonical_aa="keep"))
+        min_len = 50
+        df_keep = aa.load_dataset(name=DATASET_WITH_NON_CANONICAL, non_canonical_aa="keep", min_len=min_len)
+        n_removed = n_before - len(df_keep)
+        assert n_removed > 0
+        aa.load_dataset(name=DATASET_WITH_NON_CANONICAL, min_len=min_len, verbose=True)
+        out = capsys.readouterr().out
+        assert "min_len" in out
+        assert f"removed {n_removed} sequence" in out
+
+    def test_verbose_reports_max_len_removal_exact_count(self, capsys):
+        """verbose=True reports the max_len drop count == n_before - n_after exactly."""
+        n_before = len(aa.load_dataset(name=DATASET_WITH_NON_CANONICAL, non_canonical_aa="keep"))
+        max_len = 300
+        df_keep = aa.load_dataset(name=DATASET_WITH_NON_CANONICAL, non_canonical_aa="keep", max_len=max_len)
+        n_removed = n_before - len(df_keep)
+        assert n_removed > 0
+        aa.load_dataset(name=DATASET_WITH_NON_CANONICAL, max_len=max_len, verbose=True)
+        out = capsys.readouterr().out
+        assert "max_len" in out
+        assert f"removed {n_removed} sequence" in out
+
+    def test_verbose_off_is_silent(self, capsys):
+        """verbose=False (the default) emits no removal messages."""
+        aa.load_dataset(name=DATASET_WITH_NON_CANONICAL, verbose=False)
+        assert capsys.readouterr().out == ""
+
+    def test_opt_out_keeps_all_entries(self):
+        """The non_canonical_aa='keep' opt-out removes 0 entries (raw on-disk row count)."""
+        raw = ut.read_csv_cached(
+            ut.FOLDER_DATA + "benchmarks" + ut.SEP + DATASET_WITH_NON_CANONICAL + f".{ut.STR_FILE_TYPE}"
+        )
+        df_keep = aa.load_dataset(name=DATASET_WITH_NON_CANONICAL, non_canonical_aa="keep")
+        assert len(df_keep) == len(raw)
+
+    def test_default_output_byte_identical_to_verbose_off(self):
+        """Default call returns df_seq byte-identical regardless of verbose (no data change)."""
+        df_default = aa.load_dataset(name=DATASET_WITH_NON_CANONICAL)
+        df_verbose = aa.load_dataset(name=DATASET_WITH_NON_CANONICAL, verbose=True)
+        pd.testing.assert_frame_equal(df_default, df_verbose)
 
 
 def _recompute_avg_length(name):


### PR DESCRIPTION
## Summary

`aa.load_dataset` silently dropped rows in three places — the `min_len` filter, the `max_len` filter, and `_adjust_non_canonical_aa` under the default `non_canonical_aa='remove'` — surfacing nothing unless a filter removed *every* row. This makes the previously silent filtering observable.

A new **`verbose: bool = False`** parameter reports how many entries each removal step drops, via `ut.print_out` (gated on `verbose`, emitted only when the count is non-zero). The returned data is **byte-identical** when `verbose` is off. The retain-everything opt-out is the existing `non_canonical_aa='keep'`.

```python
aa.load_dataset(name="SEQ_CAPSID", verbose=True)
# -> 'SEQ_CAPSID': removed 73 sequence(s) containing non-canonical amino acids.

aa.load_dataset(name="SEQ_CAPSID", non_canonical_aa="keep")   # retains every entry
```

## Design

- `verbose` validated through `ut.check_verbose` (validates via `check_bool` **and** honors the global `aa.options['verbose']`), matching the house pattern used by `TreeModel` / `EmbeddingPreprocessor`.
- Per-step `n_removed = n_before - n_after` computed at each removal site; printed only when `verbose and n_removed > 0` (and `non_canonical_aa == 'remove'` for the non-canonical step).
- No separate opt-out flag added — retaining entries is the existing `non_canonical_aa='keep'` (and `min_len`/`max_len` already default to `None`). Keeps the API slim.

## Acceptance criteria (issue KPIs)

- [x] On a dataset with non-canonical sequences, `verbose=True` emits a message whose reported count **equals** `n_before - n_after` exactly (asserted per step via `capsys`).
- [x] Opt-out (`non_canonical_aa='keep'`) removes **0** entries — `len(df_seq)` equals the raw on-disk row count.
- [x] Default call (`verbose` off) returns a `df_seq` **byte-identical** to current `master` (`pd.testing.assert_frame_equal`).

## Ripple

- Code + Validate block, numpydoc (`versionchanged:: 1.1.0` + param docs), 8 new tests, example notebook (`load_dataset.ipynb`, re-executed with outputs), release notes (Unreleased → Changed).
- No `__all__` change (additive parameter on an already-public function).

## Notes

- Frontend/backend: validation in the `# Check input` block; backend untouched.
- No `print()` (uses `ut.print_out`); bare `ValueError` guards unchanged.

Closes #76