### PR TITLE
docs: make class/method/function names clickable API links across the docs

### DIFF
--- a/docs/source/api_pipe.rst
+++ b/docs/source/api_pipe.rst
@@ -15,7 +15,7 @@ AAanalysis exposes the same analysis through two interfaces:
 
 The :ref:`building blocks <api>` (``aa``) are the explicit objects and functions you
 compose for full control over every step. The **golden pipelines** (``aap``) chain the
-standard ``load`` to ``CPP`` to ``model`` to ``explain`` to ``plot`` workflow into a
+standard ``load`` to :class:`~aaanalysis.CPP` to ``model`` to ``explain`` to ``plot`` workflow into a
 single call, much as ``pyplot`` sits over Matplotlib's ``Axes`` and ``Figure``. They are
 stateless wrappers whose defaults match the explicit path, and they live in their own
 module under a separate alias (``import aaanalysis.pipe as aap``). Reach for ``aa`` when

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -116,8 +116,8 @@ learning, explainable AI, and protein-design stack. It *consumes* upstream repre
 embeddings, structures) and even competitor descriptor sets, and runs them through its interpretable
 core (*Part × Split × Scale* · AAontology · CPP). Downstream machine-learning and explainable-AI
 methods then either *consume* these features directly or are *integrated* into AAanalysis through
-wrappers or native implementations — for example SHAP via ``ShapModel``, or machine-learning models
-such as random forests via ``TreeModel`` — so the resulting features, explanations, and design
+wrappers or native implementations — for example SHAP via :class:`~aaanalysis.ShapModel`, or machine-learning models
+such as random forests via :class:`~aaanalysis.TreeModel` — so the resulting features, explanations, and design
 objectives feed straight into the standard ML / XAI / optimization tools.
 
 Click the diagram to open the full map (with PNG / PDF / HTML download options), or read

--- a/docs/source/index/docstring_guide.rst
+++ b/docs/source/index/docstring_guide.rst
@@ -71,7 +71,7 @@ Invariants:
   describes — its own paper, or the project paper ``[Breimann25]_`` for the core
   γ-secretase CPP / dPULearn / TreeModel algorithms it covers. **Most classes —
   every data-prep / utility / helper class (preprocessors, loaders,
-  ``NumericalFeature``, ``AAlogo``, …) — carry no citation, and that is correct,
+  :class:`~aaanalysis.NumericalFeature`, :class:`~aaanalysis.AAlogo`, …) — carry no citation, and that is correct,
   not a gap.** Never add one to satisfy a checker note. **Verify before adding,
   and never invent one:** the key must be defined in ``references.rst`` (the
   checker's ``CITATION-UNDEFINED`` flags typo'd / fabricated keys) *and* the cited
@@ -145,7 +145,7 @@ Invariants:
   (e.g. DNA, 3D, ID, CPU, PDB) need no expansion.
 * ``Returns`` is **named** (``name : type``) and matches the returned variable.
   Two type-only idioms are allowed: a bare class name (scikit-learn self-return,
-  e.g. ``AAclust``) and a polymorphic ``X or Y``.
+  e.g. :class:`~aaanalysis.AAclust`) and a polymorphic ``X or Y``.
 * **Fixed-option parameters use** ``Literal``, **not** ``str``. When a parameter
   accepts a closed, finite set of string options (the values a ``check_str_options``
   /membership check validates against), type-hint it in the *signature* as
@@ -218,8 +218,8 @@ Cross-references (``See Also``)
   ``name : desc`` numpydoc entries and no ``  :  `` (space-colon-space).
 * **Every cross-reference must resolve.** A ``:class:``/``:meth:``/``:func:``
   target (in ``See Also`` *or* inline prose) must name a real public symbol —
-  ``CPP``, ``CPP.run_num``, ``aaanalysis.combine_dict_nums``. Watch
-  capitalization (``AAlogo``, not ``AALogo``) and method names on the right
+  :class:`~aaanalysis.CPP`, :meth:`~aaanalysis.CPP.run_num`, ``aaanalysis.combine_dict_nums``. Watch
+  capitalization (:class:`~aaanalysis.AAlogo`, not ``AALogo``) and method names on the right
   class. The checker's ``XREF-UNRESOLVED`` flags an internal target that does
   not resolve; external refs (``pandas.DataFrame``) are left alone.
 * **Order multi-layer links by documentation layer.** When a ``See Also`` (or
@@ -287,13 +287,13 @@ is registered; every ``<abbr> = aa.<Class>()`` and notebook filename matches).
 
 Rules:
 
-* ``AA*`` classes keep the ``aa`` prefix; acronyms stay whole (``CPP`` → ``cpp``);
-  the established public spelling is kept (``dPULearn`` → ``dpul``).
-* A plot pair is the base abbreviation plus ``_plot`` (``CPPPlot`` → ``cpp_plot``).
+* ``AA*`` classes keep the ``aa`` prefix; acronyms stay whole (:class:`~aaanalysis.CPP` → ``cpp``);
+  the established public spelling is kept (:class:`~aaanalysis.dPULearn` → ``dpul``).
+* A plot pair is the base abbreviation plus ``_plot`` (:class:`~aaanalysis.CPPPlot` → ``cpp_plot``).
 * **Legacy/incumbency wins.** Existing short forms are kept (``aac``, ``aal``);
-  the ``aa`` prefix is enforced where missing (``AAWindowSampler`` → ``aaws``);
+  the ``aa`` prefix is enforced where missing (:class:`~aaanalysis.AAWindowSampler` → ``aaws``);
   and when two classes would collide the *newer* one takes the longer form — so
