### PR TITLE
docs(readme): Decision Map full width (fixes left-aligned look)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -158,10 +158,10 @@ task (residue, domain, or protein level, plus determinant discovery and design) 
 right AAanalysis workflow and classes. Click the map to open the full, downloadable
 version (PNG / PDF / HTML).
 
-.. figure:: https://raw.githubusercontent.com/breimanntools/aaanalysis/master/docs/source/_artwork/diagrams/decision_map.png
+.. image:: https://raw.githubusercontent.com/breimanntools/aaanalysis/master/docs/source/_artwork/diagrams/decision_map.png
    :alt: AAanalysis Decision Map: which tool for which task
    :target: https://aaanalysis.readthedocs.io/en/latest/_static/decision_map.html
-   :width: 70%
+   :width: 100%
    :align: center
 
 Data Flow Map


### PR DESCRIPTION
The Decision Map looked left-aligned because GitHub's RST renderer **keeps an image's width but strips the `align-center` class** (it removes classes from user HTML), so a 70%-width image can't be centered there. Raw HTML would center it but makes **PyPI drop the entire README** (`readme_renderer` disallows the `raw` directive — verified it returns `None`).

Full width removes the off-center right-gap and renders on both GitHub and PyPI — matching the Ecosystem and Data Flow maps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)