### PR TITLE
docs: main-page Ecosystem figure -> bare map (with download menu)

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -120,12 +120,12 @@ wrappers or native implementations — for example SHAP via ``ShapModel``, or ma
 such as random forests via ``TreeModel`` — so the resulting features, explanations, and design
 objectives feed straight into the standard ML / XAI / optimization tools.
 
-Click the diagram to open the full map, or read the
-`ecosystem positioning article <_static/aaanalysis_ecosystem.html>`_ — a self-contained
+Click the diagram to open the full map (with PNG / PDF / HTML download options), or read
+the `ecosystem positioning article <_static/aaanalysis_ecosystem.html>`_: a self-contained
 page with the map, its positioning brief, and further background.
 
 .. figure:: _artwork/diagrams/aaanalysis_ecosystem.svg
-   :target: _static/aaanalysis_ecosystem.html
+   :target: _static/ecosystem_map.html
    :alt: The AAanalysis ecosystem — where AAanalysis fits in the protein-ML stack
    :width: 100%
    :align: center


### PR DESCRIPTION
On the landing page, clicking the **Ecosystem** diagram now opens the **bare ecosystem map** (`_static/ecosystem_map.html`) — which has the upper-right **PNG / PDF / HTML download menu** — instead of the full positioning article. The article remains available as a secondary text link in the same sentence.

Also: colon instead of em dash in that sentence (house style).

(The four quick-reference bullet colons are already on master from #304; the live RTD just hadn't rebuilt yet.)

Docs-only; verify on the RTD preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)