-  ``SeqMut`` stays ``seqmut``, leaving ``sm`` free for ``ShapModel``.
+  :class:`~aaanalysis.SeqMut` stays ``seqmut``, leaving ``sm`` free for :class:`~aaanalysis.ShapModel`.
 * **A class instance is named the bare abbreviation, always** — ``cpp = aa.CPP(...)``,
   never ``cpp_res``/``cpp_dom``. If you build the same class repeatedly (e.g. one
   CPP per prediction level), **reassign the bare name** and let the *outputs* carry
@@ -308,58 +308,58 @@ Rules:
    * - Class
      - Abbr.
      - Extra
-   * - ``SequencePreprocessor``
+   * - :class:`~aaanalysis.SequencePreprocessor`
      - ``sp``
      -
-   * - ``EmbeddingPreprocessor``
+   * - :class:`~aaanalysis.EmbeddingPreprocessor`
      - ``ep``
      -
-   * - ``AAlogo`` / ``AAlogoPlot``
+   * - :class:`~aaanalysis.AAlogo` / :class:`~aaanalysis.AAlogoPlot`
      - ``aal`` / ``aal_plot``
      -
-   * - ``AAWindowSampler``
+   * - :class:`~aaanalysis.AAWindowSampler`
      - ``aaws``
      -
-   * - ``AAclust`` / ``AAclustPlot``
+   * - :class:`~aaanalysis.AAclust` / :class:`~aaanalysis.AAclustPlot`
      - ``aac`` / ``aac_plot``
      -
-   * - ``SequenceFeature``
+   * - :class:`~aaanalysis.SequenceFeature`
      - ``sf``
      -
-   * - ``NumericalFeature``
+   * - :class:`~aaanalysis.NumericalFeature`
      - ``nf``
      -
-   * - ``CPP`` / ``CPPPlot``
+   * - :class:`~aaanalysis.CPP` / :class:`~aaanalysis.CPPPlot`
      - ``cpp`` / ``cpp_plot``
      -
-   * - ``CPPGrid``
+   * - :class:`~aaanalysis.CPPGrid`
      - ``cppg``
      -
-   * - ``CPPStructurePlot``
+   * - :class:`~aaanalysis.CPPStructurePlot`
      - ``csp``
      - ``pro``
-   * - ``dPULearn`` / ``dPULearnPlot``
+   * - :class:`~aaanalysis.dPULearn` / :class:`~aaanalysis.dPULearnPlot`
      - ``dpul`` / ``dpul_plot``
      -
-   * - ``AAMut`` / ``AAMutPlot``
+   * - :class:`~aaanalysis.AAMut` / :class:`~aaanalysis.AAMutPlot`
      - ``aamut`` / ``aamut_plot``
      -
-   * - ``SeqMut`` / ``SeqMutPlot``
+   * - :class:`~aaanalysis.SeqMut` / :class:`~aaanalysis.SeqMutPlot`
      - ``seqmut`` / ``seqmut_plot``
      -
-   * - ``SeqOpt`` / ``SeqOptPlot``
+   * - :class:`~aaanalysis.SeqOpt` / :class:`~aaanalysis.SeqOptPlot`
      - ``seqopt`` / ``seqopt_plot``
      - core (``mode="impact"`` needs ``pro``)
-   * - ``TreeModel``
+   * - :class:`~aaanalysis.TreeModel`
      - ``tm``
      -
-   * - ``ShapModel``
+   * - :class:`~aaanalysis.ShapModel`
      - ``sm``
      - ``pro``
-   * - ``StructurePreprocessor``
+   * - :class:`~aaanalysis.StructurePreprocessor`
      - ``stp``
      - ``pro``
-   * - ``AnnotationPreprocessor``
+   * - :class:`~aaanalysis.AnnotationPreprocessor`
      - ``ap``
      - ``pro``
 
@@ -412,15 +412,15 @@ the *class-instance* names above are checked).
    * - Variable
      - Object (producer)
    * - ``df_seq``
-     - sequence frame (``load_dataset``, ``read_fasta``)
+     - sequence frame (:func:`~aaanalysis.load_dataset`, :func:`~aaanalysis.read_fasta`)
    * - ``df_scales`` / ``df_cat``
-     - AAontology scales / scale categories (``load_scales``, ``build_cat``)
+     - AAontology scales / scale categories (:func:`~aaanalysis.load_scales`, ``build_cat``)
    * - ``df_parts``
      - assembled parts (``sf.get_df_parts``)
    * - ``split_kws``
      - split specification (``sf.get_split_kws``) — matches the ``split_kws=`` parameter
    * - ``df_feat``
-     - feature frame, canonical schema (``cpp.run``, ``load_features``, ``sm.add_*``)
+     - feature frame, canonical schema (``cpp.run``, :func:`~aaanalysis.load_features`, ``sm.add_*``)
    * - ``X`` / ``labels``
      - feature matrix (``sf.feature_matrix``) / class labels (``df_seq["label"].to_list()``)
    * - ``df_eval``
@@ -456,20 +456,20 @@ but name *different* concepts — keep them distinct rather than collapsing them
    * - Contrast markers (the two groups being compared)
      - ``label_test`` / ``label_ref``
      - The positive/test group vs the reference group of a *contrast* —
-       ``CPP.run`` / ``CPP.eval``, ``AAlogo.get_df_logo``.
+       :meth:`~aaanalysis.CPP.run` / :meth:`~aaanalysis.CPP.eval`, :meth:`~aaanalysis.AAlogo.get_df_logo`.
    * - Single labeling (1D)
      - ``labels``
      - One per-sample class-label vector, shape ``(n_samples,)`` — e.g.
