### PR TITLE
docs(readme): center the Decision Map (figure directive)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -158,7 +158,7 @@ task (residue, domain, or protein level, plus determinant discovery and design) 
 right AAanalysis workflow and classes. Click the map to open the full, downloadable
 version (PNG / PDF / HTML).
 
-.. image:: https://raw.githubusercontent.com/breimanntools/aaanalysis/master/docs/source/_artwork/diagrams/decision_map.png
+.. figure:: https://raw.githubusercontent.com/breimanntools/aaanalysis/master/docs/source/_artwork/diagrams/decision_map.png
    :alt: AAanalysis Decision Map: which tool for which task
    :target: https://aaanalysis.readthedocs.io/en/latest/_static/decision_map.html
    :width: 70%


### PR DESCRIPTION
The Decision Map rendered left-aligned on GitHub because `.. image:: :align: center` doesn't actually center a standalone image there. Switching to `.. figure::` wraps it in a centered block, which GitHub honours. Same PNG, target, and 70% width.

Preview on the `docs/center-decision-map` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)