### PR TITLE
doc(api): rename 'Protein Design' API section to 'Protein Engineering' + add SeqOpt

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -93,10 +93,10 @@ Explainable AI
     TreeModel
     ShapModel
 
-.. _protein_design_api:
+.. _protein_engineering_api:
 
-Protein Design
-==============
+Protein Engineering
+===================
 .. autosummary::
     :toctree: generated/
     :template: autosummary/class_template.rst
@@ -105,6 +105,8 @@ Protein Design
     AAMutPlot
     SeqMut
     SeqMutPlot
+    SeqOpt
+    SeqOptPlot
 
 .. _utility_functions_api:
 


### PR DESCRIPTION
Renames the API-reference section (`docs/source/api.rst`) heading + label from **Protein Design** to **Protein Engineering**, and adds `SeqOpt` / `SeqOptPlot` to its autosummary (they were public in `__all__` since SeqOpt became core but absent from the API reference). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)