### PR TITLE
docs(feature_engineering_pro): mark CPPStructurePlot as experimental

### DIFF
--- a/aaanalysis/feature_engineering_pro/_cpp_structure_plot.py
+++ b/aaanalysis/feature_engineering_pro/_cpp_structure_plot.py
@@ -101,6 +101,12 @@ class CPPStructurePlot:
     Plotting class for painting :class:`CPP` feature impact onto a 3D protein structure
     (**[pro]**, requires ``aaanalysis[pro]``) [Breimann25]_.
 
+    .. warning::
+
+        **Experimental.** This class and its methods are under active development; their API
+        (signatures, defaults, return objects) may change between minor releases without the
+        usual deprecation cycle. Pin a version if you depend on the current behaviour.
+
     Each feature's signed impact is mapped to the residue positions it spans and painted
     residue-by-residue onto the protein cartoon, rendered with the interactive
     `py3Dmol <https://pypi.org/project/py3Dmol/>`_ viewer. A red-white-blue ramp shows where


### PR DESCRIPTION
## Summary

Adds an `.. warning:: Experimental` admonition to the `CPPStructurePlot` class docstring. The
class and its methods (`map_structure` / `plot_combined` / `plot_linked` / `interactive` /
`explore`) are under active development; their API may change between minor releases without the
usual deprecation cycle, so this pro surface is **not** yet covered by the package's strict semver
guarantee.

Docstring-only change (no code/behaviour change). Relates to the still-open #288 (Stages C/D
pending) — the issue stays open.