### PR TITLE
docs(usage-principles): 'Provided by' boxes + consistent depth + prediction-task restructure

### DIFF
--- a/docs/source/index/usage_principles/aaclust.rst
+++ b/docs/source/index/usage_principles/aaclust.rst
@@ -7,6 +7,14 @@ AAclust: Selecting Redundancy-Reduced Scale Sets
 of amino acid scales, introduced in [Breimann24a]_. Using Pearson correlation, AAclust optimizes the number of clusters
 (*k*) and selects one representative scale per cluster, as illustrated in the figure below:
 
+.. admonition:: Provided by
+   :class: note
+
+   In AAanalysis this is the :class:`~aaanalysis.AAclust` class. See the
+   :ref:`API reference <api>` for signatures, the
+   :doc:`AAclust tutorial </generated/tutorial3a_aaclust>` for hands-on use, and the
+   :ref:`Evaluating Clustering <eval_aaclust>` chapter for assessment.
+
 
 .. figure:: /_artwork/schemes/scheme_AAclust1.png
    :align: center

--- a/docs/source/index/usage_principles/aaontology.rst
+++ b/docs/source/index/usage_principles/aaontology.rst
@@ -3,16 +3,35 @@
 AAontology: Classification of Amino Acid Scales
 ===============================================
 
-AAontology is a two-level classification of amino acid scale, introduced in [Breimann24b]_.
+Amino acid scales turn each residue into a number (hydrophobicity, charge, size, and so
+on), but hundreds of scales exist and most of them measure overlapping properties.
+AAontology is a two-level classification that organises these scales by *what they
+actually capture*, introduced in [Breimann24b]_. It is what lets a CPP feature carry a
+readable physicochemical meaning rather than an opaque scale identifier: every scale
+belongs to a subcategory (for example *Polarity*) and a top-level category (for example
+*ASA/Volume*), so a feature signature can be summarised by category and interpreted at a
+glance.
 
-It was created by automatic scale classification and manual refinement:
+.. admonition:: Provided by
+   :class: note
+
+   In AAanalysis the ontology ships with the data. :func:`~aaanalysis.load_scales`
+   returns the scales (``df_scales``) together with their two-level classification
+   (``df_cat``). Browse the full category and subcategory list in
+   :ref:`Data Tables <tables>`, and see the :ref:`API reference <api>` for the loader
+   options.
+
+AAontology was created by automatic scale classification followed by manual refinement:
 
 .. figure:: /_artwork/schemes/scheme_AAontology1.png
 
    Workflow of scale classification from [Breimann24b]_.
 
-
-AAontology comprises 586 amino acid scales, organized into 67 scale subcategories, and 8 scale categories:
+It comprises 586 amino acid scales, organised into 67 subcategories and 8 categories.
+Grouping scales this way keeps the feature space interpretable: instead of ranking 586
+raw scales, CPP can pick representatives per category (see :ref:`AAclust
+<usage_principles_aaclust>`) and report a signature in terms of a handful of
+physicochemical themes.
 
 .. figure:: /_artwork/schemes/scheme_AAontology2.png
 

--- a/docs/source/index/usage_principles/feature_identification.rst
+++ b/docs/source/index/usage_principles/feature_identification.rst
@@ -1,3 +1,5 @@
+.. _usage_principles_feature_identification:
+
 CPP: Identifying Physicochemical Signatures
 ===========================================
 
@@ -5,6 +7,14 @@ The central algorithm of the AAanalysis framework is Comparative Physicochemical
 feature engineering algorithm for interpretable protein prediction [Breimann25]_. CPP enables the identification
 of physicochemical signatures underlying biological recognition processes. It thereby extends rational protein
 biology beyond mere sequence motifs.
+
+.. admonition:: Provided by
+   :class: note
+
+   In AAanalysis this is the :class:`~aaanalysis.CPP` class, with
+   :class:`~aaanalysis.SequenceFeature` for building parts and splits and
+   :class:`~aaanalysis.CPPPlot` for the figures. See the :ref:`API reference <api>`
+   and the :ref:`tutorials <tutorials>`.
 
 The core idea of CPP is its feature concept:
 

--- a/docs/source/index/usage_principles/prediction_tasks.rst
+++ b/docs/source/index/usage_principles/prediction_tasks.rst
@@ -20,20 +20,29 @@ and the classes that carry it out. Use it as the front door to the
 :ref:`tutorials <tutorials>` (which teach one function at a time) and the
 :ref:`protocols <protocols>` (which walk an end-to-end workflow).
 
