### PR TITLE
fix(tree-model): per-round seeding so a fixed random_state gives independent rounds (#343 #2)

### DIFF
--- a/aaanalysis/explainable_ai/_backend/tree_model/tree_model_fit.py
+++ b/aaanalysis/explainable_ai/_backend/tree_model/tree_model_fit.py
@@ -6,6 +6,28 @@ from sklearn.ensemble import RandomForestClassifier
 import aaanalysis.utils as ut
 
 
+# I Helper Functions
+def _seed_model_kwargs(list_model_kwargs, random_state=None, round_idx=0):
+    """Per-round-seeded copies of the importance-model kwargs.
+
+    With a fixed ``random_state`` round ``i`` uses ``random_state + i`` so the rounds differ
+    (the multi-round importance average is a real Monte-Carlo mean with non-zero std) yet stay
+    reproducible. With ``random_state=None`` the kwargs are returned unchanged, so every fit
+    re-draws fresh entropy. Only models that already carry a ``random_state`` (added by
+    ``check_model_kwargs`` when the estimator supports it) are reseeded. Mirrors ``ShapModel``'s
+    per-round reseeding.
+    """
+    if random_state is None:
+        return [dict(model_kwargs) for model_kwargs in list_model_kwargs]
+    seeded = []
+    for model_kwargs in list_model_kwargs:
+        model_kwargs = dict(model_kwargs)
+        if "random_state" in model_kwargs:
+            model_kwargs["random_state"] = random_state + round_idx
+        seeded.append(model_kwargs)
+    return seeded
+
+
 # II Main methods
 # 1. Step: Recursive feature elimination (RFE)
 def _recursive_feature_elimination(X, labels=None, step=None, n_feat_max=50, n_feat_min=25, n_cv=5, scoring="f1",
@@ -81,6 +103,9 @@ def fit_tree_based_models(X=None, labels=None,
                          f"to obtain {str_n_sets} of {n_feat_min} to {n_feat_max} features.")
         ut.print_start_progress(start_message=start_message)
     for i in range(n_rounds):
+        # Per-round reseed so a fixed random_state yields DIFFERENT rounds (real Monte-Carlo
+        # averaging with a non-zero importance std); no-op when random_state is None.
+        random_state_round = random_state + i if random_state is not None else None
         if is_preselected is not None:
             is_selected = is_preselected.astype(bool)
         else:
@@ -88,14 +113,15 @@ def fit_tree_based_models(X=None, labels=None,
         # 1. Step: Recursive feature elimination
         if use_rfe:
             args = dict(labels=labels, n_feat_min=n_feat_min, n_feat_max=n_feat_max, n_cv=n_cv, scoring=metric,
-                        step=step, random_state=random_state, verbose=verbose, i=i, n_rounds=n_rounds,
+                        step=step, random_state=random_state_round, verbose=verbose, i=i, n_rounds=n_rounds,
                         is_preselected=is_selected)
             is_selected = _recursive_feature_elimination(X, **args)
         is_selected_rounds[i, :] = is_selected
-        # 2. Step: Compute feature importance
+        # 2. Step: Compute feature importance (reseed the importance models per round too)
+        round_model_kwargs = _seed_model_kwargs(list_model_kwargs, random_state=random_state, round_idx=i)
         avg_importance, list_models = _compute_feature_importance(X, labels=labels, is_selected=is_selected,
                                                                   list_model_classes=list_model_classes,
-                                                                  list_model_kwargs=list_model_kwargs)
+                                                                  list_model_kwargs=round_model_kwargs)
         feature_importance[i, :] = avg_importance
         list_models_rounds.append(list_models)
     if verbose and use_rfe:

--- a/docs/adr/0051-treemodel-per-round-seeding.md
+++ b/docs/adr/0051-treemodel-per-round-seeding.md
@@ -1,0 +1,49 @@
+# ADR-0051 — TreeModel per-round seeding (fixed seed → independent rounds)
+
+Status: Accepted — 2026-07-06
+
+## Context
+
+`fit_tree_based_models` runs `n_rounds` of RFE + importance fits and averages the per-round
+feature importances. It passed a **constant** `random_state` to both the RFE
+`RandomForestClassifier` and the importance-model kwargs, so under a fixed seed every round fit
+identical estimators: `feat_importance_std` (and `predict_proba`'s `pred_std`) collapsed to exactly
+`0` and rounds 2..N were wasted. This hit the encouraged reproducibility path (a fixed
+`random_state`, or the global `options["random_state"]`) and contradicted the documented "average
+across training rounds enhances robustness" claim. `ShapModel` already reseeds per round
+(`random_state + round`).
+
+Part of #343 (defect #2). Under the `None` default the rounds already varied (fresh global entropy
+each fit), so only the fixed-seed path was degenerate.
+
+## Decision
+
+Reseed per round: round `i` uses `random_state + i` for the RFE `RandomForestClassifier` and for
+each importance model that carries a `random_state` (added by `check_model_kwargs` when the
+estimator supports it), via a local `_seed_model_kwargs` mirroring `ShapModel`'s. **No-op when
+`random_state is None`** (the `None` default path is byte-identical to before).
+
+**ADR-0032 tier:** this changes fixed-seed importance output (mean + std), so it is output-affecting
+— but the prior output was a degenerate `std=0` with wasted rounds, not a meaningful result worth
+preserving, and the `None` default is unchanged. Applied **directly** (no legacy/opt-in), per the
+maintainer decision on #343 (unlike defect #1, there is no reproducible-but-useful behavior to keep).
+
+## Regolden / anchors
+
+- **No existing regression anchor pinned TreeModel importances** (the unit + integration suites
+  assert structure, not exact values), so nothing needed regolding; those suites stay green.
+- **New guard:** platform-independent structural invariants (`test_tm_per_round_seed.py`) — non-zero
+  std under a fixed seed, same-seed reproducibility, single-round `std=0`. A frozen exact-value hash
+  was **rejected**: RandomForest Gini importances are not bit-identical across the CI matrix (BLAS /
+  sklearn build), so an exact anchor would be flaky; the invariants encode exactly what the fix
+  guarantees and gate on every runner (not just the nightly).
+- **No example/notebook change:** `examples/explainable_ai/tm.ipynb` exercises `TreeModel.eval`
+  (a separate CV path, `eval_feature_selections`), not the fixed `fit` importance path, so its
+  output is unaffected; the fix adds no public parameter.
+
+## Consequences
+
+- Fixed-seed TreeModel importances change once (degenerate → real Monte-Carlo mean + non-zero std);
+  reproducibility within a seed is preserved. The `None`-default output is unchanged.
+- `ShapModel` is unchanged (already correct); `TreeModel` now matches its per-round reseeding.
+- #343 defect #3 (BH p-value monotonicity) remains open.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -58,4 +58,5 @@ Regenerate this table with:
 | [0048](0048-select-scales-curation-surface.md) | `AAclust.pre_select_scales` for metadata-only scale exclusion | Accepted | 2026-06-29 |  |
 | [0049](0049-cpp-profile-nonnegative-shap-signed.md) | CPP profile y-axis is non-negative; three plot-rendering "fixes" are rejected | Accepted | 2026-07-04 |  |
 | [0050](0050-cpp-redundancy-legacy-exact.md) | CPP redundancy criterion: `legacy` default, `exact` opt-in | Accepted | 2026-07-05 |  |
+| [0051](0051-treemodel-per-round-seeding.md) | TreeModel per-round seeding (fixed seed → independent rounds) | Accepted | 2026-07-06 |  |
 <!-- ADR-INDEX:END -->

--- a/docs/source/index/release_notes.rst
+++ b/docs/source/index/release_notes.rst
@@ -305,6 +305,12 @@ Added
 Changed
 ~~~~~~~
 
+- :class:`~aaanalysis.TreeModel`: **per-round seeding fix** — with a fixed ``random_state`` (or the
+  global ``options["random_state"]``), :meth:`~aaanalysis.TreeModel.fit` now reseeds each round to
+  ``random_state + i`` so the rounds are independent. Previously every round fit identical estimators,
+  so ``feat_importance_std`` (and :meth:`~aaanalysis.TreeModel.predict_proba`'s ``pred_std``) collapsed
+  to exactly ``0`` and rounds 2..N were wasted. Fixed-seed importances change once (degenerate → real
+  Monte-Carlo mean with non-zero std); the ``random_state=None`` default is unchanged.
 - **Uniform plot return contract**: Every public ``*Plot`` method now returns a single
   ``(fig, ax)`` pair (forwarding attribute access to ``ax``, so existing
   ``ax = plot(...); ax.set_title(...)`` code keeps working), replacing the previous mix

--- a/tests/unit/tree_model_tests/test_tm_per_round_seed.py
+++ b/tests/unit/tree_model_tests/test_tm_per_round_seed.py
@@ -1,0 +1,54 @@
+"""Anchor tests for TreeModel per-round seeding.
+
+Under a fixed ``random_state`` each round must reseed to ``random_state + i`` so the rounds
+are independent: the multi-round importance mean is a real Monte-Carlo average and
+``feat_importance_std`` is non-zero. Before the fix every round used the same seed, so the
+std collapsed to exactly 0 and rounds 2..N were wasted.
+
+These are structural invariants (non-zero std, same-seed reproducibility, single-round std=0)
+rather than a frozen importance hash: RandomForest Gini importances are not bit-identical
+across the CI matrix (BLAS / sklearn build), so an exact-value anchor would be flaky, whereas
+these invariants are platform-independent and encode exactly what the fix guarantees.
+"""
+import numpy as np
+import aaanalysis as aa
+from sklearn.datasets import make_classification
+
+
+def _xy():
+    X, y = make_classification(n_samples=120, n_features=30, n_informative=12, random_state=0)
+    return X, y.tolist()
+
+
+class TestTreeModelPerRoundSeed:
+    def test_fixed_seed_gives_nonzero_importance_std(self):
+        # The core defect fix: fixed seed -> rounds differ -> non-zero std (was exactly 0).
+        X, y = _xy()
+        tm = aa.TreeModel(random_state=42).fit(X, labels=y, n_rounds=5, n_feat_min=10, n_feat_max=20)
+        std = np.asarray(tm.feat_importance_std, dtype=float)
+        assert np.nanmax(std) > 0
+        assert (std > 0).sum() >= 1
+
+    def test_fixed_seed_is_reproducible(self):
+        # Reseeding is deterministic: same seed -> identical mean and std across runs.
+        X, y = _xy()
+        a = aa.TreeModel(random_state=42).fit(X, labels=y, n_rounds=5, n_feat_min=10, n_feat_max=20)
+        b = aa.TreeModel(random_state=42).fit(X, labels=y, n_rounds=5, n_feat_min=10, n_feat_max=20)
+        assert np.allclose(np.asarray(a.feat_importance, dtype=float),
+                           np.asarray(b.feat_importance, dtype=float))
+        assert np.allclose(np.asarray(a.feat_importance_std, dtype=float),
+                           np.asarray(b.feat_importance_std, dtype=float))
+
+    def test_different_seeds_give_different_importance(self):
+        # Different base seeds -> different (but valid) importance signatures.
+        X, y = _xy()
+        a = aa.TreeModel(random_state=42).fit(X, labels=y, n_rounds=5, n_feat_min=10, n_feat_max=20)
+        b = aa.TreeModel(random_state=7).fit(X, labels=y, n_rounds=5, n_feat_min=10, n_feat_max=20)
+        assert not np.allclose(np.asarray(a.feat_importance, dtype=float),
+                               np.asarray(b.feat_importance, dtype=float))
+
+    def test_single_round_has_zero_std(self):
+        # Sanity: with one round there is no spread, so std must be exactly 0.
+        X, y = _xy()
+        tm = aa.TreeModel(random_state=42).fit(X, labels=y, n_rounds=1, n_feat_min=10, n_feat_max=20)
+        assert np.allclose(np.asarray(tm.feat_importance_std, dtype=float), 0.0)


### PR DESCRIPTION
Fixes defect #2 of #343: `TreeModel` did no per-round seeding, so under a fixed `random_state`
every round fit identical estimators.

## Problem

`fit_tree_based_models` passed a **constant** `random_state` to the RFE `RandomForestClassifier`
and the importance-model kwargs. Under a fixed seed (a `random_state` arg or the global
`options["random_state"]`) every round fit identical estimators, so `feat_importance_std` (and
`predict_proba`'s `pred_std`) collapsed to exactly `0` and rounds 2..N were wasted — contradicting
the documented "average across training rounds enhances robustness" claim. `ShapModel` already
reseeds per round.

## Fix

Round `i` reseeds to `random_state + i` for the RFE `RandomForestClassifier` and each importance
model that carries a `random_state` (added by `check_model_kwargs` when the estimator supports it),
via a local `_seed_model_kwargs` mirroring `ShapModel`'s. **No-op when `random_state is None`** — the
default path is byte-identical.

## Validation

- Fixed seed → `feat_importance_std` non-zero (was exactly `0`) and reproducible; `None` path unchanged.
- TreeModel unit suite **123 passed**; new `test_tm_per_round_seed.py` **4 passed**; smoke /
  find_features / integration TreeModel consumers **146 passed**. No existing anchor pinned
  importances → no regolden.

## Guard

Structural invariants (`test_tm_per_round_seed.py`): non-zero std under a fixed seed, same-seed
reproducibility, different-seed divergence, single-round `std=0`. A frozen exact-value hash was
**rejected** — RandomForest Gini importances are not bit-identical across the CI matrix
(BLAS / sklearn build), so an exact anchor would be flaky; the invariants encode exactly what the fix
guarantees and gate on every runner.

## Scope

No public API change; no notebook change (`TreeModel.eval` uses a separate `eval_feature_selections`
path, unaffected by the `fit` change). ADR-0051; release note (Changed).

Part of #343 (defect #2 — defect #1 shipped in #351; defect #3 BH-p-value monotonicity remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