-       ``CPP.run``, ``TreeModel.fit`` / ``eval``, ``ShapModel.fit``,
-       ``dPULearn.fit``.
+       :meth:`~aaanalysis.CPP.run`, :meth:`~aaanalysis.TreeModel.fit` / ``eval``, :meth:`~aaanalysis.ShapModel.fit`,
+       :meth:`~aaanalysis.dPULearn.fit`.
    * - List of labelings (2D, multi-dataset)
      - ``list_labels``
      - Several labelings stacked, shape ``(n_datasets, n_samples)``, paired with
-       ``names_datasets`` — ``AAclust.eval``, ``dPULearn.eval``. Distinct from
+       ``names_datasets`` — :meth:`~aaanalysis.AAclust.eval`, :meth:`~aaanalysis.dPULearn.eval`. Distinct from
        ``labels`` **on purpose**: the plural marks a list of datasets, not one.
    * - Target-class selector (a single class to attribute)
      - ``label_target_class``
-     - ``ShapModel.fit`` — the one class whose model prediction the SHAP values
+     - :meth:`~aaanalysis.ShapModel.fit` — the one class whose model prediction the SHAP values
        explain. It can be **any** class (the positive, the negative/reference,
        or any index in a multi-class model), so it is **not** the same concept as
        ``label_test`` and deliberately keeps its own name.
@@ -632,16 +632,16 @@ in by these rules:
    (data in → analyse → engineer features → model → design → helpers).
 #. **Within a section, follow data flow:** inputs/loaders first, then the
    processing classes, then combiners/outputs (Data Handling = loaders →
-   preprocessors → ``combine_dict_nums``).
+   preprocessors → :func:`~aaanalysis.combine_dict_nums`).
 #. **Parallel-modality families go sequence → structure → embedding → annotation**
    (the sequence-to-structure-to-function logic), e.g. the preprocessors:
-   ``SequencePreprocessor``, ``StructurePreprocessor``, ``EmbeddingPreprocessor``,
-   ``AnnotationPreprocessor``.
+   :class:`~aaanalysis.SequencePreprocessor`, :class:`~aaanalysis.StructurePreprocessor`, :class:`~aaanalysis.EmbeddingPreprocessor`,
+   :class:`~aaanalysis.AnnotationPreprocessor`.
 #. **A logic class is immediately followed by its ``*Plot`` pair**, and close
-   variants form one contiguous family: ``AAclust`` → ``AAclustPlot``; the CPP
-   family ``CPP`` → ``CPPGrid`` → ``CPPPlot``; ``dPULearn`` → ``dPULearnPlot``.
-#. **Core before pro** where modality does not dictate otherwise (``TreeModel``
-   before ``ShapModel``).
+   variants form one contiguous family: :class:`~aaanalysis.AAclust` → :class:`~aaanalysis.AAclustPlot`; the CPP
+   family :class:`~aaanalysis.CPP` → :class:`~aaanalysis.CPPGrid` → :class:`~aaanalysis.CPPPlot`; :class:`~aaanalysis.dPULearn` → :class:`~aaanalysis.dPULearnPlot`.
+#. **Core before pro** where modality does not dictate otherwise (:class:`~aaanalysis.TreeModel`
+   before :class:`~aaanalysis.ShapModel`).
 #. **Group functions by kind** in Utility Functions: the ``comp_*`` metrics
    together, then display/options, then the ``plot_*`` helpers.
 #. **Every public symbol appears in ``api.rst`` exactly once** — ``__all__`` (incl.

--- a/docs/source/index/ecosystem.rst
+++ b/docs/source/index/ecosystem.rst
@@ -9,8 +9,8 @@ AAanalysis is the interpretable middle layer between bioinformatics I/O and the
 downstream machine-learning, explainable-AI, causal, and protein-design stack. The
 map below shows the Python packages it complements *upstream* (sequences, embeddings,
 structures, omics) and *downstream* (models, optimization, design, XAI evaluation),
-and where its own classes (*Part × Split × Scale* · AAontology · CPP · ``TreeModel`` ·
-``ShapModel`` · ...) fit in between.
+and where its own classes (*Part × Split × Scale* · AAontology · CPP · :class:`~aaanalysis.TreeModel` ·
+:class:`~aaanalysis.ShapModel` · ...) fit in between.
 
 .. raw:: html
 

--- a/docs/source/index/glossary.rst
+++ b/docs/source/index/glossary.rst
@@ -24,7 +24,7 @@ Sequences & data objects
 
    df_parts
       Wide table with one column per :term:`part` (``tmd``, ``jmd_n``,
-      ``jmd_c``, …), produced by ``SequenceFeature.get_df_parts``.
+      ``jmd_c``, …), produced by :meth:`~aaanalysis.SequenceFeature.get_df_parts`.
 
    df_feat
       Ranked feature table: ``feature`` id, ``abs_auc``, ``mean_dif``,
@@ -87,7 +87,7 @@ Prediction tasks
    residue level
       Per-residue / windowed prediction (datasets ``AA_*``); the
       :term:`unit of comparison` is a fixed-length :term:`window`
-      (``AAWindowSampler``). Two **sub-modes**, differing only by window parity:
+      (:class:`~aaanalysis.AAWindowSampler`). Two **sub-modes**, differing only by window parity:
       *single-residue* (odd window — a site *on* a residue, e.g. a PTM) and
       *between-residues* (even window — a bond ``P1│P1′``, e.g. cleavage).
 
@@ -143,7 +143,7 @@ CPP modes
    design / engineering
       Inverting prediction: measure how a mutation shifts a sequence's CPP
       feature profile (:term:`ΔCPP`) and use that to steer a sequence toward a
-      target profile (``AAMut`` / ``SeqMut``). Deliberately model-free.
+      target profile (:class:`~aaanalysis.AAMut` / :class:`~aaanalysis.SeqMut`). Deliberately model-free.
 
    ΔCPP
       The change in a sequence's CPP feature values caused by a mutation — the