+.. admonition:: Provided by
+   :class: note
+
+   The tasks on this page are carried out by :func:`~aaanalysis.load_dataset`
+   (benchmark data), :class:`~aaanalysis.CPP` (features), the samplers and label
+   helpers (:class:`~aaanalysis.AAWindowSampler`, :class:`~aaanalysis.dPULearn`), and
+   the models (:class:`~aaanalysis.TreeModel`, :class:`~aaanalysis.ShapModel`). See
+   the :ref:`API reference <api>` for signatures.
+
 The two axes that actually define a task
 ----------------------------------------
 
-It is tempting to organize tasks by *biological scale* alone — residue, domain,
-protein. That label is useful shorthand, and AAanalysis encodes it directly in the
+It is tempting to organize tasks by *biological scale* alone (residue, domain,
+protein). That label is useful shorthand, and AAanalysis encodes it directly in the
 dataset name prefixes (``AA_*``, ``DOM_*``, ``SEQ_*``; see ``load_dataset``).
 But the scale is only a **proxy**. What genuinely
 determines how you set CPP up are two axes:
 
-- **Unit of comparison** — the part CPP profiles. A fixed-length
+- **Unit of comparison**: the part CPP profiles. A fixed-length
   :term:`window` (residue level), a :term:`part`-set such as
   ``jmd_n`` / ``tmd`` / ``jmd_c`` (domain level), or the whole chain
   (protein level).
-- **Reference construction** — how the contrasting set is built. Labeled
+- **Reference construction**: how the contrasting set is built. Labeled
   A-vs-B groups, non-site / non-cleaved windows, an unlabeled pool, or a
   composition-matched shuffled background. CPP always reads out a
   :term:`test group` against a :term:`reference group`, so a feature's effect
@@ -42,19 +51,36 @@ determines how you set CPP up are two axes:
 The :term:`prediction level` is the convenient label; these two axes are the
 substance. The table below leads with them.
 
+Compositional or positional
+---------------------------
+
+One choice cuts across every task before you even pick a row: whether CPP reads each
+part *compositionally* or *positionally*. It is not a separate parameter but emerges
+from ``split_kws`` (the CPP argument that controls how each part is read). A single
+whole-part average (``n_split_max=1`` with no patterns) is **compositional**
+(composition-like, position-agnostic); **sub-segments** (``n_split_max>1``),
+``Pattern``, or ``PeriodicPattern`` are **positional** (resolved to specific
+positions). You can always try either; it is a free choice for any task. In practice
+the strategy tracks the level: compositional suits the protein level, positional suits
+the residue level, and the domain level uses both. The deeper recipes live in the
+dedicated CPP-strategies guide.
+
 The prediction-task table
 --------------------------
 
-.. list-table:: AAanalysis prediction tasks — by unit of comparison and reference construction
+The table sorts the common protein-prediction tasks by the two axes above and, for
+each, gives the dataset prefix and the classes that typically carry it out. Find the
+row closest to your biological question:
+
+.. list-table:: AAanalysis prediction tasks: by unit of comparison and reference construction
    :header-rows: 1
-   :widths: 16 20 24 10 14 16
+   :widths: 18 22 28 12 20
    :class: longtable
 
    * - Task
      - Unit of comparison
      - Reference construction
      - Dataset prefix
-     - CPP strategy
      - Typical classes
    * - **Residue · single-residue**
 
@@ -62,7 +88,6 @@ The prediction-task table
      - One :term:`window` centered *on* a residue (odd ``aa_window_size``)
      - Site windows vs non-site windows (or an unlabeled residue pool)
      - ``AA_``
-     - Positional
      - ``AAWindowSampler``, ``CPP``, ``TreeModel``
    * - **Residue · between-residues**
 
@@ -70,7 +95,6 @@ The prediction-task table
      - One :term:`window` spanning a bond ``P1│P1′`` (even ``aa_window_size``)
      - Cleaved windows vs non-cleaved windows
      - ``AA_``
-     - Positional
      - ``AAWindowSampler``, ``CPP``, ``TreeModel``
    * - **Domain**
 
@@ -79,7 +103,6 @@ The prediction-task table
        (``jmd_n`` / ``tmd`` / ``jmd_c``)
      - Labeled A-vs-B groups (e.g. substrate vs non-substrate)
      - ``DOM_``
-     - Compositional **and** positional
      - ``SequenceFeature``, ``CPP``, ``TreeModel``
    * - **Protein**
 
