### PR TITLE
ci(coverage): scope Test Coverage concurrency by ref (stop cross-PR cancellations)

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -13,12 +13,15 @@ on:
     branches:
       - master
 
-# Cancel EVERY in-progress Test Coverage run when a new one is triggered. The
-# group is keyed on the workflow name only (no ${{ github.ref }}), so a fresh run
-# on any branch/PR supersedes all in-flight coverage runs -- only the newest one
-# survives. This is the heaviest workflow, so we never let two of them run at once.
+# Cancel a superseded in-progress Test Coverage run only within the SAME ref: a new
+# push to a branch/PR cancels that branch's own older run (no stacked redundant runs
+# on rapid pushes), but runs on different branches/PRs do NOT cancel each other. The
+# group MUST include ${{ github.ref }} -- keying it on the workflow name alone made
+# the group repo-global, so with several PRs open only the newest run survived and
+# every other PR's coverage run showed as a spurious "cancelled" (red) with no
+# coverage ever reported.
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Problem
The **Test Coverage** workflow (`test_coverage.yml`) sets its concurrency group to `${{ github.workflow }}` — the workflow *name* only, with no `${{ github.ref }}`. That makes the group **repo-global**: with `cancel-in-progress: true`, a new run on any branch/PR cancels the in-progress runs of *all* others.

With several PRs open at once, only the newest run survives; every other PR's coverage run ends as a spurious **`cancelled`** (red ✗) and never reports a coverage number. (Confirmed: the failing checks conclude `cancelled`, killed during dependency install before any test ran — not a test or coverage failure.)

## Fix
Add `${{ github.ref }}` to the group so it is scoped per branch/PR:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

Now a new push to a branch only supersedes *that branch's* own in-progress run (still no stacked redundant runs on rapid pushes), while different branches/PRs no longer cancel each other — so every PR gets its own coverage result. Standard GitHub Actions pattern. The explanatory comment is updated to match.

Trade-off: with many active branches this permits more than one coverage run at a time (the previous config deliberately serialized the heaviest workflow repo-wide). That serialization is what caused the missing coverage on all-but-one PR, so per-ref scoping is the correct behavior for a multi-PR repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)