### PR TITLE
docs(config): fix check_auto_font docstring default (True, not False)

### DIFF
--- a/aaanalysis/config.py
+++ b/aaanalysis/config.py
@@ -124,8 +124,8 @@ def resolve_n_jobs(n_jobs=None, n_work=None):
 def check_auto_font():
     """Return whether package-wide automatic plot sizing/fonts are enabled.
 
-    Global toggle (no per-call argument). When ``True``, dense plots may derive
-    their figure size from the data shape; when ``False`` (default) plots behave
+    Global toggle (no per-call argument). When ``True`` (default), dense plots may
+    derive their figure size from the data shape; when ``False`` plots behave
     exactly as before (byte-identical output).
     """
     auto_font = options["auto_font"]


### PR DESCRIPTION
## What

Correct the `check_auto_font()` helper docstring in `aaanalysis/config.py`. It
claimed the `auto_font` option defaults to `False`, but the real default is
`True`.

```diff
-    Global toggle (no per-call argument). When ``True``, dense plots may derive
-    their figure size from the data shape; when ``False`` (default) plots behave
+    Global toggle (no per-call argument). When ``True`` (default), dense plots may
+    derive their figure size from the data shape; when ``False`` plots behave
     exactly as before (byte-identical output).
```

## Why

Internal inconsistency inside one file: `config.py` sets `'auto_font': True`
(the option default), and the user-facing `Settings` class docstring already
documents `auto_font : bool, default=True`. Only this helper docstring still
said `False`. The `(default)` marker now sits on the `True` clause so the helper
matches both the actual default and its sibling docstring.

## Scope

- `config.py` only, 2-line docstring change.
- **No behavior change** — output is byte-identical; no signature, example, or
  release-note change.

Addresses gap **C2** of the plot-consistency review hub in #219. Issue #219
stays open as the review hub for the remaining `auto_font` / figure-width /
grid-size gaps; this PR only corrects the docstring inconsistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
