### PR TITLE
docs(getting-started): green box + body notebook links + Decision Map last

### DIFF
--- a/docs/source/create_notebooks_docs.py
+++ b/docs/source/create_notebooks_docs.py
@@ -45,6 +45,11 @@ FOLDER_IMAGE = FOLDER_GENERATED_RST + "images" + SEP
 # require GPU/external services and cannot be executed or rendered meaningfully).
 LIST_EXCLUDE = []
 
+# Getting-Started notebooks: linked from getting_started.rst by ``:doc:`` in the body,
+# but marked ``:orphan:`` so they do NOT appear as sub-chapters in the RTD sidebar.
+ORPHAN_TUTORIALS = {"tutorial0_minimal", "tutorial1_quick_start",
+                    "tutorial1_slow_start", "plotting_prelude"}
+
 
 # Helper functions
 class CustomPreprocessor(Preprocessor):
@@ -95,6 +100,9 @@ def export_tutorial_notebooks_to_rst():
             custom_preprocessor = CustomPreprocessor(notebook_name=notebook_name)
             rst_exporter = nbconvert.RSTExporter(preprocessors=[custom_preprocessor])
             output, resources = rst_exporter.from_notebook_node(notebook)
+            # Keep Getting-Started notebooks out of the sidebar nav (linked via :doc: instead)
+            if notebook_name in ORPHAN_TUTORIALS:
+                output = ":orphan:\n\n" + output
             # Write the RST and any accompanying files (like images)
             writer = FilesWriter(build_directory=FOLDER_GENERATED_RST)
             writer.write(output, resources, notebook_name=filename.replace('.ipynb', ''))

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -20,30 +20,21 @@ introduction, our **Quick start** and **Slow start** tutorials share the same
 examples, the latter adding the conceptual background, and the
 **Plotting Prelude** tutorial helps you create publication-ready plots.
 
-Not sure which tool fits your question? The **Decision Map** turns
-*"what do I want to do?"* into a concrete path through the AAanalysis API —
-**explore** sequences and groups, **build** features to predict and explain, or
-**optimize** for protein design. It is the fastest way to find the right starting
-point; click the map to open it full-size.
+.. admonition:: Not sure where to start? Follow the Decision Map
+   :class: tip
 
-.. raw:: html
+   Skim the :ref:`Decision Map <gs_decision_map>` at the bottom of this page — it maps
+   your goal (*explore*, *predict*, or *optimize*) to the exact AAanalysis class or
+   function — then run the notebooks below for your first result.
 
-   <a href="_static/decision_map.html" target="_blank" rel="noopener" title="Open the Decision Map">
-     <img src="_static/decision_map.png" alt="AAanalysis Decision Map"
-          style="width:100%; display:block; margin:0 auto; border:1px solid #e3e7ec; border-radius:4px;">
-   </a>
+The fastest way in is the short notebooks below: start with **A minimal CPP analysis**,
+compare the two interfaces in **Quick start** and **Slow start**, then make
+publication-ready figures with **Plotting Prelude**.
 
-These short notebooks walk through that first loop step by step — start with
-**A minimal CPP analysis**, compare the two interfaces in **Quick start** and
-**Slow start**, then make publication-ready figures with **Plotting Prelude**:
-
-.. toctree::
-   :maxdepth: 1
-
-   generated/tutorial0_minimal
-   generated/tutorial1_quick_start
-   generated/tutorial1_slow_start
-   generated/plotting_prelude
+- :doc:`A minimal CPP analysis </generated/tutorial0_minimal>`
+- :doc:`Quick start with AAanalysis </generated/tutorial1_quick_start>`
+- :doc:`Slow start with AAanalysis </generated/tutorial1_slow_start>`
+- :doc:`Plotting Prelude </generated/plotting_prelude>`
 
 Quick start
 -----------
@@ -80,3 +71,19 @@ AAanalysis offers the same analysis two ways, both documented in the Reference:
 
     import aaanalysis as aa            # explicit building blocks
     import aaanalysis.pipe as aap      # golden pipelines
+
+.. _gs_decision_map:
+
+Decision Map
+------------
+The Decision Map lays out the whole framework as a single flowchart: from your goal
+(*explore*, *predict*, or *optimize*) down to the exact AAanalysis class or function to
+call, including the CPP feature-engineering panel. Use it to find the right tool for
+your question; click it to open the full-size version.
+
+.. raw:: html
+
+   <a href="_static/decision_map.html" target="_blank" rel="noopener" title="Open the Decision Map">
+     <img src="_static/decision_map.png" alt="AAanalysis Decision Map"
+          style="width:70%; display:block; margin:0 auto; border:1px solid #e3e7ec; border-radius:4px;">
+   </a>


### PR DESCRIPTION
Restructures the Getting Started page per review.

**New order:** intro → green "Not sure where to start?" box → short intro → the notebook **body links** → Quick start → The two APIs → **Decision Map (last)**.

- **Green box restored** (admonition), preceded by the normal-text page intro, and it points down to the Decision Map section.
- **Notebook links are now plain `:doc:` body links** under a short intro paragraph, and the four Getting-Started notebooks are exported with `:orphan:` (small `create_notebooks_docs.py` change) so they **no longer appear as sub-chapters in the RTD sidebar** — only the real sections (Quick start, The two APIs, Decision Map) do.
- **Decision Map moved to its own section at the end**, with an intro paragraph and a **smaller (70%)** figure.
- Applies the house rule: every block (box, link list, figure) is preceded by a short normal-text intro.

Best verified on the RTD preview — check that the Getting Started sidebar no longer nests the four notebooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)