@@ -87,16 +110,14 @@ The prediction-task table
      - The whole chain as a single part
      - Labeled A-vs-B groups of proteins
      - ``SEQ_``
-     - Compositional
      - ``CPP``, ``TreeModel``
    * - **Determinant discovery**
 
        (cross-cutting; no prediction target)
-     - Any unit — window, part-set, or chain
+     - Any unit (window, part-set, or chain)
      - Two groups contrasted to surface *what distinguishes them*
        (interpreted via :term:`AAontology`)
      - ``AA_`` / ``DOM_`` / ``SEQ_``
-     - Compositional or positional
      - ``CPP``, ``CPPPlot``
    * - **Design / engineering**
 
@@ -104,15 +125,13 @@ The prediction-task table
      - A sequence profiled against a target CPP profile
      - A target / reference profile the sequence is moved toward (``ΔCPP``)
      - ``AA_`` / ``DOM_`` / ``SEQ_``
-     - Compositional or positional
      - ``AAMut``, ``SeqMut``
    * - **Relational / interaction**
 
-       (scope boundary — not a level)
+       (scope boundary, not a level)
      - Interface **segments** only (a part-set on each partner)
      - In scope for interface segments only; pairwise contacts hand off
      - Interface segments via ``DOM_`` / ``AA_``
-     - Positional (segments)
      - Out of scope: structure / PLM tooling
 
 Reading the table
@@ -128,7 +147,7 @@ window, a bond between two residues). They share the windowing machinery, so the
 are sub-modes of one level rather than two levels.
 
 **The two cross-cutting rows.** :term:`Determinant discovery` and
-:term:`design / engineering` are not levels — they apply *at any level* and run
+:term:`design / engineering` are not levels; they apply *at any level* and run
 in opposite directions. Determinant discovery asks *what physicochemically
 distinguishes two groups* (CPP's purest, most interpretable use, with no
 prediction target). Design / engineering inverts that: it measures how a mutation
@@ -136,22 +155,10 @@ shifts a sequence's CPP profile (:term:`ΔCPP`) and steers a sequence toward a
 target. Both showcase the interpretability edge, so they are first-class rows.
 
 **The boundary row.** :term:`Relational / interaction <relational / interaction>`
-tasks — PPI interfaces and residue–residue contacts — are listed to be honest
+tasks (PPI interfaces and residue–residue contacts) are listed to be honest
 about the taxonomy's edge. AAanalysis profiles interface **segments**; long-range
 pairwise contacts and PPI-pair prediction are **out of scope** and hand off to
 structure / PLM tooling. It is a documented boundary, **not** a fourth level.
-
-CPP strategy in one line
-------------------------
-
-The **CPP strategy** column is :term:`compositional vs positional`, and it is not
-a parameter — it *emerges* from ``split_kws`` (the CPP argument that controls how
-each part is read). A single whole-part average
-(``Segment(1,1)``) is **compositional** (composition-like, position-agnostic);
-sub-segments, ``Pattern``, or ``PeriodicPattern`` are **positional**. The strategy
-tracks the level: compositional suits the protein level, positional suits the
-residue level, and the domain level uses both. The deeper recipes live in the
-dedicated CPP-strategies guide.
 
 Where to go next
 ----------------

--- a/docs/source/index/usage_principles/pu_learning.rst
+++ b/docs/source/index/usage_principles/pu_learning.rst
@@ -10,6 +10,13 @@ protein sequence prediction, where even minor alterations can lead to significan
 A practical solution is to harness the abundance of unlabeled data to identify negative samples, a strategy
 that becomes essential when obtaining a balanced dataset is challenging.
 
+.. admonition:: Provided by
+   :class: note
+
+   In AAanalysis this is the :class:`~aaanalysis.dPULearn` class. See the
+   :ref:`API reference <api>` and the :ref:`Evaluating PU Learning <eval_pu_learning>`
+   chapter for how the identified negatives are assessed.
+
 .. toctree::
    :hidden:
 

--- a/docs/source/index/usage_principles/xai.rst
+++ b/docs/source/index/usage_principles/xai.rst
@@ -1,24 +1,46 @@
+.. _usage_principles_xai:
+
 Explainable AI with Single-Residue Resolution
 =============================================
 
