### PR TITLE
fix(cpp): restore ranking Σ summary + SHAP legend below the bars

### DIFF
--- a/aaanalysis/feature_engineering/_backend/cpp/cpp_plot_ranking.py
+++ b/aaanalysis/feature_engineering/_backend/cpp/cpp_plot_ranking.py
@@ -176,23 +176,17 @@ def plot_feature_rank(ax=None, df_feat=None, n=20, xlim=(0, 4),
     plt.xlim(xlim)
 
     _add_annotation_right(sub_fig=sub_fig, text_size=fontsize_annotation, an_in_val=x_max/2, max_val=xlim[1])
-    # Add legend. Every bar row carries a % label (the short low bars' labels reach nearly to
-    # the panel edge), so there is no in-grid whitespace for the summary. Open a small
-    # headroom band ABOVE the top bar (extend the y-limit; the title sits above that) and put
-    # the summary there, right-aligned, clear of both the title and every per-bar label. The
-    # SHAP +/- entries stack just under it, still inside the headroom band.
-    n_head = 2.7 if shap_plot else 1.4
-    ax.set_ylim(n - 0.5, -n_head)
+    # Add legend
     str_sum = f"Σ={round(df_feat[col_imp].sum(), 1)}%"
-    args = dict(ha="right", size=fontsize_annotation, clip_on=False)
-    rank_info_xy_default = (xlim[1], -0.7)
+    args = dict(ha="right", size=fontsize_annotation)
+    rank_info_xy_default = (xlim[1]*1.1, n-2.5)
     _rank_info_xy = ut.adjust_tuple_elements(tuple_in=rank_info_xy,
                                             tuple_default=rank_info_xy_default)
     x, y = _rank_info_xy
-    plt.text(x, y, str_sum, weight="normal", va="bottom", **args)
+    plt.text(x, y, str_sum, weight="normal", **args)
     if shap_plot:
-        plt.text(x, y - 0.8, "negative", weight="bold", color=ut.COLOR_SHAP_NEG, va="bottom", **args)
-        plt.text(x, y - 1.6, "positive", weight="bold", color=ut.COLOR_SHAP_POS, va="bottom", **args)
+        plt.text(x, y+1, "negative", weight="bold", color=ut.COLOR_SHAP_NEG, va="top", **args)
+        plt.text(x, y+1, "positive", weight="bold", color=ut.COLOR_SHAP_POS, va="bottom", **args)
 
 
 # II Main Functions

--- a/tests/unit/cpp_plot_tests/test_cpp_plot_ranking.py
+++ b/tests/unit/cpp_plot_tests/test_cpp_plot_ranking.py
@@ -40,24 +40,6 @@ class TestRanking:
         assert isinstance(axes[0], plt.Axes)
         plt.close()
 
-    def test_sum_annotation_in_headroom_not_on_bar_rows(self):
-        # Regression: the "Σ=..%" summary (and, in SHAP mode, the +/- legend) sits in the
-        # headroom ABOVE the top bar (y < 0), never on a bar row (y in [0, n_top-1]) where it
-        # would overlap the per-bar % labels.
-        for shap_plot in (False, True):
-            df_feat = create_df_feat().copy()
-            kws = {}
-            if shap_plot:
-                df_feat["feat_impact_x"] = np.sign(df_feat["mean_dif"]) * df_feat["feat_importance"]
-                kws = dict(shap_plot=True, col_imp="feat_impact_x", col_dif="mean_dif")
-            cpp_plot = aa.CPPPlot()
-            fig, axes = cpp_plot.ranking(df_feat=df_feat, n_top=15, **kws)
-            sums = [t for t in axes[2].texts if t.get_text().startswith("Σ")]
-            assert sums, "no Σ summary annotation found"
-            assert all(t.get_position()[1] < 0 for t in sums), \
-                f"Σ summary not in headroom (expected y<0): {[t.get_position() for t in sums]}"
-            plt.close()
-
     @settings(max_examples=3, deadline=None)
     @given(n_top=st.integers(min_value=2, max_value=20))
     def test_n_top(self, n_top):


### PR DESCRIPTION
Reverts 24e3bfa4 (*"move ranking Σ summary into headroom above the bars"*).

That commit relocated the cumulative-importance summary (`Σ=…%`) and the SHAP `+/-` legend from below the bars into a headroom band **above** them, to avoid overlap with the per-bar `%` labels. On the real CPP-SHAP ranking figures the above-bars placement crowds the panel header (title + legend + Σ stacked together) and reads worse, so this restores the previous **below-the-bars** placement.

**Changes**
- `_backend/cpp/cpp_plot_ranking.py`: anchor `Σ=…%` and the `positive`/`negative` legend below the bars again (pre-24e3bfa4 layout); no y-limit headroom band.
- `tests/unit/cpp_plot_tests/test_cpp_plot_ranking.py`: drop the headroom-placement assertion that commit added.

**Trade-off:** 24e3bfa4 was added to prevent the summary from overlapping the short low bars' `%` labels at the panel's right edge; this revert reinstates that (small) crowding risk in favour of the preferred below-bars layout.

**Verified:** `CPPPlot().ranking(...)` renders `Σ=…%` at the bottom-right of the ranking panel again (both `shap_plot` modes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)