@@ -165,7 +165,7 @@ Numerical features
       amino-acid scales.
 
    numerical CPP
-      ``CPP.run_num`` — the numerical-mode pipeline that profiles
+      :meth:`~aaanalysis.CPP.run_num` — the numerical-mode pipeline that profiles
       :term:`dict_num` inputs (sliced to :term:`part`-sets) instead of
       amino-acid scale look-ups. Generalizes CPP beyond physicochemical scales.
 
@@ -176,11 +176,11 @@ Models & explainability
 
    feature importance
       An **unsigned, group-level** ranking of how much each :term:`feature`
-      contributes to a model (e.g. ``TreeModel`` Monte-Carlo importance).
+      contributes to a model (e.g. :class:`~aaanalysis.TreeModel` Monte-Carlo importance).
 
    feature impact
       A **signed, per-sample** attribution of how each :term:`feature` pushes a
-      single prediction (e.g. ``ShapModel``; visualized via ``shap_plot``).
+      single prediction (e.g. :class:`~aaanalysis.ShapModel`; visualized via ``shap_plot``).
 
 Reducing features
 -----------------
@@ -189,22 +189,22 @@ Reducing features
 
    redundancy reduction
       Clustering correlated amino-acid scales and keeping one representative per
-      cluster (``AAclust``) to obtain a redundancy-reduced scale set.
+      cluster (:class:`~aaanalysis.AAclust`) to obtain a redundancy-reduced scale set.
 
    medoid
-      The representative scale of an ``AAclust`` cluster; the
+      The representative scale of an :class:`~aaanalysis.AAclust` cluster; the
       redundancy-reduced set is the set of medoids.
 
    feature selection
       Choosing an informative subset of features — e.g. recursive feature
-      elimination (RFE) inside ``TreeModel``.
+      elimination (RFE) inside :class:`~aaanalysis.TreeModel`.
 
    feature pruning
       Dropping correlated or uninformative features before modeling
-      (``NumericalFeature.filter_correlation``).
+      (:meth:`~aaanalysis.NumericalFeature.filter_correlation`).
 
    feature simplification
-      ``CPP.simplify`` — swapping features onto fewer, more interpretable scales
+      :meth:`~aaanalysis.CPP.simplify` — swapping features onto fewer, more interpretable scales
       without retraining.
 
 PU learning
@@ -213,11 +213,11 @@ PU learning
 .. glossary::
 
    PU labels
-      ``dPULearn`` input labels: ``1`` = positive, ``2`` = unlabeled. The output
+      :class:`~aaanalysis.dPULearn` input labels: ``1`` = positive, ``2`` = unlabeled. The output
       adds ``0`` = :term:`reliable negative`.
 
    reliable negative
-      An unlabeled sample that ``dPULearn`` identifies as confidently negative
+      An unlabeled sample that :class:`~aaanalysis.dPULearn` identifies as confidently negative
       (output label ``0``), drawn from the unlabeled pool.
 
 Window sampling
@@ -251,4 +251,4 @@ Class conventions
 
    Plot class
       A ``*Plot`` mirror of an analytical class — same arguments, visualization
-      only (e.g. ``CPPPlot`` mirrors ``CPP``).
+      only (e.g. :class:`~aaanalysis.CPPPlot` mirrors :class:`~aaanalysis.CPP`).

--- a/docs/source/index/release_notes.rst
+++ b/docs/source/index/release_notes.rst
@@ -21,8 +21,8 @@ Added
 
 - **EmbeddingPreprocessor**: Per-residue protein language model (PLM) embeddings.
   ``encode`` normalizes raw embeddings into a ``[0, 1]`` per-residue ``dict_num``
-  (``minmax`` / ``quantile`` / ``sigmoid``) for ``CPP.run_num``; ``build_scales`` /
-  ``build_cat`` collapse them into pseudo-scales for ``CPP.run``. ``fetch_embeddings``
+  (``minmax`` / ``quantile`` / ``sigmoid``) for :meth:`~aaanalysis.CPP.run_num`; ``build_scales`` /
+  ``build_cat`` collapse them into pseudo-scales for :meth:`~aaanalysis.CPP.run`. ``fetch_embeddings``
   (``[embed]`` extra) downloads a curated PLM (ESM-2, ESM-1b, ProtT5, ProstT5) from the
   Hugging Face Hub and computes per-protein (mean/max/cls pooling) or per-residue
   embeddings; ``pool_embeddings`` reduces per-residue arrays to per-protein vectors. The
@@ -36,34 +36,34 @@ Added
   (``fetch_uniprot``, ``ingest``, ``register_feature``, ``encode``, ``build_scales``,
   ``build_cat``, ``to_df_seq``).
 - **combine_dict_nums**: Concatenates per-residue tensors (embedding / structure /
-  annotation) along the feature axis into one combined ``CPP.run_num`` input.
+  annotation) along the feature axis into one combined :meth:`~aaanalysis.CPP.run_num` input.
 
 **Feature Engineering**
 
 - **CPPGrid**: ``Tool``-style wrapper (``run`` + ``eval``) that runs a parallel grid
-  sweep of ``CPP`` configurations in one call; configurations differing only in
+  sweep of :class:`~aaanalysis.CPP` configurations in one call; configurations differing only in
   ``n_filter`` collapse into a single run. ``eval(sort_by=...)`` scores the
   configurations (``avg_ABS_AUC`` by default) best-first.
 - **CPP.run_num**: Numerical mode sourcing per-residue values from a pre-sliced tensor
   (``dict_num_parts``) instead of an amino-acid → scale lookup — embedding / structure /
