### PR TITLE
fix(cpp): canonical BH monotonicity for p_val_fdr_bh (#343 #3)

### DIFF
--- a/aaanalysis/feature_engineering/_backend/cpp/_utils_feature_stat.py
+++ b/aaanalysis/feature_engineering/_backend/cpp/_utils_feature_stat.py
@@ -45,7 +45,11 @@ def _bh_corrected_pvalues(pvals):
     sorted_pvals = pvals[sorted_indices]
     ranks = np.arange(1, n+1)
     corrected_pvals = sorted_pvals * n / ranks
-    corrected_pvals[corrected_pvals > 1] = 1  # p-values cannot exceed 1
+    # BH monotonicity: reverse cumulative minimum (the canonical step-up procedure, matching
+    # statsmodels' multipletests('fdr_bh')). Without it the adjusted p-values can be non-monotone
+    # in p-value order. Affects only the reported ``p_val_fdr_bh`` column, not feature selection.
+    corrected_pvals = np.minimum.accumulate(corrected_pvals[::-1])[::-1]
+    corrected_pvals = np.minimum(corrected_pvals, 1.0)  # p-values cannot exceed 1
     # Reorder to the original order
     corrected_pvals_original_order = np.empty(n, dtype=float)
     corrected_pvals_original_order[sorted_indices] = corrected_pvals

--- a/docs/adr/0052-bh-pvalue-monotonicity.md
+++ b/docs/adr/0052-bh-pvalue-monotonicity.md
@@ -1,0 +1,41 @@
+# ADR-0052 — BH-adjusted p-value monotonicity (canonical Benjamini–Hochberg)
+
+Status: Accepted — 2026-07-06
+
+## Context
+
+`_bh_corrected_pvalues` computed `sorted_pvals * n / ranks` and clipped to 1 but **omitted the
+reverse cumulative-minimum**, the monotonicity step of the canonical Benjamini–Hochberg step-up
+procedure. So `p_val_fdr_bh` could be non-monotone in p-value order and deviate from
+`statsmodels.multipletests('fdr_bh')` in non-monotone regions (values **inflated / conservative**,
+never anti-conservative). Part of #343 (defect #3).
+
+The deviation affects only the **reported** `p_val_fdr_bh` column in `df_feat`: CPP's feature
+selection and ranking use `abs_auc` / `abs_mean_dif`, not the BH p-value.
+
+## Decision
+
+Insert the reverse cumulative minimum before clipping:
+`corrected = np.minimum.accumulate(corrected[::-1])[::-1]`, matching statsmodels. Applied directly
+(the prior output was simply non-canonical; nothing worth preserving).
+
+**ADR-0032 tier:** output-affecting for the reported column only — no selection/ranking change and
+**no performance cost** (one extra O(n) vectorized pass over the already-sorted array, run once per
+CPP run, dominated by the existing O(n log n) sort).
+
+## Regolden / anchors
+
+- **No regolden:** the CPP exact-value regression anchor (ADR-0015) freezes top-feature identity +
+  `abs_auc`, not p-value columns — it passes unchanged with the fix (verified via
+  `AAA_RUN_REGRESSION=1`). No test pinned `p_val_fdr_bh`.
+- **New guard:** `test_cpp_bh_monotonicity.py` compares `_bh_corrected_pvalues` to an independent
+  canonical reference (an explicit suffix-minimum, structurally different from
+  `np.minimum.accumulate`) and asserts monotonicity + a known non-monotone case. Platform-independent
+  (pure formula), so it gates on every runner.
+
+## Consequences
+
+- `p_val_fdr_bh` now matches canonical BH; values change only in the previously non-monotone regions.
+  No selection, ranking, or performance change.
+- Closes the last of #343's three output-changing defects (#1 shipped #351 / ADR-0050,
+  #2 shipped #353 / ADR-0051).

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -59,4 +59,5 @@ Regenerate this table with:
 | [0049](0049-cpp-profile-nonnegative-shap-signed.md) | CPP profile y-axis is non-negative; three plot-rendering "fixes" are rejected | Accepted | 2026-07-04 |  |
 | [0050](0050-cpp-redundancy-legacy-exact.md) | CPP redundancy criterion: `legacy` default, `exact` opt-in | Accepted | 2026-07-05 |  |
 | [0051](0051-treemodel-per-round-seeding.md) | TreeModel per-round seeding (fixed seed → independent rounds) | Accepted | 2026-07-06 |  |
+| [0052](0052-bh-pvalue-monotonicity.md) | BH-adjusted p-value monotonicity (canonical Benjamini–Hochberg) | Accepted | 2026-07-06 |  |
 <!-- ADR-INDEX:END -->

--- a/docs/source/index/release_notes.rst
+++ b/docs/source/index/release_notes.rst
@@ -386,6 +386,11 @@ Changed
 Fixed
 ~~~~~
 
+- **BH-adjusted p-values (#343)**: ``p_val_fdr_bh`` in ``df_feat`` now follows canonical
+  Benjamini–Hochberg — the reverse cumulative-minimum (monotonicity) step was missing, so the
+  reported values could be non-monotone / slightly conservative in non-monotone regions. Only the
+  reported column changes; feature selection and ranking (``abs_auc`` / ``abs_mean_dif``) are
+  unaffected.
 - :meth:`~aaanalysis.CPP.run` with ``n_jobs > 1`` no longer crashes in non-interactive
   contexts (e.g. ``python -c``, heredocs, some subprocess shells) where starting a
   ``multiprocessing.Manager`` for the cross-process progress bar raised ``EOFError`` /

--- a/tests/unit/cpp_tests/test_cpp_bh_monotonicity.py
+++ b/tests/unit/cpp_tests/test_cpp_bh_monotonicity.py
@@ -1,0 +1,53 @@
+"""Anchor tests for BH-adjusted p-values (canonical Benjamini-Hochberg monotonicity).
+
+``_bh_corrected_pvalues`` previously omitted the reverse-cumulative-minimum step, so
+``p_val_fdr_bh`` could be non-monotone in p-value order and deviate from canonical BH.
+These tests pin it to a canonical reference (an independent explicit suffix-minimum, so
+the check does not merely re-run the implementation) and assert monotonicity. Only the
+reported column is affected; feature selection (``abs_auc`` / ``abs_mean_dif``) is not.
+"""
+import numpy as np
+
+from aaanalysis.feature_engineering._backend.cpp._utils_feature_stat import _bh_corrected_pvalues
+
+
+def _reference_bh(pvals):
+    """Canonical BH via an explicit suffix-minimum (independent of ``np.minimum.accumulate``)."""
+    p = np.asarray(pvals, dtype=float)
+    n = len(p)
+    order = np.argsort(p, kind="stable")
+    p_sorted = p[order]
+    raw = p_sorted * n / np.arange(1, n + 1)
+    adj = np.array([raw[i:].min() for i in range(n)])   # min over all later (higher) ranks
+    adj = np.minimum(adj, 1.0)
+    out = np.empty(n, dtype=float)
+    out[order] = adj
+    return out
+
+
+class TestBHMonotonicity:
+    def test_matches_canonical_bh_random(self):
+        rng = np.random.RandomState(0)
+        for _ in range(25):
+            pvals = rng.uniform(0, 1, size=int(rng.randint(5, 60)))
+            np.testing.assert_allclose(_bh_corrected_pvalues(pvals), _reference_bh(pvals), rtol=1e-12, atol=1e-15)
+
+    def test_output_is_monotone_in_pvalue_order(self):
+        rng = np.random.RandomState(1)
+        pvals = rng.uniform(0, 1, size=50)
+        adj = _bh_corrected_pvalues(pvals)
+        order = np.argsort(pvals)
+        assert np.all(np.diff(adj[order]) >= -1e-12)   # non-decreasing in p-value order
+
+    def test_known_nonmonotone_case(self):
+        # Raw p*n/rank is non-monotone here; canonical BH pulls the later value down.
+        pvals = np.array([0.01, 0.90, 0.02, 0.85])
+        adj = _bh_corrected_pvalues(pvals)
+        np.testing.assert_allclose(adj, _reference_bh(pvals), rtol=1e-12)
+        order = np.argsort(pvals)
+        assert np.all(np.diff(adj[order]) >= -1e-12)
+
+    def test_clipped_to_one(self):
+        pvals = np.array([0.5, 0.6, 0.7, 0.99])
+        adj = _bh_corrected_pvalues(pvals)
+        assert np.all(adj <= 1.0)


### PR DESCRIPTION
Fixes defect #3 of #343 (the last one): `p_val_fdr_bh` omitted the Benjamini–Hochberg monotonicity step.

## Problem

`_bh_corrected_pvalues` computed `sorted_pvals * n / ranks` and clipped to 1 but **skipped the
reverse cumulative-minimum** — the monotonicity step of canonical Benjamini–Hochberg. So
`p_val_fdr_bh` in `df_feat` could be non-monotone in p-value order and deviate from
`statsmodels.multipletests('fdr_bh')` in non-monotone regions (inflated / conservative, never
anti-conservative).

## Fix

Insert the reverse cumulative minimum before clipping (matching statsmodels):

```python
corrected_pvals = np.minimum.accumulate(corrected_pvals[::-1])[::-1]
```

## Scope & impact

- **Reported column only.** Feature selection and ranking use `abs_auc` / `abs_mean_dif`, not the BH
  p-value — no features change.
- **No performance cost:** one extra O(n) vectorized pass over the already-sorted array, run once per
  CPP run (dominated by the existing O(n log n) sort).
- **No regolden:** the CPP exact-value regression anchor (ADR-0015) freezes top-feature identity +
  `abs_auc`, not p-value columns — it passes unchanged with the fix (verified via
  `AAA_RUN_REGRESSION=1`). No test pinned `p_val_fdr_bh`.

## Guard

`test_cpp_bh_monotonicity.py` compares `_bh_corrected_pvalues` to an **independent** canonical
reference (an explicit suffix-minimum, structurally different from `np.minimum.accumulate`) over
random inputs + a known non-monotone case, and asserts monotonicity. Platform-independent → gates on
every runner.

ADR-0052; release note (Fixed).

Part of #343 (defect #3 — the last of its three output-changing defects; #1 shipped #351 / ADR-0050,
#2 shipped #353 / ADR-0051).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
