### PR TITLE
fix(perf): exclude p_val_fdr_bh from perf A/B digest (BH #343 drift), pin new values

### DIFF
--- a/tests/benchmarks/test_perf_hot_paths.py
+++ b/tests/benchmarks/test_perf_hot_paths.py
@@ -108,6 +108,15 @@ def _digest(obj):
 
     def upd(x):
         if isinstance(x, pd.DataFrame):
+            # TEMPORARY (remove when the 1.1.0 release re-baselines the perf A/B):
+            # the canonical BH-monotonicity fix (#343) deliberately changed the
+            # reported ``p_val_fdr_bh`` column vs the 1.0.3 release (it does not
+            # affect feature selection). Exclude ONLY that column from the byte-exact
+            # output A/B so the gate still compares every OTHER column vs the release;
+            # the new ``p_val_fdr_bh`` values are pinned in
+            # tests/unit/cpp_tests/test_cpp_regression.py.
+            if "p_val_fdr_bh" in x.columns:
+                x = x.drop(columns="p_val_fdr_bh")
             h.update(b"DF|"); h.update("|".join(map(str, x.columns)).encode())
             h.update(pd.util.hash_pandas_object(x, index=True).values.tobytes())
         elif isinstance(x, pd.Series):

--- a/tests/unit/cpp_tests/test_cpp_regression.py
+++ b/tests/unit/cpp_tests/test_cpp_regression.py
@@ -41,6 +41,11 @@ pytestmark = [
 # Re-freeze ONLY on an intentional, reviewed change to CPP scoring.
 FROZEN_TOP_FEATURE = "TMD_C_JMD_C-Segment(2,3)-CHOP780212"
 FROZEN_TOP_ABS_AUC = 0.328
+# Top feature's BH-adjusted p-value after the canonical monotonicity fix (#343).
+# Pinned here because the perf A/B output digest excludes 'p_val_fdr_bh' until the
+# 1.1.0 release re-baselines it (see tests/benchmarks/test_perf_hot_paths.py), so
+# this anchor is what still guards the exact BH values. Re-freeze on the 1.1.0 release.
+FROZEN_TOP_P_VAL_FDR_BH = 0.0002519268
 N_SAMPLES = 40
 N_SCALES = 20
 N_FILTER = 50
@@ -68,3 +73,10 @@ class TestCPPRegression:
     def test_top_abs_auc_frozen(self):
         df_feat = _run_reference_pipeline()
         assert round(float(df_feat["abs_auc"].iloc[0]), 3) == FROZEN_TOP_ABS_AUC
+
+    def test_top_p_val_fdr_bh_frozen(self):
+        # Guards the exact BH-adjusted p-value (#343 monotonicity fix) while the
+        # perf A/B temporarily excludes 'p_val_fdr_bh' from its byte-exact digest.
+        df_feat = _run_reference_pipeline()
+        assert float(df_feat["p_val_fdr_bh"].iloc[0]) == pytest.approx(
+            FROZEN_TOP_P_VAL_FDR_BH, rel=1e-6)


### PR DESCRIPTION
## Problem
The perf A/B gate byte-exact-compares each benchmark's output vs the **1.0.3 release**. PR #356's canonical **BH-monotonicity fix (#343)** deliberately changed the `p_val_fdr_bh` column (it does *not* affect feature selection), so `test_cpp_run` and `test_sequence_feature_get_df_feat` now "drift" vs 1.0.3 and the gate **hard-fails** — blocking **every** PR (#357/#358/#359 and master's own CI) until 1.1.0 re-baselines.

## Fix (test-only, surgical, temporary)
- **Exclude only `p_val_fdr_bh`** from the benchmark output digest (`tests/benchmarks/test_perf_hot_paths.py`). Every *other* column is still byte-exact-compared vs the release — an unintended change to feature selection, `abs_auc`, `mean_dif`, etc. still fails the gate.
- **Pin the new BH values** in the CPP regression anchor (`test_top_p_val_fdr_bh_frozen`) so `p_val_fdr_bh` is still validated exactly — just against the new BH-monotone value, not the stale 1.0.3 one.
- **Temporary:** both carry a "remove on the 1.1.0 release" note; the release re-baselines the A/B automatically.

## Verified
- Digest: a `p_val_fdr_bh`-only change → same digest (allowed); any other-column change → different digest (still gated).
- Regression anchor (forced-on) passes 3/3 incl. the new frozen `p_val_fdr_bh`.
- No change to the gate script (`.github/scripts/check_perf_regression.py`) or any library code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
