### PR TITLE
docs: fix delta_cpp RST substitution error + retitle getting-started to 'The two APIs'

### DIFF
--- a/aaanalysis/_schemas.py
+++ b/aaanalysis/_schemas.py
@@ -304,9 +304,9 @@ DICT_DF_SCHEMAS = {
             COL_REGION: _field("str", "Sequence part the position falls in.",
                                required=True, allowed_values=list(COLS_SEQ_PARTS),
                                example="tmd"),
-            COL_DELTA_CPP: _field("float", "Sum|dX| feature-space magnitude of the "
-                                  "mutation.", required=True, range=[0, None],
-                                  example=2.4),
+            COL_DELTA_CPP: _field("float", "Summed absolute (L1) feature-space "
+                                  "magnitude of the mutation.", required=True,
+                                  range=[0, None], example=2.4),
             COL_SHIFT_SCORE: _field("float", "Signed shift toward the test-class "
                                     "profile.", required=True, example=-0.8),
             COL_DELTA_PRED: _field("float", "Change of the model prediction score "
@@ -335,9 +335,9 @@ DICT_DF_SCHEMAS = {
                               required=True, range=[1, None], example=2),
             COL_SEQ_MUT: _field("str", "Full sequence with all the variant's mutations "
                                 "applied.", required=True, example="...K...P..."),
-            COL_DELTA_CPP: _field("float", "Sum|dX| feature-space magnitude of the "
-                                  "combined variant.", required=True, range=[0, None],
-                                  example=4.1),
+            COL_DELTA_CPP: _field("float", "Summed absolute (L1) feature-space "
+                                  "magnitude of the combined variant.", required=True,
+                                  range=[0, None], example=4.1),
             COL_SHIFT_SCORE: _field("float", "Signed shift toward the test-class "
                                     "profile for the combined variant.", required=True,
                                     example=1.3),
@@ -360,7 +360,8 @@ DICT_DF_SCHEMAS = {
                                      range=[0, None], example=3),
             COL_FRAC_DISRUPTIVE: _field("float", "n_disruptive / n_mut.", required=True,
                                         range=[0, 1], example=0.15),
-            COL_MEAN_DELTA_CPP: _field("float", "Mean |delta_cpp| over scanned "
+            COL_MEAN_DELTA_CPP: _field("float", "Mean delta_cpp (summed absolute "
+                                       "feature-space magnitude) over scanned "
                                        "mutations.", required=True, range=[0, None],
                                        example=1.1),
         },
@@ -390,9 +391,10 @@ DICT_DF_SCHEMAS = {
             COL_DELTA_PRED: _field("float", "Objective: change of the model prediction "
                                    "score (percentage points). Present when an objective "
                                    "uses it.", required=False, example=18.7),
-            COL_DELTA_CPP: _field("float", "Objective: Sum|dX| feature-space magnitude. "
-                                  "Present when an objective uses it.", required=False,
-                                  range=[0, None], example=4.1),
+            COL_DELTA_CPP: _field("float", "Objective: summed absolute (L1) "
+                                  "feature-space magnitude. Present when an objective "
+                                  "uses it.", required=False, range=[0, None],
+                                  example=4.1),
             COL_SHIFT_SCORE: _field("float", "Objective: signed shift toward the "
                                     "test-class profile. Present when an objective uses "
                                     "it.", required=False, example=1.3),

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -49,14 +49,15 @@ walk through this loop step by step.
    generated/tutorial1_slow_start
    generated/plotting_prelude
 
-Two interfaces: ``aa`` and ``aap``
-----------------------------------
-AAanalysis offers the same analysis two ways. The :ref:`API reference <api>` covers the
-explicit **building blocks** (``import aaanalysis as aa``): the individual objects and
-functions you compose for full control. The :ref:`pipeline reference <api_pipe>` covers
-the **golden pipelines** (``import aaanalysis.pipe as aap``): stateless one-call wrappers
-that chain those building blocks into complete workflows. Reach for ``aa`` when you want
-control over each step, and ``aap`` when you want a sensible default workflow in one call.
+The two APIs
+------------
+AAanalysis offers the same analysis two ways, both documented in the Reference:
+
+- **Building blocks** (``import aaanalysis as aa``) — the individual objects and
+  functions you compose, for full control over each step. See :ref:`API <api>`.
+- **Golden pipelines** (``import aaanalysis.pipe as aap``) — stateless one-call
+  wrappers that chain those building blocks into a sensible default workflow.
+  See :ref:`API (Pipe) <api_pipe>`.
 
 .. code-block:: python
 

--- a/docs/source/index/usage_principles/df_schemas.rst
+++ b/docs/source/index/usage_principles/df_schemas.rst
@@ -617,7 +617,7 @@ SeqMut.scan per-mutation scan (one row per scanned single mutation).
      - yes
      - no
      - no
-     - Sum|dX| feature-space magnitude of the mutation.
+     - Summed absolute (L1) feature-space magnitude of the mutation.
      - range: [0, inf]; e.g. 2.4
    * - ``shift_score``
      - float
@@ -697,7 +697,7 @@ SeqMut.combine combined-variant table (one row per multi-mutation variant; all o
      - yes
      - no
      - no
-     - Sum|dX| feature-space magnitude of the combined variant.
+     - Summed absolute (L1) feature-space magnitude of the combined variant.
      - range: [0, inf]; e.g. 4.1
    * - ``shift_score``
      - float
@@ -770,7 +770,7 @@ SeqMut.eval per-protein/region summary (one row per region).
      - yes
      - no
      - no
-     - Mean |delta_cpp| over scanned mutations.
+     - Mean delta_cpp (summed absolute feature-space magnitude) over scanned mutations.
      - range: [0, inf]; e.g. 1.1
 
 ``df_pareto``
@@ -843,7 +843,7 @@ SeqOpt.run Pareto front (one row per non-dominated variant of the single wild-ty
      - no
      - no
      - no
-     - Objective: Sum|dX| feature-space magnitude. Present when an objective uses it.
+     - Objective: summed absolute (L1) feature-space magnitude. Present when an objective uses it.
      - range: [0, inf]; e.g. 4.1
    * - ``shift_score``
      - float


### PR DESCRIPTION
## Summary

Integrates two stranded-but-valuable docs commits that were left on detached-HEAD worktrees (no branch, no PR) by a closed session, recovered and rebased onto current `master`:

1. **Fix a live RST render bug** (`docs(schemas)`): the `df_seqmut` / `df_pareto` / scan schema descriptions used pipe-math notation (`Sum|dX|`, `Mean |delta_cpp|`). The space before `|delta_cpp|` makes docutils read it as an **undefined substitution reference**, erroring the rendered **Data Dictionary** page. Reworded to plain-text "summed/mean absolute (L1) feature-space magnitude" in `aaanalysis/_schemas.py` and regenerated `df_schemas.rst`. The `test_df_schemas` drift test stays green (14 passed).
2. **Getting-started polish** (`docs(getting-started)`): retitle the two-interface intro to **"The two APIs"** with a clean two-bullet (`aa` building blocks / `aap` golden pipelines) format.

Docs-only. The duplicate copy of (2) and an already-merged "data dictionary → Reference" commit were discarded; a superseded `#76` reimplementation was dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