-In life sciences, AI and machine learning have significantly advanced protein analysis, yet their full potential
-is hindered by the black-box nature of traditional models, which obscures the understanding of how predictions are made.
-This gap is bridged by explainable AI (eXAI), which not only forecasts outcomes but also demystifies the underlying
-reasons, offering detailed insights into protein functions at the amino acid level.
+In the life sciences, AI and machine learning have significantly advanced protein
+analysis, yet their full potential is held back by the black-box nature of traditional
+models, which obscures how a prediction is made. Explainable AI (eXAI) closes this gap:
+it not only forecasts an outcome but also surfaces the reasons for it, giving detailed
+insight into protein function at the amino acid level. In AAanalysis this matters twice
+over, because CPP features are already interpretable by construction, so an explanation
+resolves to a concrete *Part × Split × Scale* signal rather than an anonymous input.
 
+.. admonition:: Provided by
+   :class: note
+
+   In AAanalysis this is :class:`~aaanalysis.TreeModel` (predictions and *global* feature
+   importance), :class:`~aaanalysis.ShapModel` (SHAP-based *local*, per-sequence feature
+   impact), and :class:`~aaanalysis.CPPPlot` (the visualisations). See the
+   :ref:`API reference <api>` for signatures and the :ref:`tutorials <tutorials>` for
+   hands-on use.
 
 What is explainable AI?
 -----------------------
-Explainable AI (eXAI) transforms opaque AI models into transparent systems, enabling human experts to grasp the rationale
-behind specific predictions. This is particularly pivotal in life sciences, where comprehending each amino acid's role
-can revolutionize drug discovery and disease treatment.
+Explainable AI (eXAI) transforms opaque AI models into transparent systems, letting human
+experts grasp the rationale behind specific predictions. This is particularly pivotal in
+the life sciences, where understanding each amino acid's role can inform drug discovery
+and disease treatment. Explanations come at two levels: *global* importance ranks which
+features matter across a whole dataset (``TreeModel``), while *local* attribution explains
+one specific sequence, residue by residue (``ShapModel``).
 
 Combining CPP with SHAP
 -----------------------
-To explain machine learning-based prediction results for individual proteins with single-residue resolution,
-we combined CPP with the explainable AI framework `SHAP <https://shap.readthedocs.io/en/latest/index.html>`_.
-AAanalysis offers four different visualizations:
+To explain machine-learning predictions for individual proteins at single-residue
+resolution, AAanalysis combines CPP with the explainable-AI framework
+`SHAP <https://shap.readthedocs.io/en/latest/index.html>`_. Because every CPP feature maps
+back to a specific sequence part and physicochemical scale, a SHAP value can be projected
+onto the exact residues it describes. AAanalysis exposes this through
+:class:`~aaanalysis.CPPPlot`, which offers four complementary views: a group-level feature
+map, a ranked feature profile, and per-sequence CPP-SHAP plots that colour the sequence by
+each residue's contribution.
 
 .. figure:: /_artwork/schemes/scheme_CPP_eAI.png
 
-   Overview of explainable AI with single-residue resolution by combining CPP with the SHAP, from [Breimann25]_.
+   Overview of explainable AI with single-residue resolution by combining CPP with SHAP,
+   from [Breimann25]_.


### PR DESCRIPTION
Makes the six Usage-Principles concept pages consistent and pins each to its API.

**Provided-by boxes.** Every section now carries a consistent `Provided by` note box naming the class/function that implements it:
- AAontology -> `load_scales`
- AAclust -> `AAclust`
- CPP -> `CPP` (+ `SequenceFeature`, `CPPPlot`)
- dPULearn -> `dPULearn`
- XAI -> `TreeModel` + `ShapModel` + `CPPPlot`
- Prediction tasks -> the workflow classes (`load_dataset`, `CPP`, `AAWindowSampler`, `dPULearn`, `TreeModel`, `ShapModel`)

**Consistent depth.** The two thin pages (AAontology, XAI) were fleshed out so the set reads evenly (AAontology now explains the two-level scheme and why it makes features interpretable; XAI explains global vs local and the four visualisations).

**Prediction-task page restructure** (per review):
- introduce **compositional vs positional before** the table, with the definition **sub-segments = `n_split_max>1`** (matching the CPP docstring);
- give the table a short lead-in (intro-before-block house rule);
- **drop the "CPP strategy" column** — it is a free choice for every task, now stated once in the intro rather than per row.

**House style.** Em dashes -> colon / comma / parentheses in the rendered text.

Verified with a full `make html`: builds clean, zero warnings on these files, and every `:class:`/`:func:`/`:ref:` in the boxes resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)