### PR TITLE
fix(cpp): slim the colored margin under sequence-bar letters

### DIFF
--- a/aaanalysis/feature_engineering/_backend/cpp/_utils_cpp_plot_positions.py
+++ b/aaanalysis/feature_engineering/_backend/cpp/_utils_cpp_plot_positions.py
@@ -101,14 +101,20 @@ def _adjust_xticks_labels(xticks=None, xtick_labels=None, add_xtick_pos=True,
     return xticks, xtick_labels
 
 
+# Colored sequence cell: fraction of the (heatmap-edge) top margin mirrored below the letters.
+# 1.0 = symmetric; smaller keeps the band flush to the grid on top but slim underneath.
+_SEQ_CELL_BOTTOM_MARGIN_FRAC = 0.4
+
+
 def _add_seq_cell_backgrounds(ax=None, labels=None, colors=None, x_shift=0.0):
     """Paint a seamless, full-width colored cell behind each residue letter (``fill`` mode).
 
     The per-letter text bbox is glyph-sized, so narrow residues leave hairline gaps and the
     colored band reads as ragged against the uniform heatmap grid. Draw one rectangle per
     residue instead: full-width (1.0 data unit) and centered on the tick so it lines up exactly
-    with the heatmap column, its **top flush against the heatmap edge** and a symmetric margin
-    below the letters, so the band is gap-free on every side.
+    with the heatmap column, its **top flush against the heatmap edge** and a slim margin below
+    the letters, so the band is gap-free on every side without piling excess color under the
+    residues.
     """
     fig = ax.figure
     fig.canvas.draw()
@@ -119,12 +125,13 @@ def _add_seq_cell_backgrounds(ax=None, labels=None, colors=None, x_shift=0.0):
     lo = min(e.y0 for e in exts)
     hi = max(e.y1 for e in exts)
     # The sequence band sits just outside the heatmap; snap its inner edge to the nearest axis
-    # limit (the heatmap border) so there is no gap between the cells and the grid, then mirror
-    # that margin past the far side of the letters so top and bottom margins match.
+    # limit (the heatmap border) so there is no gap between the cells and the grid. Extend the
+    # far edge only a fraction of that top margin past the letters, so the band stays flush to the
+    # grid on top but does not carry a heavy block of color under the (descender-free) residues.
     center = 0.5 * (lo + hi)
     edge = min(ax.get_ylim(), key=lambda v: abs(v - center))
     near, far = (lo, hi) if abs(lo - edge) <= abs(hi - edge) else (hi, lo)
-    margin = abs(near - edge)
+    margin = abs(near - edge) * _SEQ_CELL_BOTTOM_MARGIN_FRAC
     y_far = far + margin * (1 if far >= near else -1)
     y0, y1 = sorted((edge, y_far))
     for i, c in enumerate(colors):

--- a/tests/unit/cpp_plot_tests/test_cpp_plot_feature_map.py
+++ b/tests/unit/cpp_plot_tests/test_cpp_plot_feature_map.py
@@ -1122,6 +1122,24 @@ class TestFeatureMapSeqCharFill:
         plt.close("all")
         assert len(cells_off) == 0                          # fill=False keeps the legacy glyph bbox
 
+    def test_fill_cell_flush_to_heatmap_edge(self):
+        # The colored cell's inner edge snaps exactly onto a heatmap border (a y-limit), so there
+        # is no gap between the sequence band and the grid above it. (The band's far edge is a slim
+        # margin past the letters; that margin is a visual constant, not asserted here because the
+        # font's bounding box includes empty descender space below the caps.)
+        from matplotlib.patches import Rectangle
+        df_feat = aa.load_features(name="DOM_GSEC").head(40)
+        cpp = aa.CPPPlot(df_scales=aa.load_scales())
+        _, ax = cpp.feature_map(df_feat=df_feat, add_imp_bar_top=False, seq_char_fill=True, **self._seq_kws())
+        ax.figure.canvas.draw()
+        cells = [p for p in ax.patches if isinstance(p, Rectangle) and abs(p.get_width() - 1.0) < 1e-6]
+        ys = [p.get_y() for p in cells] + [p.get_y() + p.get_height() for p in cells]
+        cy0, cy1 = min(ys), max(ys)
+        ylim = ax.get_ylim()
+        plt.close("all")
+        flush = min(min(abs(cy0 - e), abs(cy1 - e)) for e in ylim)
+        assert flush < 1e-6                                       # one band edge is flush to the grid
+
     def test_fill_bad_type_raises(self):
         df_feat = aa.load_features(name="DOM_GSEC").head(40)
         cpp = aa.CPPPlot(df_scales=aa.load_scales())


### PR DESCRIPTION
Follow-up to the seamless sequence-bar fix (#383). The residue cells kept a **symmetric** margin — the same distance below the letters as the top margin that snaps to the heatmap edge — which piled a heavy block of color under the (descender-free) amino-acid letters.

## Change

Keep the cell's top flush to the heatmap grid, but extend the far edge only **~40%** of that margin past the letters (`_SEQ_CELL_BOTTOM_MARGIN_FRAC = 0.4`), so the band stays gap-free without excess color underneath. Chosen from a rendered A/B/C comparison (symmetric / 40% / flush).

## Tests

- Replaces the seamless-cell class's geometry assertion with a robust **flush-to-heatmap-edge** check (one band edge sits exactly on a y-limit). The exact bottom margin is a visual constant and intentionally not asserted — the font bounding box includes empty descender space below the caps, so a strict pixel margin would be brittle.
- `TestFeatureMapSeqCharFill` 5/5 pass; flake8 + docstring clean.
- No `df_feat` impact (plotting only); visual-regression baselines render the no-sequence path (unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)