-  annotation features through the same pipeline and output schema as ``CPP.run``.
+  annotation features through the same pipeline and output schema as :meth:`~aaanalysis.CPP.run`.
 - **CPP.simplify ``candidate_search='fast'``**: Opt-in heuristic capping the candidate
   scales evaluated per feature, for a large speed-up on big scale pools (mainly
   ``greedy``). The default ``'exact'`` reproduces the previous result; ``'fast'`` is
   statistically equivalent (kept-feature Jaccard ≥ 0.95, ΔavgABS_AUC ≤ 0.005 on the
   canonical data).
 - **SequenceFeature.get_labels_ovr / get_labels_ovo**: Convert multi-class ``labels``
-  into binary sets for ``CPP`` — one-vs-rest (all samples kept) or one-vs-one (per
+  into binary sets for :class:`~aaanalysis.CPP` — one-vs-rest (all samples kept) or one-vs-one (per
   class-pair, each pair's value source row-matched).
 - **SequenceFeature.get_labels_quantile / get_labels_tiered**: Discretize a continuous
   target into binary ``labels`` — a single quantile cut, or a fixed positive set swept
   against stepwise-lowered negative cuts (each tier row-matched).
 - **SequenceFeature.get_df_parts_from_windows**: Assemble a reference ``df_parts`` from
-  per-part window sets (e.g. ``AAWindowSampler.sample_synthetic`` output).
+  per-part window sets (e.g. :meth:`~aaanalysis.AAWindowSampler.sample_synthetic` output).
 - **SequenceFeature.get_seq_kws**: Return one protein's ``{jmd_n_seq, tmd_seq, jmd_c_seq}``
   as a ready-to-splat ``seq_kws`` dict (by entry or position), parts taken from
   ``df_parts`` so the residues stay bound to the feature geometry — removing the manual
-  slicing glue when feeding ``CPPPlot.profile`` / ``feature_map`` (e.g. sample-level SHAP
+  slicing glue when feeding :meth:`~aaanalysis.CPPPlot.profile` / ``feature_map`` (e.g. sample-level SHAP
   plots).
 - **SequenceFeature.get_feature_descriptions**: One standardized, human-readable
   sentence per ``PART-SPLIT-SCALE`` feature id (region + split + AAontology scale name /
@@ -72,12 +72,12 @@ Added
 - **AAclust.pre_select_scales**: Metadata-only pre-filter that drops scales by AAontology
   ``category`` (``cat_out``) / ``subcategory`` (``subcat_out``) via ``df_cat`` — the
   preparation step before ``select_scales`` or ``filter_coverage`` (no clustering).
-- **AAclust.select_scales**: Wrapper around ``AAclust.fit`` that returns the
-  redundancy-reduced scale subset (one medoid per cluster) directly, ready for ``CPP``.
+- **AAclust.select_scales**: Wrapper around :meth:`~aaanalysis.AAclust.fit` that returns the
+  redundancy-reduced scale subset (one medoid per cluster) directly, ready for :class:`~aaanalysis.CPP`.
 - **AAclust.select_proteins**: Protein-level redundancy reduction over a per-protein
   feature matrix ``X`` — clusters proteins, selects one medoid per cluster, annotates
   ``df_seq`` with ``cluster`` / ``is_representative`` / ``dist_to_rep`` — the numerical
-  counterpart to ``filter_seq``.
+  counterpart to :func:`~aaanalysis.filter_seq`.
 - **AAclustPlot.centers / medoids accept ``df_scales``**: Pass scales via ``df_scales``
   (transposed internally) instead of ``centers(np.array(df_scales).T, ...)``; pass
   proteins / embeddings / CPP features via ``X`` (used as-is). The explicit ``X``
@@ -107,13 +107,13 @@ Added
   red-white-blue ramp and a ``'plddt'`` AlphaFold-confidence mode, with ``whole`` / ``fade`` /
   ``zoom`` focus. By default each feature's full impact is painted on every residue it spans
   (app-fidelity colouring); ``normalize_by_span=True`` switches to the span-normalized sum used
-  by ``CPPPlot.profile`` and the ``CPPPlot.feature_map`` top per-position bar. ``plot_combined``
-  returns a ``CombinedView`` showing the py3Dmol cartoon next to the ``CPPPlot.feature_map``
+  by :meth:`~aaanalysis.CPPPlot.profile` and the :meth:`~aaanalysis.CPPPlot.feature_map` top per-position bar. ``plot_combined``
+  returns a ``CombinedView`` showing the py3Dmol cartoon next to the :meth:`~aaanalysis.CPPPlot.feature_map`
   image (``write_html`` exports the pair; ``savefig(path)`` saves the feature-map panel as a static
   PNG / PDF for papers — the 3D cartoon is interactive and has no headless image), reproducing the
   deployed cleavage app's signature layout. ``interactive`` returns a live `ipywidgets <https://ipywidgets.readthedocs.io>`_
   explorer (added to the ``[pro]`` extra) where a site slider drives a user ``predictor`` and
-  repaints the linked 3D structure and ``CPPPlot.feature_map`` together (debounced), the
+  repaints the linked 3D structure and :meth:`~aaanalysis.CPPPlot.feature_map` together (debounced), the
   notebook-native version of the app's per-site explore loop. A **highlight (position) slider**
   links the two panels live: picking a residue lights it up in the 3D cartoon and marks its
   feature-map column without re-predicting, and with the ``ipympl`` (``%matplotlib widget``)
@@ -124,7 +124,7 @@ Added
   exports it as a standalone, shareable page. ``explore(df_feat, sequence, df_seq=..., labels=...,
   model=...)`` is the integrated one call: it builds a **built-in per-site predictor** (compute the
   query window's values for the fixed feature set, predict the probability, attach the per-site SHAP
-  impact via a default ``ShapModel`` refit — no ``CPP.run`` rediscovery) and dispatches to a
+  impact via a default :class:`~aaanalysis.ShapModel` refit — no :meth:`~aaanalysis.CPP.run` rediscovery) and dispatches to a
   selectable ``output`` (``'widget'`` / ``'html'`` / ``'static'``); ``model`` takes a name
   (``'rf'`` / ``'svm'`` / ``'log_reg'``), an estimator, or a list, and a custom
   ``predictor=(sequence, p1) -> df_feat`` remains the escape hatch. With ``output='html'``,
@@ -139,17 +139,17 @@ Added
   ``sample_motif_matched``, ``sample_synthetic``).
 - **scan_motif** (``[pro]``): Scans candidate proteins for statistically significant PWM
   occurrences via MEME/FIMO, complementing the pure-Python
-  ``AAWindowSampler.sample_motif_matched`` sampler.
+  :meth:`~aaanalysis.AAWindowSampler.sample_motif_matched` sampler.
 
 **Protein Design**
 
 - **SeqOpt — multi-objective protein engineering** (**core**; only ``mode="impact"`` needs
-  ``aaanalysis[pro]``): A new ``SeqOpt`` optimizer
-  (with ``SeqOptPlot``) performs **machine-learning-guided directed evolution** of one
+  ``aaanalysis[pro]``): A new :class:`~aaanalysis.SeqOpt` optimizer
+  (with :class:`~aaanalysis.SeqOptPlot`) performs **machine-learning-guided directed evolution** of one
   wild-type — searching the Pareto front across several objectives at once, with a
-  model-bound ``SeqMut`` as the fitness engine and a re-implementation of NSGA-II for
+  model-bound :class:`~aaanalysis.SeqMut` as the fitness engine and a re-implementation of NSGA-II for
   selection (this is protein *engineering*, not *de novo design*). Two guidance modes:
-  ``mode="impact"`` refits ``ShapModel`` each generation under fuzzy labeling to target the
+  ``mode="impact"`` refits :class:`~aaanalysis.ShapModel` each generation under fuzzy labeling to target the
   strongest-``feat_impact`` residues; ``mode="importance"`` walks positions by static
   ``feat_importance``. The evolutionary toolbox is a complete pure-Python re-implementation
   (DEAP is a dev/test-only parity oracle; runtime stays DEAP-free): ``crossover`` (uniform /
@@ -160,16 +160,16 @@ Added
   ``callable(sequence) -> float`` (an external scikit / torch model or sequence-level
   tool / web API), cached per variant. ``run`` returns ``df_pareto`` (objective columns +
   ``rank`` + ``crowding``) backed by a cumulative Pareto archive; ``eval`` reports
-  hypervolume / front size / spread / convergence. **Visualization**: ``SeqOptPlot`` covers
+  hypervolume / front size / spread / convergence. **Visualization**: :class:`~aaanalysis.SeqOptPlot` covers
   ``pareto_front`` (2-D / 3-D), ``parallel_coordinates``, ``convergence`` (hypervolume +
   spread + per-objective best/mean/worst band), ``hypervolume``, ``mutation_map`` (front
   substitution-enrichment heatmap) and ``genealogy`` (mutational-lineage tree). Reproducible
   via ``random_state`` / ``seed``.
-- **SeqMut model-guided mode (ML-guided directed evolution)**: ``SeqMut`` is optionally
+- **SeqMut model-guided mode (ML-guided directed evolution)**: :class:`~aaanalysis.SeqMut` is optionally
   model-aware — binding a fitted classifier (``SeqMut(model=..., target_class=...)``, any
   object with ``predict_proba``) makes ``scan`` / ``suggest`` / ``mutate`` report
   ``delta_pred`` (the prediction-score shift in percentage points) and ``suggest`` rank
-  by it. Without a model, ``SeqMut`` stays the deterministic, model-free ΔCPP tool.
+  by it. Without a model, :class:`~aaanalysis.SeqMut` stays the deterministic, model-free ΔCPP tool.
 - **SeqMut.combine**: Scores combined multi-mutation variants — several point mutations
   applied to one sequence and evaluated as a single design.
 - **SeqMutPlot**: ``mutation_landscape`` renders the ``delta_pred`` prediction-shift
@@ -199,7 +199,7 @@ Added
 - **aap.find_features**: Staged, interpretable CPP AutoML search. Stage 1
   cross-validates the full Cartesian Part × Split × Scale grid and ranks each axis by
   its marginal-mean impact; Stage 2 refines the single highest-impact axis against
-  ``n_filter``; Stage 3 refines the winning feature set (``CPP.simplify`` + recursive
+  ``n_filter``; Stage 3 refines the winning feature set (:meth:`~aaanalysis.CPP.simplify` + recursive
   feature elimination, each kept only if it is not Pareto-dominated). Selection is
   multi-objective: within each stage the Pareto-optimal-then-simplest configuration
   across all ``metric`` wins, scored by the averaged cross-validated performance of one
@@ -267,7 +267,7 @@ Changed
   ``(fig, ax)`` pair (forwarding attribute access to ``ax``, so existing
   ``ax = plot(...); ax.set_title(...)`` code keeps working), replacing the previous mix
   of shapes. **Breaking change, scheduled for the next major release:**
-  ``AAclustPlot.centers`` / ``medoids`` return ``(fig, ax)`` and expose the PCA-component
+  :meth:`~aaanalysis.AAclustPlot.centers` / ``medoids`` return ``(fig, ax)`` and expose the PCA-component
   DataFrame on the ``df_components_`` attribute instead of as the second return value.
 - **CPP performance**: The Cython feature-matrix kernel, macOS-safe threaded ``n_jobs``,
   scale / AA-index caching, and scale / sample batching land in this release, replacing
@@ -280,7 +280,7 @@ Changed
   explodes each 1-based anchor into one ``jmd_n`` / ``tmd`` / ``jmd_c`` row
   (``entry_win``). ``get_df_parts`` is also several-fold faster (vectorized; output
   unchanged).
-- **n_jobs**: Unified parallelism convention across ``CPP`` / ``CPPGrid`` (``1`` serial,
+- **n_jobs**: Unified parallelism convention across :class:`~aaanalysis.CPP` / :class:`~aaanalysis.CPPGrid` (``1`` serial,
   ``-1`` all cores, ``N>1`` exactly N, ``None`` optimized), with an ``options['n_jobs']``
   global override.
 - **CPPPlot.feature**: Titles the plot with the feature's human-readable description,
@@ -305,10 +305,10 @@ Changed
   parameter. Concurrency is off by default (parallel requests risk HTTP-429 throttling);
   when enabled, results reassemble in input order, so output is byte-identical.
 - **Performance (same output)**: Many internal hotspots were vectorized or parallelized
-  with byte-identical results — ``AAWindowSampler`` filtering / sampling, ``AAclust``
-  medoid distances, the per-feature KLD path in ``dPULearn.eval``, ``encode_one_hot``,
-  ``AAMut.comp_substitution_impact``, ``get_sliding_aa_window``, and several
-  ``StructurePreprocessor`` encoders (``encode_pdb`` contact / disulfide / pLDDT, a shared
+  with byte-identical results — :class:`~aaanalysis.AAWindowSampler` filtering / sampling, :class:`~aaanalysis.AAclust`
+  medoid distances, the per-feature KLD path in :meth:`~aaanalysis.dPULearn.eval`, ``encode_one_hot``,
+  :meth:`~aaanalysis.AAMut.comp_substitution_impact`, ``get_sliding_aa_window``, and several
+  :class:`~aaanalysis.StructurePreprocessor` encoders (``encode_pdb`` contact / disulfide / pLDDT, a shared
   per-entry chain-pick and alignment cache, ``get_dssp``). Public APIs and outputs are
   unchanged.
 - **Developer tooling**: A committed ``pytest-benchmark`` suite (``tests/benchmarks/``,

--- a/docs/source/index/usage_principles.rst
+++ b/docs/source/index/usage_principles.rst
@@ -36,7 +36,7 @@ machine-learning, explainable-AI, and protein-design stack, see
 embeddings can serve as the numerical representation of amino acids; embeddings can be
 created via
 `Google Colab <https://colab.research.google.com/drive/1N3Sf5EDwqHEN2lyPNcW5w6Mct5FZ2-W2?usp=sharing>`_
-and are integrated with CPP through ``CPP.run_num``.
+and are integrated with CPP through :meth:`~aaanalysis.CPP.run_num`.
 
 AAanalysis provides a handful of DataFrames for seamless data management. Starting with amino acid scale information
 (**df_scales**, **df_cat**) and protein sequences (**df_seq**), it enables segmentation into parts (**df_parts**)

--- a/docs/source/index/usage_principles/df_feat_contract.rst
+++ b/docs/source/index/usage_principles/df_feat_contract.rst
@@ -3,7 +3,7 @@
 df_feat: the CPP Output Contract
 ================================
 
-The feature DataFrame ``df_feat`` returned by ``CPP.run`` is the primary
+The feature DataFrame ``df_feat`` returned by :meth:`~aaanalysis.CPP.run` is the primary
 output other tools build on. To make that boundary safe to depend on, its schema
 is a **documented, test-guarded contract**: each consumer reads columns by their
 documented name and type, and a schema-stability test fails if a contracted column
@@ -11,9 +11,9 @@ is renamed or removed, a dtype changes, or the feature-id format changes.
 
 ``df_feat`` follows a **standardized, deterministic column order**. The columns listed
 in the :ref:`Data Schemas <df_schemas>` are the *canonical lower bound* — every
-``CPP.run`` output carries them, always in this order. Optional and dynamic columns (a
+:meth:`~aaanalysis.CPP.run` output carries them, always in this order. Optional and dynamic columns (a
 test-dependent p-value variant, diagnostic residue columns, and the explainable-AI
-columns appended by ``TreeModel`` / ``ShapModel``) are appended after ``positions`` in a
+columns appended by :class:`~aaanalysis.TreeModel` / :class:`~aaanalysis.ShapModel`) are appended after ``positions`` in a
 stable order, so the canonical order is a lower bound, never a restriction.
 
 Feature id grammar

--- a/docs/source/index/usage_principles/prediction_tasks.rst
+++ b/docs/source/index/usage_principles/prediction_tasks.rst
@@ -34,7 +34,7 @@ The two axes that actually define a task
 
 It is tempting to organize tasks by *biological scale* alone (residue, domain,
 protein). That label is useful shorthand, and AAanalysis encodes it directly in the
-dataset name prefixes (``AA_*``, ``DOM_*``, ``SEQ_*``; see ``load_dataset``).
+dataset name prefixes (``AA_*``, ``DOM_*``, ``SEQ_*``; see :func:`~aaanalysis.load_dataset`).
 But the scale is only a **proxy**. What genuinely
 determines how you set CPP up are two axes:
 
@@ -88,14 +88,14 @@ row closest to your biological question:
      - One :term:`window` centered *on* a residue (odd ``aa_window_size``)
      - Site windows vs non-site windows (or an unlabeled residue pool)
      - ``AA_``
-     - ``AAWindowSampler``, ``CPP``, ``TreeModel``
+     - :class:`~aaanalysis.AAWindowSampler`, :class:`~aaanalysis.CPP`, :class:`~aaanalysis.TreeModel`
    * - **Residue · between-residues**
 
        (e.g. a cleavage / scissile bond)
      - One :term:`window` spanning a bond ``P1│P1′`` (even ``aa_window_size``)
      - Cleaved windows vs non-cleaved windows
      - ``AA_``
-     - ``AAWindowSampler``, ``CPP``, ``TreeModel``
+     - :class:`~aaanalysis.AAWindowSampler`, :class:`~aaanalysis.CPP`, :class:`~aaanalysis.TreeModel`
    * - **Domain**
 
        (a defined sub-region)
@@ -103,14 +103,14 @@ row closest to your biological question:
        (``jmd_n`` / ``tmd`` / ``jmd_c``)
      - Labeled A-vs-B groups (e.g. substrate vs non-substrate)
      - ``DOM_``
-     - ``SequenceFeature``, ``CPP``, ``TreeModel``
+     - :class:`~aaanalysis.SequenceFeature`, :class:`~aaanalysis.CPP`, :class:`~aaanalysis.TreeModel`
    * - **Protein**
 
        (the whole chain)
      - The whole chain as a single part
      - Labeled A-vs-B groups of proteins
      - ``SEQ_``
-     - ``CPP``, ``TreeModel``
+     - :class:`~aaanalysis.CPP`, :class:`~aaanalysis.TreeModel`
    * - **Determinant discovery**
 
        (cross-cutting; no prediction target)
@@ -118,14 +118,14 @@ row closest to your biological question:
      - Two groups contrasted to surface *what distinguishes them*
        (interpreted via :term:`AAontology`)
      - ``AA_`` / ``DOM_`` / ``SEQ_``
-     - ``CPP``, ``CPPPlot``
+     - :class:`~aaanalysis.CPP`, :class:`~aaanalysis.CPPPlot`
    * - **Design / engineering**
 
        (cross-cutting; inverts prediction)
      - A sequence profiled against a target CPP profile
      - A target / reference profile the sequence is moved toward (``ΔCPP``)
      - ``AA_`` / ``DOM_`` / ``SEQ_``
-     - ``AAMut``, ``SeqMut``
+     - :class:`~aaanalysis.AAMut`, :class:`~aaanalysis.SeqMut`
    * - **Relational / interaction**
 
        (scope boundary, not a level)
@@ -171,7 +171,7 @@ Where to go next
    - **Workflows:** the :ref:`protocols <protocols>` catalog turns each task in
      this table into a start-to-finish workflow.
    - **Mechanics:** the per-function :ref:`tutorials <tutorials>` cover
-     ``CPP``, ``SequenceFeature``, ``AAclust``, and the rest.
+     :class:`~aaanalysis.CPP`, :class:`~aaanalysis.SequenceFeature`, :class:`~aaanalysis.AAclust`, and the rest.
    - **Full case studies:** the :ref:`use cases <use_cases>` showcase a
      published study end to end, as a template to adapt to your own data.
    - **Vocabulary:** every term used here is defined in the

--- a/docs/source/index/usage_principles/xai.rst
+++ b/docs/source/index/usage_principles/xai.rst
@@ -26,8 +26,8 @@ Explainable AI (eXAI) transforms opaque AI models into transparent systems, lett
 experts grasp the rationale behind specific predictions. This is particularly pivotal in
 the life sciences, where understanding each amino acid's role can inform drug discovery
 and disease treatment. Explanations come at two levels: *global* importance ranks which
-features matter across a whole dataset (``TreeModel``), while *local* attribution explains
-one specific sequence, residue by residue (``ShapModel``).
+features matter across a whole dataset (:class:`~aaanalysis.TreeModel`), while *local* attribution explains
+one specific sequence, residue by residue (:class:`~aaanalysis.ShapModel`).
 
 Combining CPP with SHAP
 -----------------------

--- a/docs/source/protocols.rst
+++ b/docs/source/protocols.rst
@@ -14,7 +14,7 @@ Protocols
 =========
 
 **Tutorials and protocols are different things.** A :ref:`tutorial <tutorials>`
-teaches you *one function* (what ``CPP`` or ``ShapModel`` does and how to call it).
+teaches you *one function* (what :class:`~aaanalysis.CPP` or :class:`~aaanalysis.ShapModel` does and how to call it).
 A **protocol** teaches you a *workflow*: it answers a single biological question
 from start to finish and, above all, builds the mental model for **when and why**
 to reach for each tool. Where a protocol uses a function, it links to that


### PR DESCRIPTION
Every mention of a public **class / method / function** in the prose docs now links straight to its API page, instead of being a plain red literal.

**What changed.** Across all `.rst` pages, standalone literals were converted to Sphinx roles:
- classes -> `:class:`~aaanalysis.<Name>`` (106)
- functions -> `:func:`~aaanalysis.<Name>`` (7)
- methods -> `:meth:`~aaanalysis.<Class>.<method>`` (35)

**Scope guard (as requested).** Only names in `aaanalysis.__all__` are converted, so **data objects and parameters stay literal** (`df_seq`, `split_kws`, `labels`, `df_feat`, `jmd_n`, ...), and call snippets with arguments (`CPP(df_parts=...)`) are untouched. 11 files touched.

**Verified** with a full `make html`: every converted reference resolves (no net-new "reference target not found" warnings), and the built pages render them as links to the generated API pages (e.g. `CPP` -> `generated/aaanalysis.CPP.html`).

Note: this covers the `.rst` documentation pages; the notebook (`.ipynb`) markdown cells are a separate follow-up if you want them linked too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)