### PR TITLE
docs(introduction): complete Overview-of-Documentation links + quick-reference list

### DIFF
--- a/docs/source/index/introduction.rst
+++ b/docs/source/index/introduction.rst
@@ -54,14 +54,25 @@ parameters and outputs, the :ref:`Protocols <protocols>` walk through complete, 
 analyses for biological questions, and the :ref:`Use Cases <use_cases>` showcase published
 studies end to end from bundled data.
 
-**Reference**: Look up the exact signatures in the :ref:`API <api>` documentation, browse the
-overview :ref:`Data Tables <tables>` (including the **AAontology** scale classification and benchmark
-protein datasets), check the :ref:`Glossary <glossary>` of key terms, and discover the scientific
-foundation of AAanalysis in the :ref:`Scientific References <references>` section.
+**Reference**: Look up the exact signatures in the :ref:`API <api>` documentation, or reach for the
+one-call golden pipelines in :ref:`API (Pipelines) <api_pipe>`. Browse the overview
+:ref:`Data Tables <tables>` (including the **AAontology** scale classification and benchmark protein
+datasets) and the :ref:`DataFrame schemas <df_schemas>` that define every ``df_*`` contract, check the
+:ref:`Glossary <glossary>` of key terms, and discover the scientific foundation of AAanalysis in the
+:ref:`Scientific References <references>` section.
 
 **Project**: Development conventions and how to contribute live in the
-:ref:`Contributing <contributing>` guide, and the :ref:`Release Notes <release_notes>` track changes
-across versions.
+:ref:`Contributing <contributing>` guide, the :ref:`Docstring Guide <docstring_guide>` documents the
+docstring style, and the :ref:`Release Notes <release_notes>` track changes across versions.
 
-To see how AAanalysis fits among related bioinformatics, machine-learning, and explainability
-tools, explore the `AAanalysis Ecosystem <../_static/aaanalysis_ecosystem.html>`_.
+Finally, four at-a-glance reference documents summarise the whole framework — keep them open while
+you work:
+
+- `Cheat Sheet <../_static/cheat_sheet.html>`_ — the canonical workflow, the main classes by
+  capability, and the *Part × Split × Scale* feature ontology on three pages.
+- `Decision Map <../_static/decision_map.html>`_ — a flowchart from your goal (*explore*, *predict*,
+  or *optimize*) to the exact AAanalysis class or function to call.
+- `Ecosystem Map <../_static/aaanalysis_ecosystem.html>`_ — where AAanalysis fits among related
+  bioinformatics, machine-learning, and explainability tools.
+- `Data Flow Map <../_static/dataflow_map.html>`_ — how data flows from sequences and scales through
+  CPP to features, models, and explanations.


### PR DESCRIPTION
Strengthens the **Overview of Documentation** section in `index/introduction.rst`.

- **Every chapter is now linked.** Reference gains the previously-missing :ref:`API (Pipelines) <api_pipe>` and :ref:`DataFrame schemas <df_schemas>`; Project gains the :ref:`Docstring Guide <docstring_guide>`.
- **New quick-reference list** at the end: four bullets linking the at-a-glance documents — **Cheat Sheet**, **Decision Map**, **Ecosystem Map**, **Data Flow Map** — each with a one-line description, preceded by a short intro paragraph (per the house rule). The former standalone Ecosystem sentence is folded into the list.

Docs-only; verify on the RTD preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)