### PR TITLE
docs(prediction-tasks): protein row lists fixed-size terminal parts

### DIFF
--- a/docs/source/index/usage_principles/prediction_tasks.rst
+++ b/docs/source/index/usage_principles/prediction_tasks.rst
@@ -107,7 +107,8 @@ row closest to your biological question:
    * - **Protein**
 
        (the whole chain)
-     - The whole chain as a single part
+     - The whole chain as a single part, or fixed-size N- and C-terminal parts via
+       ``jmd_n`` / ``jmd_c`` (multi-part support arrives after v2.0)
      - Labeled A-vs-B groups of proteins
      - ``SEQ_``
      - ``CPP``, ``TreeModel``


### PR DESCRIPTION
The **Protein** row's *unit of comparison* now notes that, besides the whole chain as a single part, you can profile **fixed-size N- and C-terminal parts** via ``jmd_n`` / ``jmd_c``; multi-part support for the protein level arrives after v2.0.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)