### PR TITLE
fix(cpp): interleave SHAP feature_map bar segments in feature order (no blue-at-end)

### DIFF
--- a/aaanalysis/feature_engineering/_backend/cpp/cpp_plot_feature_map.py
+++ b/aaanalysis/feature_engineering/_backend/cpp/cpp_plot_feature_map.py
@@ -40,24 +40,23 @@ def plot_feat_importance_bars_subcat(ax=None,
     if shap_plot:
         # Cumulative feature impact per subcategory, stacked in ONE direction (matching the
         # top per-position bars): one thin white-edged segment per contributing feature
-        # (red=positive, blue=negative). Index each row numerically (row i in list_cat order,
-        # every row reserves its slot even with no impact) so bars stay aligned with the
-        # heatmap rows -- see test_shap_impact_bar_aligns_with_correct_row.
+        # (red=positive, blue=negative), stacked in the feature order (NOT grouped by sign),
+        # so red and blue interleave as they occur rather than piling all negatives at the
+        # tail. Index each row numerically (row i in list_cat order, every row reserves its
+        # slot even with no impact) so bars stay aligned with the heatmap rows -- see
+        # test_shap_impact_bar_aligns_with_correct_row.
         df = df_feat[[col_cat, col_imp]]
         totals = []
         for i, cat in enumerate(list_cat):
             vals = df.loc[df[col_cat] == cat, col_imp].values
             left = 0.0
             for v in vals:
-                if v > 0:
-                    ax.barh(i, v, left=left, color=ut.COLOR_SHAP_POS,
-                            edgecolor="white", linewidth=0.3, align="edge")
-                    left += v
-            for v in vals:
-                if v < 0:
-                    ax.barh(i, abs(v), left=left, color=ut.COLOR_SHAP_NEG,
-                            edgecolor="white", linewidth=0.3, align="edge")
-                    left += abs(v)
+                if v == 0:
+                    continue
+                color = ut.COLOR_SHAP_POS if v > 0 else ut.COLOR_SHAP_NEG
+                ax.barh(i, abs(v), left=left, color=color,
+                        edgecolor="white", linewidth=0.3, align="edge")
+                left += abs(v)
             totals.append(left)
     else:
         # Get feature importance per scale class
@@ -117,22 +116,21 @@ def plot_feat_importance_bars_pos(ax=None,
                            value_type="sum", normalize=False)
     # Plot bars
     if shap_plot:
-        # Cumulative feature impact per position, stacked in one direction with one
-        # thin white-edged segment per contributing feature (red=positive, blue=negative).
+        # Cumulative feature impact per position, stacked in one direction with one thin
+        # white-edged segment per contributing feature (red=positive, blue=negative), stacked
+        # in the subcategory order (NOT grouped by sign), so red and blue interleave as they
+        # occur rather than piling all negatives at the top.
         totals = []
         for j in range(df_pos.shape[1]):
             vals = df_pos.iloc[:, j].values
             bottom = 0.0
             for v in vals:
-                if v > 0:
-                    ax.bar(j, v, bottom=bottom, color=ut.COLOR_SHAP_POS,
-                           edgecolor="white", linewidth=0.3, align="edge")
-                    bottom += v
-            for v in vals:
-                if v < 0:
-                    ax.bar(j, abs(v), bottom=bottom, color=ut.COLOR_SHAP_NEG,
-                           edgecolor="white", linewidth=0.3, align="edge")
-                    bottom += abs(v)
+                if v == 0:
+                    continue
+                color = ut.COLOR_SHAP_POS if v > 0 else ut.COLOR_SHAP_NEG
+                ax.bar(j, abs(v), bottom=bottom, color=color,
+                       edgecolor="white", linewidth=0.3, align="edge")
+                bottom += abs(v)
             totals.append(bottom)
         ax.set_ylim(0, max(totals + [0]))
     else:

--- a/tests/unit/cpp_plot_tests/test_cpp_plot_feature_map.py
+++ b/tests/unit/cpp_plot_tests/test_cpp_plot_feature_map.py
@@ -937,6 +937,33 @@ class TestCCPlotFeatureMapShap:
         assert all(h >= 0 for h in heights), "position bars must not extend down (negative height)"
         plt.close()
 
+    def test_shap_bars_interleave_by_feature_order_not_grouped(self):
+        """Segments stack in feature order (red/blue interleaved), NOT grouped all-positive-
+        then-all-negative. Six alternating-sign features in one subcategory must render a
+        right bar whose segments alternate along the axis -- i.e. a blue segment precedes a
+        later red one, which sign-grouping (all reds, then all blues) could never produce."""
+        cpp_plot = aa.CPPPlot()
+        df_feat = get_df_feat(n=6).reset_index(drop=True)
+        df_feat["category"] = df_feat["category"].iloc[0]
+        df_feat["subcategory"] = df_feat["subcategory"].iloc[0]
+        df_feat[COL_FEAT_IMPACT_TEST] = [3.0, -3.0, 3.0, -3.0, 3.0, -3.0]
+        fig, hm = cpp_plot.feature_map(df_feat=df_feat, shap_plot=True,
+                                       col_val=COL_MEAN_DIF_TEST, col_imp=COL_FEAT_IMPACT_TEST)
+        fig.canvas.draw()
+        hm_x0 = hm.get_position().x0
+        bar_ax = next(a for a in fig.get_axes()
+                      if a is not hm and a.get_position().x0 > hm_x0 + 0.1
+                      and a.get_position().width < 0.2 and a.get_position().height > 0.4)
+        code = {_rgba(SHAP_POS): "R", _rgba(SHAP_NEG): "B"}
+        segs = sorted((p for p in bar_ax.patches
+                       if _rgba(p.get_facecolor()) in code and p.get_width() > 0.01),
+                      key=lambda p: p.get_x())
+        seq = "".join(code[_rgba(p.get_facecolor())] for p in segs)
+        assert seq.count("R") >= 2 and seq.count("B") >= 2, seq
+        assert any(seq[k] == "B" and "R" in seq[k + 1:] for k in range(len(seq))), \
+            f"segments grouped by sign, not interleaved: {seq}"
+        plt.close()
+
     def test_shap_markers_present(self):
         """Magnitude markers (squares) are still drawn in SHAP mode."""
         cpp_plot = aa.CPPPlot()


### PR DESCRIPTION
Follow-up to the #219 SHAP-bar work. The stacked SHAP impact bars drew **all red (positive) segments first, then all blue (negative)** — so blue always piled at the tail of every bar (top and right panels), an ordering artifact rather than the true per-feature order.

Now each feature's `|impact|` is stacked in its **natural row/position order**, colored by sign, so red and blue **interleave** as they actually occur. One direction and total bar length are unchanged. Regression test asserts a blue segment can precede a later red one (impossible under sign-grouping). No visual-regression baseline change (those are non-SHAP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)