### PR TITLE
docs(shap,cpp): clarify sample-level vs group-level mean_dif for CPP-SHAP maps

### DIFF
--- a/aaanalysis/explainable_ai_pro/_shap_model.py
+++ b/aaanalysis/explainable_ai_pro/_shap_model.py
@@ -814,6 +814,16 @@ class ShapModel(Wrapper):
         The calculated differences are added to ``df_feat`` as new columns named ``mean_dif_'name(s)'``,
         corresponding to each sample or group.
 
+        .. note::
+
+           This per-sample column (sample minus the ``label_ref`` group average) is what a sample-level
+           CPP-SHAP map or ranking should be colored by: pass it as ``col_val`` to
+           :meth:`CPPPlot.feature_map`, :meth:`CPPPlot.ranking`, or :meth:`CPPPlot.profile`. It is
+           **not** the group-level ``mean_dif`` from :meth:`CPP.run` (test group minus reference group),
+           which is identical for every sample. Choose ``label_ref`` so the reference group matches the
+           contrast you want each sample explained against (e.g. an ``others`` / unlabeled group rather
+           than a curated negative set).
+
         .. versionadded:: 0.1.0
 
         Parameters

--- a/aaanalysis/feature_engineering/_cpp_plot.py
+++ b/aaanalysis/feature_engineering/_cpp_plot.py
@@ -1384,10 +1384,23 @@ class CPPPlot:
               is given instead, the SHAP impact is shown directly in the heatmap (diverging colormap) and
               the cumulative bars are switched off.
 
+            .. note::
+
+               A sample-level map must be colored by a *sample-specific* difference, i.e. **this one
+               sample (protein) minus the reference group average**, not by the group-level `mean_dif`
+               (test group minus reference group). Compute it per sample with
+               :meth:`ShapModel.add_sample_mean_dif` (which writes a `mean_dif_'name'` column contrasting
+               the selected sample against the ``label_ref`` group) and pass that column as ``col_val``.
+               Reusing the group-level `mean_dif` here would show the group signature under every sample's
+               SHAP impact instead of each protein's own deviation. Set ``name_ref`` to the reference
+               group's name (e.g. ``"others"``) so the colorbar label matches.
+
         col_cat : {'category', 'subcategory', 'scale_name'}, default='subcategory'
             Column name in ``df_feat`` for scale information (y-axis).
         col_val : {'mean_dif', 'abs_mean_dif', 'abs_auc', ``mean_dif_'name'``, ``feat_impact_'name'``}, default='mean_dif'
             Column name in ``df_feat`` for numerical values to display. Must match with the ``shap_plot`` setting.
+            For a sample-level (SHAP) map use a sample-specific ``mean_dif_'name'`` column (sample minus
+            reference group, from :meth:`ShapModel.add_sample_mean_dif`), not the group-level ``'mean_dif'``.
         col_imp :  {``feat_importance``, ``feat_importance_'name'``, ``feat_impact_'name'``}, default='feat_importance'
             Column name in ``df_feat`` for feature importance (group-, subgroup- or sample-level) or, when
             ``shap_plot=True``, for sample-level feature impact. Must match with the ``shap_plot`` setting.


### PR DESCRIPTION
## Summary

Docstring-only clarification of a recurring point of confusion in the CPP-SHAP workflow: a **sample-level** feature map/ranking must be colored by a *sample-specific* difference (one protein minus the reference-group average), **not** the group-level `mean_dif` from `CPP.run` (test group minus reference group, which is identical for every sample).

## Changes (2 files, docstrings only)

- **`ShapModel.add_sample_mean_dif`** — a `.. note::` stating this per-sample column is what a sample-level CPP-SHAP map/ranking should be colored by (pass as `col_val` to `CPPPlot.feature_map`/`ranking`/`profile`), and to choose `label_ref` for the intended contrast.
- **`CPPPlot.feature_map`** — a matching `.. note::` (compute the per-sample column via `ShapModel.add_sample_mean_dif`; reusing the group-level `mean_dif` would show the group signature under every sample), plus a `col_val` parameter clarification.

No code changes; defaults and behavior unchanged. Docstring structural checker passes (0 defects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)