### PR TITLE
fix(struct): per-feature failure isolation + encode() backend router (#340)

### DIFF
--- a/aaanalysis/data_handling_pro/_struct_preproc.py
+++ b/aaanalysis/data_handling_pro/_struct_preproc.py
@@ -196,6 +196,37 @@ def _drop_or_raise_failed_entries(df_seq, ok_per_row, on_failure,
     return df_seq, ok_per_row, list(range(len(df_seq)))
 
 
+def _nan_feature_block(L, num_dims):
+    """All-NaN ``(L, num_dims)`` float block for a single isolated feature.
+
+    Used by the per-feature failure isolation (issue #340): when one feature
+    is unavailable (e.g. ``depth`` without the ``msms`` binary) or its encoder
+    raises for an entry, only that feature's column(s) are filled with NaN
+    while the other requested features are kept.
+    """
+    return np.full((L, num_dims), np.nan, dtype=np.float64)
+
+
+def _warn_isolated_features(unavailable, failed, source_label):
+    """Emit exactly one ``UserWarning`` per isolated feature (issue #340).
+
+    ``unavailable`` maps feature_key -> cause for features that could not be
+    computed at all (a missing external tool); ``failed`` maps feature_key ->
+    example error for features whose encoder raised on some entries. Both are
+    aggregated across entries so each failing feature is named once.
+    """
+    for key, cause in unavailable.items():
+        warnings.warn(
+            f"{cause} -> feature '{key}' unavailable; filled with NaN, "
+            f"other features kept.",
+            UserWarning, stacklevel=3)
+    for key, cause in failed.items():
+        warnings.warn(
+            f"{source_label} encoder '{key}' failed for one or more "
+            f"entries (e.g. {cause}); filled with NaN, other features kept.",
+            UserWarning, stacklevel=3)
+
+
 def _ensure_dssp_columns(df_seq, features_get_dssp, pdb_folder, ss_mode,
                          gap_handling, verbose):
     """Run get_dssp inline if ``df_seq`` is missing the requested DSSP columns.
@@ -938,18 +969,29 @@ class StructurePreprocessor:
             plddt_disorder, plddt_tier, chi1_sincos, chi2_sincos,
             ca_centroid_dist, ca_centroid_dist_norm, contact_count_8A,
             contact_count_12A, hse, disulfide}``. The ``depth`` feature
-            requires the external ``msms`` binary on PATH; absence raises
-            ``RuntimeError`` with an install hint.
+            requires the external ``msms`` binary on PATH; when it is absent
+            (or a per-entry encoder raises) only that feature's column(s) are
+            filled with NaN and the other features are kept (per-feature
+            isolation), unless ``on_failure='raise'``.
         plddt_disorder_threshold : float, default=70.0
             predicted Local Distance Difference Test (pLDDT) cutoff (in
             ``[0, 100]``) for the ``plddt_disorder`` feature: a residue whose
             AlphaFold pLDDT is below this value is flagged disordered (``1.0``),
             else ordered (``0.0``).
         on_failure : {'nan', 'drop', 'raise'}, default='nan'
-            Failure policy for entries whose PDB load fails (missing file,
-            unparseable structure, no matched chain). ``'nan'`` fills with
-            NaN-only tensors; ``'drop'`` removes those entries; ``'raise'``
-            re-raises.
+            Failure policy. Two independent failure axes are handled:
+
+            - **Entry-level** (missing file, unparseable structure, no matched
+              chain): ``'nan'`` fills the whole entry with NaN and sets
+              ``pdb_ok=False``; ``'drop'`` removes the entry; ``'raise'``
+              re-raises.
+            - **Feature-level** (a single feature is unavailable — e.g.
+              ``depth`` without ``msms`` — or its encoder raises for an entry):
+              under ``'nan'`` / ``'drop'`` only that feature's column(s) are
+              NaN-filled while every other feature is kept and the entry is
+              retained (``pdb_ok`` stays ``True``); one ``UserWarning`` names
+              each isolated feature. Under ``'raise'`` any feature failure
+              re-raises.
         return_df : bool, default=False
             If ``True``, also return the per-row status DataFrame as a second
             element ``(dict_num, df_seq_out)``. If ``False`` (default), return
@@ -969,8 +1011,10 @@ class StructurePreprocessor:
         ValueError
             On invalid arguments.
         RuntimeError
-            If ``msms`` is not installed and ``'depth'`` is requested, or if
-            any entry failed under ``on_failure='raise'``.
+            Only under ``on_failure='raise'``: if ``msms`` is not installed
+            and ``'depth'`` is requested, if a per-feature encoder raises, or
+            if any entry failed at the entry level. Under ``'nan'`` / ``'drop'``
+            these are isolated (NaN-filled) instead.
 
         Examples
         --------
@@ -994,8 +1038,20 @@ class StructurePreprocessor:
         ut.check_number_range(name="plddt_disorder_threshold",
                               val=plddt_disorder_threshold,
                               min_val=0.0, max_val=100.0, just_int=False)
-        if "depth" in features:
-            check_msms_available()
+        # Per-feature availability (issue #340): 'depth' needs the external
+        # 'msms' binary. Under on_failure='raise' a missing binary is fatal
+        # (with an install hint); otherwise isolate 'depth' to its own NaN
+        # column(s) and keep every other feature, warning once after the loop.
+        unavailable_features: Dict[str, str] = {}
+        if "depth" in features and not is_msms_available():
+            if on_failure == "raise":
+                check_msms_available()  # raises RuntimeError with install hint
+            unavailable_features["depth"] = (
+                "'msms' binary not found on PATH (install via "
+                "`conda install -c bioconda msms`)")
+        # Per-(entry, feature) encoder failures, aggregated across entries so
+        # each failing feature triggers exactly one warning.
+        failed_features: Dict[str, str] = {}
         pdb_folder = Path(pdb_folder)
         entries = df_seq[ut.COL_ENTRY].tolist()
         sequences = df_seq[ut.COL_SEQ].tolist()
@@ -1032,30 +1088,29 @@ class StructurePreprocessor:
                                           dtype=np.float64)
                 ok_per_row.append(False)
                 continue
-            blocks: List[np.ndarray] = []
-            entry_ok = True
             # Collect the structure's amino-acid chains and pick the best match
             # for this sequence at most ONCE per entry, then share that
             # (chain, residues, atom_seq, identity) across every encoder rather
             # than re-walking the structure ~13x. The pick is a deterministic
             # function of (structure, seq), so sharing is byte-identical to
-            # per-encoder recompute. Computed lazily inside the per-key ``try``
-            # below (not hoisted here) so a RuntimeError degrades just this row
-            # (pdb_ok=False) exactly as when each encoder resolved it
-            # internally — hoisting it out of the try would let the error abort
-            # the whole encode_pdb call instead of the single entry.
-            chain_pick = None
-            chain_pick_done = False
+            # per-encoder recompute. ``_resolve_best_chain`` returns a
+            # (None, ...) tuple for a structure with no amino-acid chains
+            # instead of raising; the encoders map that to an all-NaN block, so
+            # it is not an entry-level failure.
+            chain_pick = _resolve_best_chain(structure, seq)
             # The per-residue pLDDT read (structure walk + alignment) is shared
-            # across the three pLDDT keys, computed at most once per entry, with
-            # the same per-entry error-envelope rationale.
+            # across the three pLDDT keys, computed at most once per entry.
             plddt_shared = None
             plddt_done = False
+            blocks: List[np.ndarray] = []
             for key in features:
+                num_dims = REGISTRY[key]["num_dims"]
+                # Feature globally unavailable (e.g. 'depth' without msms):
+                # isolate it to its own NaN column(s), keep the rest.
+                if key in unavailable_features:
+                    blocks.append(_nan_feature_block(L, num_dims))
+                    continue
                 try:
-                    if not chain_pick_done:
-                        chain_pick = _resolve_best_chain(structure, seq)
-                        chain_pick_done = True
                     if key == "bfactor":
                         block, identity = encode_bfactor(
                             structure, seq, chain_pick=chain_pick)
@@ -1119,21 +1174,18 @@ class StructurePreprocessor:
                             f"   encode_pdb: entry={entry}, key={key}, "
                             f"identity={identity:.3f}, n_res={block.shape[0]}")
                 except RuntimeError as e:
-                    warnings.warn(
-                        f"PDB encoder '{key}' failed for entry '{entry}': "
-                        f"{e}; this row will have pdb_ok=False",
-                        UserWarning)
-                    entry_ok = False
-                    break
-            if not entry_ok:
-                dict_pdb[entry] = np.full((L, D_total), np.nan,
-                                          dtype=np.float64)
-                ok_per_row.append(False)
-                continue
+                    # Per-feature isolation (issue #340): NaN only this
+                    # feature's column(s) for this entry; keep the others.
+                    if on_failure == "raise":
+                        raise
+                    blocks.append(_nan_feature_block(L, num_dims))
+                    failed_features.setdefault(key, str(e))
             arr = np.concatenate(blocks, axis=1) if len(blocks) > 1 \
                 else blocks[0]
             dict_pdb[entry] = arr
             ok_per_row.append(True)
+        _warn_isolated_features(unavailable_features, failed_features,
+                                source_label="PDB")
         # Apply on_failure policy
         df_aug = df_seq.copy()
         df_aug[_COL_PDB_OK] = ok_per_row
@@ -1199,7 +1251,10 @@ class StructurePreprocessor:
             ``(0, edges[0]]``, ``(edges[0], edges[1]]``, ``(edges[1], L]``.
         on_failure : {'nan', 'drop', 'raise'}, default='nan'
             What to do for entries whose PAE load fails (missing sidecar,
-            malformed JSON, shape mismatch).
+            malformed JSON, shape mismatch). If instead a single PAE encoder
+            raises for an otherwise-loaded entry, only that feature's
+            column(s) are NaN-filled (per-feature isolation) and one
+            ``UserWarning`` names it — unless ``on_failure='raise'``.
         return_df : bool, default=False
             If ``True``, also return the per-row status DataFrame as a second
             element ``(dict_num, df_seq_out)``. If ``False`` (default), return
@@ -1266,6 +1321,9 @@ class StructurePreprocessor:
         D_total = get_total_dims(features)
         dict_pae: Dict[str, np.ndarray] = {}
         ok_per_row: List[bool] = []
+        # Per-(entry, feature) encoder failures, aggregated so each failing
+        # feature warns once (issue #340 per-feature isolation).
+        failed_features: Dict[str, str] = {}
         session_tmp = tempfile.TemporaryDirectory()
         session_tmp_path = Path(session_tmp.name)
         for entry, seq in zip(entries, sequences):
@@ -1295,8 +1353,8 @@ class StructurePreprocessor:
                 ok_per_row.append(False)
                 continue
             blocks: List[np.ndarray] = []
-            entry_ok = True
             for key in features:
+                num_dims = REGISTRY[key]["num_dims"]
                 try:
                     if key == "pae_row_mean":
                         block = encode_pae_row_mean(pae)
@@ -1325,21 +1383,17 @@ class StructurePreprocessor:
                             f"   encode_pae: entry={entry}, key={key}, "
                             f"L={L}")
                 except RuntimeError as e:
-                    warnings.warn(
-                        f"PAE encoder '{key}' failed for entry '{entry}': "
-                        f"{e}; this row will have pae_ok=False",
-                        UserWarning)
-                    entry_ok = False
-                    break
-            if not entry_ok:
-                dict_pae[entry] = np.full((L, D_total), np.nan,
-                                          dtype=np.float64)
-                ok_per_row.append(False)
-                continue
+                    # Per-feature isolation (issue #340): NaN only this
+                    # feature's column(s) for this entry; keep the others.
+                    if on_failure == "raise":
+                        raise
+                    blocks.append(_nan_feature_block(L, num_dims))
+                    failed_features.setdefault(key, str(e))
             arr = np.concatenate(blocks, axis=1) if len(blocks) > 1 \
                 else blocks[0]
             dict_pae[entry] = arr
             ok_per_row.append(True)
+        _warn_isolated_features({}, failed_features, source_label="PAE")
         df_aug = df_seq.copy()
         df_aug["pae_ok"] = ok_per_row
         df_aug, ok_after, keep_idx = _drop_or_raise_failed_entries(
@@ -1582,7 +1636,10 @@ class StructurePreprocessor:
         on_failure : {'nan', 'drop', 'raise'}, default='nan'
             What to do for entries whose chopping file is missing or
             unparseable. ``'nan'`` fills with NaN-only tensors;
-            ``'drop'`` removes those entries; ``'raise'`` re-raises.
+            ``'drop'`` removes those entries; ``'raise'`` re-raises. If a
+            single domain encoder raises for an otherwise-parsed entry, only
+            that feature's column(s) are NaN-filled (per-feature isolation)
+            and one ``UserWarning`` names it — unless ``on_failure='raise'``.
         return_df : bool, default=False
             If ``True``, also return the per-row status DataFrame as a second
             element ``(dict_num, df_seq_out)``. If ``False`` (default), return
@@ -1658,6 +1715,9 @@ class StructurePreprocessor:
         D_total = get_total_dims(features)
         dict_domains: Dict[str, np.ndarray] = {}
         ok_per_row: List[bool] = []
+        # Per-(entry, feature) encoder failures, aggregated so each failing
+        # feature warns once (issue #340 per-feature isolation).
+        failed_features: Dict[str, str] = {}
         for entry, seq, inline_chopping in zip(entries, sequences,
                                                chopping_col):
             _check_entry_is_filesystem_safe(entry)
@@ -1711,8 +1771,8 @@ class StructurePreprocessor:
                     ok_per_row.append(False)
                     continue
             blocks: List[np.ndarray] = []
-            entry_ok = True
             for key in features:
+                num_dims = REGISTRY[key]["num_dims"]
                 try:
                     if key == "domain_boundary":
                         block = encode_domain_boundary(L, domains)
@@ -1732,22 +1792,17 @@ class StructurePreprocessor:
                             f"   encode_domains: entry={entry}, key={key}, "
                             f"n_domains={len(domains)}, L={L}")
                 except RuntimeError as e:
-                    warnings.warn(
-                        f"Domain encoder '{key}' failed for entry "
-                        f"'{entry}': {e}; this row will have "
-                        f"domain_ok=False",
-                        UserWarning)
-                    entry_ok = False
-                    break
-            if not entry_ok:
-                dict_domains[entry] = np.full((L, D_total), np.nan,
-                                              dtype=np.float64)
-                ok_per_row.append(False)
-                continue
+                    # Per-feature isolation (issue #340): NaN only this
+                    # feature's column(s) for this entry; keep the others.
+                    if on_failure == "raise":
+                        raise
+                    blocks.append(_nan_feature_block(L, num_dims))
+                    failed_features.setdefault(key, str(e))
             arr = np.concatenate(blocks, axis=1) if len(blocks) > 1 \
                 else blocks[0]
             dict_domains[entry] = arr
             ok_per_row.append(True)
+        _warn_isolated_features({}, failed_features, source_label="Domain")
         df_aug = df_seq.copy()
         # When inline-chopping is the source, df_seq may already carry a
         # 'domain_ok' column from get_domains; overwrite it with the
@@ -1761,6 +1816,198 @@ class StructurePreprocessor:
             dict_domains = {k: v for k, v in dict_domains.items()
                             if k in kept_entries}
         return (dict_domains, df_aug) if return_df else dict_domains
+
+    # ------------------------------------------------------------------
+    # encode  (feature/backend router)
+    # ------------------------------------------------------------------
+    def encode(
+        self,
+        df_seq: pd.DataFrame,
+        *,
+        features: List[str],
+        pdb_folder: Optional[Union[str, Path]] = None,
+        pae_folder: Optional[Union[str, Path]] = None,
+        domain_folder: Optional[Union[str, Path]] = None,
+        ss_mode: Literal["ss3", "ss8"] = "ss3",
+        gap_handling: Literal["pad", "omit"] = "pad",
+        plddt_disorder_threshold: float = 70.0,
+        local_window: int = 5,
+        pae_band_edges: Tuple[int, int] = (5, 15),
+        on_failure: Literal["nan", "drop", "raise"] = "nan",
+        return_df: bool = False,
+    ) -> Union[Dict[str, np.ndarray], Tuple[Dict[str, np.ndarray], pd.DataFrame]]:
+        """Encode a mixed feature list, routing each key to the right backend.
+
+        One entry point that hides the ``encode_dssp`` / ``encode_pdb`` /
+        ``encode_pae`` / ``encode_domains`` split: each requested feature key
+        is dispatched to its owning encoder via the feature registry, and the
+        per-backend outputs are merged into a single ``[0, 1]``-normalized
+        ``dict_num`` whose D-axis follows the requested ``features`` order (so
+        it lines up with :meth:`build_scales` / :meth:`build_cat`). You no
+        longer need to know which source a key comes from or call
+        :func:`aaanalysis.combine_dict_nums` yourself.
+
+        .. versionadded:: 1.1.0
+
+        Parameters
+        ----------
+        df_seq : pd.DataFrame, shape (n_samples, n_seq_info)
+            DataFrame containing an ``entry`` column with unique protein
+            identifiers and a ``sequence`` column with full protein sequences.
+        features : list of str
+            Any mix of feature keys from the StructurePreprocessor registry.
+            Each key is routed to its owning encoder (DSSP / PDB / PAE /
+            domains); keys from different sources may be freely interleaved.
+        pdb_folder : str or pathlib.Path, optional
+            Directory of ``<entry>.pdb`` / ``.cif`` files. Required when the
+            requested ``features`` include any DSSP or PDB key (DSSP may
+            instead reuse pre-computed columns already on ``df_seq``).
+        pae_folder : str or pathlib.Path, optional
+            Directory of AlphaFold PAE sidecar JSONs. Required when the
+            requested ``features`` include any PAE key.
+        domain_folder : str or pathlib.Path, optional
+            Directory of per-entry chopping files. Required when the requested
+            ``features`` include any domain key, unless ``df_seq`` already
+            carries a ``chopping`` column.
+        ss_mode : {'ss3', 'ss8'}, default='ss3'
+            Forwarded to :meth:`encode_dssp` when a DSSP key is requested.
+        gap_handling : {'pad', 'omit'}, default='pad'
+            Forwarded to :meth:`encode_dssp` when a DSSP key is requested.
+        plddt_disorder_threshold : float, default=70.0
+            Forwarded to :meth:`encode_pdb` when the ``plddt_disorder`` key is
+            requested.
+        local_window : int, default=5
+            Forwarded to :meth:`encode_pae` for the local / distal PAE means.
+        pae_band_edges : tuple of (int, int), default=(5, 15)
+            Forwarded to :meth:`encode_pae` for ``pae_band_means``.
+        on_failure : {'nan', 'drop', 'raise'}, default='nan'
+            Passed through to every routed backend. ``'nan'`` isolates
+            failures (entry-level entries or single features are NaN-filled,
+            everything else kept); ``'drop'`` removes entries that any routed
+            backend dropped (the merged output keeps only entries present in
+            every source); ``'raise'`` re-raises.
+        return_df : bool, default=False
+            If ``True``, also return an echo of ``df_seq`` (kept entries) plus
+            a boolean ``encode_ok`` column that is the per-entry AND of every
+            routed backend's entry-level status.
+
+        Returns
+        -------
+        dict_num : dict[str, np.ndarray]
+            ``{entry: (L_entry, D_total) ndarray}`` with the requested
+            ``features`` concatenated along D in the given order. Values are
+            in ``[0, 1]`` (NaN for unresolved positions or isolated features).
+        df_seq_out : pd.DataFrame
+            Returned only when ``return_df=True``. Echo of ``df_seq`` (kept
+            entries) plus a boolean ``encode_ok`` column.
+
+        Raises
+        ------
+        ValueError
+            On invalid arguments, unknown feature keys, or a missing folder
+            required by one of the routed backends.
+        RuntimeError
+            Propagated from a routed backend under ``on_failure='raise'``.
+
+        See Also
+        --------
+        * :meth:`encode_dssp`, :meth:`encode_pdb`, :meth:`encode_pae`,
+          :meth:`encode_domains`: the per-source encoders this method routes to.
+        * :func:`aaanalysis.combine_dict_nums`: the manual merge this method
+          performs internally.
+
+        Examples
+        --------
+        .. include:: examples/strp_encode.rst
+        """
+        # Validate
+        ut.check_df_seq(df_seq=df_seq)
+        if ut.COL_SEQ not in df_seq.columns:
+            raise ValueError(
+                f"'df_seq' should contain a '{ut.COL_SEQ}' column for encode")
+        validate_feature_keys(features)
+        _check_handle_failure(on_failure)
+        ut.check_bool(name="return_df", val=return_df)
+        # Group requested features by owning backend, preserving order.
+        by_method: Dict[str, List[str]] = {}
+        for f in features:
+            by_method.setdefault(REGISTRY[f]["method"], []).append(f)
+        # Router-level folder checks (name the offending features).
+        if ENCODER_PDB in by_method and pdb_folder is None:
+            raise ValueError(
+                f"'pdb_folder' is required to encode features "
+                f"{by_method[ENCODER_PDB]} (routed to encode_pdb)")
+        if ENCODER_PAE in by_method and pae_folder is None:
+            raise ValueError(
+                f"'pae_folder' is required to encode features "
+                f"{by_method[ENCODER_PAE]} (routed to encode_pae)")
+        if (ENCODER_DOMAINS in by_method and domain_folder is None
+                and _COL_CHOPPING not in df_seq.columns):
+            raise ValueError(
+                f"'domain_folder' is required to encode features "
+                f"{by_method[ENCODER_DOMAINS]} (routed to encode_domains), "
+                f"unless 'df_seq' already carries a 'chopping' column")
+        # Dispatch each backend on its feature subset; keep per-source status.
+        sub_dicts: Dict[str, Dict[str, np.ndarray]] = {}
+        entries_in_order = df_seq[ut.COL_ENTRY].tolist()
+        ok_by_entry: Dict[str, bool] = {e: True for e in entries_in_order}
+        for method, feats in by_method.items():
+            if method == ENCODER_DSSP:
+                d, df_sub = self.encode_dssp(
+                    df_seq=df_seq, pdb_folder=pdb_folder, features=feats,
+                    ss_mode=ss_mode, gap_handling=gap_handling,
+                    on_failure=on_failure, return_df=True)
+                ok_col = "encode_dssp_ok"
+            elif method == ENCODER_PDB:
+                d, df_sub = self.encode_pdb(
+                    df_seq=df_seq, pdb_folder=pdb_folder, features=feats,
+                    plddt_disorder_threshold=plddt_disorder_threshold,
+                    on_failure=on_failure, return_df=True)
+                ok_col = _COL_PDB_OK
+            elif method == ENCODER_PAE:
+                d, df_sub = self.encode_pae(
+                    df_seq=df_seq, pae_folder=pae_folder, features=feats,
+                    local_window=local_window, pae_band_edges=pae_band_edges,
+                    on_failure=on_failure, return_df=True)
+                ok_col = "pae_ok"
+            else:  # ENCODER_DOMAINS
+                d, df_sub = self.encode_domains(
+                    df_seq=df_seq, domain_folder=domain_folder,
+                    features=feats, on_failure=on_failure, return_df=True)
+                ok_col = _COL_DOMAIN_OK
+            sub_dicts[method] = d
+            if ok_col in df_sub.columns:
+                for e, ok in zip(df_sub[ut.COL_ENTRY].tolist(),
+                                 df_sub[ok_col].tolist()):
+                    ok_by_entry[e] = ok_by_entry.get(e, True) and bool(ok)
+        # Keep entries present in every routed sub-dict ('drop' may prune).
+        kept = [e for e in entries_in_order
+                if all(e in d for d in sub_dicts.values())]
+        # Reassemble each entry in the ORIGINAL feature order by slicing each
+        # sub-dict's D-axis back into per-feature blocks.
+        dim_of = {f: REGISTRY[f]["num_dims"] for f in features}
+        offset_of: Dict[str, int] = {}
+        for method, feats in by_method.items():
+            col = 0
+            for f in feats:
+                offset_of[f] = col
+                col += dim_of[f]
+        dict_num: Dict[str, np.ndarray] = {}
+        for e in kept:
+            blocks = []
+            for f in features:
+                arr = sub_dicts[REGISTRY[f]["method"]][e]
+                c0 = offset_of[f]
+                blocks.append(arr[:, c0:c0 + dim_of[f]])
+            dict_num[e] = (np.concatenate(blocks, axis=1)
+                           if len(blocks) > 1 else blocks[0])
+        if not return_df:
+            return dict_num
+        df_out = df_seq[df_seq[ut.COL_ENTRY].isin(kept)].reset_index(
+            drop=True).copy()
+        df_out["encode_ok"] = [ok_by_entry.get(e, True)
+                               for e in df_out[ut.COL_ENTRY].tolist()]
+        return dict_num, df_out
 
     # ------------------------------------------------------------------
     # build_scales + build_cat

--- a/docs/source/index/release_notes.rst
+++ b/docs/source/index/release_notes.rst
@@ -29,8 +29,14 @@ Added
   new ``[embed]`` extra isolates the heavy ``torch`` / ``transformers`` dependencies.
 - :class:`~aaanalysis.StructurePreprocessor` (``[pro]``): Converts PDB / CIF / AlphaFold files (and PAE
   sidecars) into ``[0, 1]``-normalized per-residue tensors (``get_dssp``, ``encode_dssp``,
-  ``encode_pdb``, ``encode_pae``, ``get_domains``, ``encode_domains``, ``build_scales``,
-  ``build_cat``).
+  ``encode_pdb``, ``encode_pae``, ``get_domains``, ``encode_domains``, ``encode``,
+  ``build_scales``, ``build_cat``). ``encode`` is a single feature/backend router that
+  dispatches each requested feature key to its owning encoder and merges the outputs into
+  one ``dict_num``, so callers no longer need to know the DSSP / PDB / PAE / domain split.
+  Failure isolation is **per-feature**: an unavailable feature (e.g. ``depth`` without the
+  external ``msms`` binary) or a per-entry encoder error now fills only that feature's
+  column(s) with NaN, keeps every other feature, and emits one actionable ``UserWarning``
+  — instead of NaN-ing the whole protein (``on_failure='raise'`` still raises).
 - :class:`~aaanalysis.AnnotationPreprocessor` (``[pro]``): Fetches UniProt (or ingests user / predictor)
   per-residue PTM and functional-site annotations and encodes them into tensors
   (``fetch_uniprot``, ``ingest``, ``register_feature``, ``encode``, ``build_scales``,

--- a/examples/data_handling_pro/strp_encode.ipynb
+++ b/examples/data_handling_pro/strp_encode.ipynb
@@ -1,0 +1,236 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b0c2d3",
+   "metadata": {},
+   "source": [
+    "# `StructurePreprocessor.encode()`\n",
+    "\n",
+    "`encode` is the single feature/backend router: you pass one mixed `features` list and it dispatches each key to its owning encoder (`encode_dssp` / `encode_pdb` / `encode_pae` / `encode_domains`) via the feature registry, then merges the per-source tensors into one `[0, 1]`-normalized `dict_num` whose D-axis follows the requested feature order. You no longer need to know which source a key comes from or call `combine_dict_nums` yourself. Here we mix PDB ATOM features (`bfactor`, `plddt`) with an AlphaFold PAE summary (`pae_row_mean`) using the bundled `AF_TINY` fixture."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b2c1d0e4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T15:09:42.192809Z",
+     "iopub.status.busy": "2026-07-04T15:09:42.192446Z",
+     "iopub.status.idle": "2026-07-04T15:09:43.521906Z",
+     "shell.execute_reply": "2026-07-04T15:09:43.521677Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "merged shape (L, D): (30, 3) -> D follows feats order ['bfactor', 'pae_row_mean', 'plddt']\n"
+     ]
+    }
+   ],
+   "source": [
+    "import warnings\n",
+    "import tempfile, shutil\n",
+    "from pathlib import Path\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import aaanalysis as aa\n",
+    "import aaanalysis.utils as ut\n",
+    "aa.options['verbose'] = False\n",
+    "warnings.filterwarnings('ignore')\n",
+    "\n",
+    "PDB_FIXTURES = Path(aa.__file__).resolve().parent / '_data' / 'pdb_test'\n",
+    "strp = aa.StructurePreprocessor(verbose=False)\n",
+    "df_seq = pd.DataFrame({'entry': ['AF_TINY'],\n",
+    "                       'sequence': ['ACDEFGHIKLMNPQRSTVWYACDEFGHIKL']})\n",
+    "# PAE sidecar under the <entry>.json name the resolver expects.\n",
+    "pae_dir = tempfile.mkdtemp()\n",
+    "shutil.copy(PDB_FIXTURES / 'AF_TINY_pae.json', Path(pae_dir) / 'AF_TINY.json')\n",
+    "\n",
+    "# One call, keys from two different sources, interleaved in any order.\n",
+    "feats = ['bfactor', 'pae_row_mean', 'plddt']\n",
+    "dict_num, df_out = strp.encode(df_seq=df_seq, features=feats,\n",
+    "                              pdb_folder=str(PDB_FIXTURES), pae_folder=pae_dir,\n",
+    "                              return_df=True)\n",
+    "arr = dict_num['AF_TINY']\n",
+    "print('merged shape (L, D):', arr.shape, '-> D follows feats order', feats)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c3d2e1f5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T15:09:43.523042Z",
+     "iopub.status.busy": "2026-07-04T15:09:43.522941Z",
+     "iopub.status.idle": "2026-07-04T15:09:43.547446Z",
+     "shell.execute_reply": "2026-07-04T15:09:43.547251Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DataFrame shape: (1, 3)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "#T_4c72e thead th {\n",
+       "  background-color: white;\n",
+       "  color: black;\n",
+       "}\n",
+       "#T_4c72e tbody tr:nth-child(odd) {\n",
+       "  background-color: #f2f2f2;\n",
+       "}\n",
+       "#T_4c72e tbody tr:nth-child(even) {\n",
+       "  background-color: white;\n",
+       "}\n",
+       "#T_4c72e th {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "#T_4c72e  td {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "</style>\n",
+       "<table id=\"T_4c72e\" style='display:block; max-height: 300px; max-width: 100%; overflow-x: auto; overflow-y: auto;'>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_4c72e_level0_col0\" class=\"col_heading level0 col0\" >entry</th>\n",
+       "      <th id=\"T_4c72e_level0_col1\" class=\"col_heading level0 col1\" >sequence</th>\n",
+       "      <th id=\"T_4c72e_level0_col2\" class=\"col_heading level0 col2\" >encode_ok</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_4c72e_level0_row0\" class=\"row_heading level0 row0\" >1</th>\n",
+       "      <td id=\"T_4c72e_row0_col0\" class=\"data row0 col0\" >AF_TINY</td>\n",
+       "      <td id=\"T_4c72e_row0_col1\" class=\"data row0 col1\" >ACDEFGHIKLMNPQRSTVWYACDEFGHIKL</td>\n",
+       "      <td id=\"T_4c72e_row0_col2\" class=\"data row0 col2\" >True</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# return_df=True echoes df_seq (kept entries) plus a combined 'encode_ok'\n",
+    "# column = AND of every routed backend's entry-level status.\n",
+    "aa.display_df(df_out, n_rows=10, show_shape=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4e3f2a6",
+   "metadata": {},
+   "source": [
+    "**Per-feature failure isolation.** If one feature is unavailable (for example `depth`, which needs the external `msms` binary) or its encoder raises for an entry, only that feature's column(s) are filled with `NaN` while every other feature is kept and the entry is retained; a single `UserWarning` names the isolated feature. This replaces the old behavior where one unavailable feature `NaN`-ed the whole entry. Below, `depth` is isolated (its column is all `NaN`) while `bfactor` and `pae_row_mean` come through intact."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e5f4a3b7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T15:09:43.548468Z",
+     "iopub.status.busy": "2026-07-04T15:09:43.548410Z",
+     "iopub.status.idle": "2026-07-04T15:09:43.552291Z",
+     "shell.execute_reply": "2026-07-04T15:09:43.552098Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       bfactor: all-NaN column? False\n",
+      "         depth: all-NaN column? True\n",
+      "  pae_row_mean: all-NaN column? False\n"
+     ]
+    }
+   ],
+   "source": [
+    "feats2 = ['bfactor', 'depth', 'pae_row_mean']\n",
+    "dn = strp.encode(df_seq=df_seq, features=feats2,\n",
+    "                pdb_folder=str(PDB_FIXTURES), pae_folder=pae_dir)\n",
+    "v = dn['AF_TINY']\n",
+    "for j, key in enumerate(feats2):\n",
+    "    print(f'{key:>14}: all-NaN column? {bool(np.isnan(v[:, j]).all())}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6a5b4c8",
+   "metadata": {},
+   "source": [
+    "**Further parameters.** `StructurePreprocessor.encode` also accepts: `domain_folder` — directory of per-entry chopping files, required when a domain key is requested unless `df_seq` already carries a `chopping` column; `ss_mode` / `gap_handling` — forwarded to `encode_dssp` when a DSSP key is requested; `plddt_disorder_threshold` — forwarded to `encode_pdb` for the `plddt_disorder` key; `local_window` / `pae_band_edges` — forwarded to `encode_pae`; `on_failure` — `'nan'` isolates failures (default), `'drop'` keeps only entries present in every routed source, `'raise'` re-raises; `return_df` — also return the `(dict_num, df_seq_out)` pair."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Further parameters\n",
+    "\n",
+    "`encode()` accepts every backend's option in one call; the router applies each ",
+    "only to the features that need it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Every routing option, passed explicitly (unused ones are ignored per feature).\n",
+    "dict_num2 = strp.encode(\n",
+    "    df_seq=df_seq,\n",
+    "    features=['bfactor', 'plddt', 'pae_row_mean'],\n",
+    "    pdb_folder=str(PDB_FIXTURES),\n",
+    "    pae_folder=pae_dir,\n",
+    "    domain_folder=None,             # only used for domain-derived features\n",
+    "    ss_mode='ss3',                  # DSSP secondary-structure alphabet: 'ss3' | 'ss8'\n",
+    "    gap_handling='pad',             # missing residues: 'pad' (NaN) | 'omit'\n",
+    "    plddt_disorder_threshold=70.0,  # AF pLDDT cutoff for the disorder feature\n",
+    "    local_window=5,                 # residue window for local-window features\n",
+    "    pae_band_edges=(5, 15),         # PAE distance-band edges (near / mid / far)\n",
+    "    on_failure='nan',               # per-feature failure policy: 'nan' | 'drop' | 'raise'\n",
+    ")\n",
+    "print('all routing options applied:', dict_num2['AF_TINY'].shape)"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/unit/data_handling_pro_tests/test_structure_preprocessor_branch.py
+++ b/tests/unit/data_handling_pro_tests/test_structure_preprocessor_branch.py
@@ -283,18 +283,38 @@ class TestDomainIoBranches:
 
 
 class TestEncodePdbDepthNoMsms:
-    """encode_pdb 'depth' dispatch: msms unavailable -> RuntimeError path
-    (the _extras.check_msms_available raise + the L1016 dispatch arm)."""
+    """encode_pdb 'depth' dispatch when msms is unavailable (issue #340).
 
-    def test_depth_raises_when_msms_missing(self):
-        if shutil.which("msms") is not None:
-            pytest.skip("msms present; this exercises the missing-tool arm")
+    Default on_failure='nan' isolates 'depth' to its own NaN column and keeps
+    the other features; on_failure='raise' still raises with an install hint.
+    msms is mocked absent so the behavior is deterministic in any environment.
+    """
+
+    _MODULE = "aaanalysis.data_handling_pro._struct_preproc"
+
+    def test_depth_isolated_when_msms_missing(self):
         td = tempfile.TemporaryDirectory()
         shutil.copy(PDB_FIXTURES / "AF_TINY.pdb", Path(td.name) / "AF_TINY.pdb")
         strp = aa.StructurePreprocessor(verbose=False)
-        with pytest.raises(RuntimeError, match="msms"):
-            strp.encode_pdb(df_seq=_df_af(), pdb_folder=td.name,
-                           features=["depth"])
+        with patch(f"{self._MODULE}.is_msms_available", return_value=False):
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                d = strp.encode_pdb(df_seq=_df_af(), pdb_folder=td.name,
+                                   features=["bfactor", "depth"])
+        assert not np.isnan(d["AF_TINY"][:, 0]).all()   # bfactor kept
+        assert np.isnan(d["AF_TINY"][:, 1]).all()       # depth isolated
+        assert sum("depth" in str(x.message) and "msms" in str(x.message)
+                   for x in w) == 1
+        td.cleanup()
+
+    def test_depth_raises_when_msms_missing_and_on_failure_raise(self):
+        td = tempfile.TemporaryDirectory()
+        shutil.copy(PDB_FIXTURES / "AF_TINY.pdb", Path(td.name) / "AF_TINY.pdb")
+        strp = aa.StructurePreprocessor(verbose=False)
+        with patch(f"{self._MODULE}.is_msms_available", return_value=False):
+            with pytest.raises(RuntimeError, match="msms"):
+                strp.encode_pdb(df_seq=_df_af(), pdb_folder=td.name,
+                               features=["depth"], on_failure="raise")
         td.cleanup()
 
 

--- a/tests/unit/data_handling_pro_tests/test_structure_preprocessor_edges.py
+++ b/tests/unit/data_handling_pro_tests/test_structure_preprocessor_edges.py
@@ -100,22 +100,28 @@ class TestEncodePdbEdges:
         assert any("parse failed" in str(x.message) for x in w)
         assert not bool(df_out.iloc[0, -1])  # *_ok column False
 
-    def test_encoder_fail_sets_not_ok(self, tmp_path):
+    def test_encoder_fail_isolates_feature(self, tmp_path):
+        # Per-feature isolation (issue #340): a per-encoder RuntimeError NaNs
+        # only that feature's column and keeps the entry (pdb_ok stays True),
+        # emitting one UserWarning naming the feature.
+        import numpy as np
         (tmp_path / "P1.pdb").write_text("x")
         strp = aa.StructurePreprocessor(verbose=False)
         # The shared per-entry chain pick runs in the frontend before the
         # encoders, so stub it (the dummy structure is never really walked);
-        # the encoder still raises to exercise the row-degrade path.
+        # the encoder still raises to exercise the feature-isolation path.
         with patch(f"{MODULE}.load_structure", return_value=object()), \
              patch(f"{MODULE}._resolve_best_chain",
                    return_value=(None, None, None, 0.0)), \
              patch(f"{MODULE}.encode_bfactor", side_effect=RuntimeError("enc boom")):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
-                _, df_out = strp.encode_pdb(df_seq=_df_one(), pdb_folder=str(tmp_path),
+                d, df_out = strp.encode_pdb(df_seq=_df_one(), pdb_folder=str(tmp_path),
                                            features=["bfactor"], return_df=True)
-        assert any("encoder" in str(x.message) for x in w)
-        assert not bool(df_out.iloc[0, -1])
+        assert any("encoder" in str(x.message) and "bfactor" in str(x.message)
+                   for x in w)
+        assert bool(df_out.iloc[0, -1])  # pdb_ok stays True (entry kept)
+        assert np.isnan(d["P1"]).all()   # the isolated feature column is NaN
 
     def test_on_failure_raise(self, tmp_path):
         # no PDB file -> failure -> raise (a 'not found' warning fires first)
@@ -203,16 +209,21 @@ class TestEncodePaeSuccess:
                        features=["pae_row_mean"])
         assert "AF_TINY" in capsys.readouterr().out
 
-    def test_encoder_fail_sets_not_ok(self, tmp_path):
+    def test_encoder_fail_isolates_feature(self, tmp_path):
+        # Per-feature isolation (issue #340): NaN only the failing feature,
+        # keep the entry (pae_ok stays True), one warning naming the feature.
+        import numpy as np
         df = _pae_df(tmp_path)
         strp = aa.StructurePreprocessor(verbose=False)
         with patch(f"{MODULE}.encode_pae_row_mean", side_effect=RuntimeError("boom")):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
-                _, df_out = strp.encode_pae(df_seq=df, pae_folder=str(tmp_path),
+                d, df_out = strp.encode_pae(df_seq=df, pae_folder=str(tmp_path),
                                            features=["pae_row_mean"], return_df=True)
-        assert any("encoder" in str(x.message) for x in w)
-        assert not bool(df_out.iloc[0, -1])
+        assert any("encoder" in str(x.message) and "pae_row_mean" in str(x.message)
+                   for x in w)
+        assert bool(df_out.iloc[0, -1])  # pae_ok stays True (entry kept)
+        assert np.isnan(d["AF_TINY"]).all()
 
 
 class TestEncodeDomainsInline:
@@ -256,14 +267,19 @@ class TestEncodeDomainsInline:
         assert any("parse failed" in str(x.message) for x in w)
         assert not bool(df_out.iloc[0, -1])
 
-    def test_encoder_fail_sets_not_ok(self):
+    def test_encoder_fail_isolates_feature(self):
+        # Per-feature isolation (issue #340): NaN only the failing feature,
+        # keep the entry (domain_ok stays True), one warning naming it.
+        import numpy as np
         strp = aa.StructurePreprocessor(verbose=False)
         with patch(f"{MODULE}.encode_domain_boundary",
                    side_effect=RuntimeError("dom boom")):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
-                _, df_out = strp.encode_domains(df_seq=self._df(),
+                d, df_out = strp.encode_domains(df_seq=self._df(),
                                                features=["domain_boundary"],
                                                return_df=True)
-        assert any("encoder" in str(x.message) for x in w)
-        assert not bool(df_out.iloc[0, -1])
+        assert any("encoder" in str(x.message) and "domain_boundary" in str(x.message)
+                   for x in w)
+        assert bool(df_out.iloc[0, -1])  # domain_ok stays True (entry kept)
+        assert np.isnan(d["P1"]).all()

--- a/tests/unit/data_handling_pro_tests/test_structure_preprocessor_encode_pdb.py
+++ b/tests/unit/data_handling_pro_tests/test_structure_preprocessor_encode_pdb.py
@@ -98,15 +98,25 @@ class TestStpEncodePdb:
                            features=["bfactor"])
 
     def test_invalid_depth_without_msms(self):
-        # When msms is missing, requesting 'depth' must raise.
+        # Per-feature isolation (issue #340): with msms missing and default
+        # on_failure='nan', requesting 'depth' NaN-fills only that feature and
+        # warns once; on_failure='raise' still raises.
+        MODULE = "aaanalysis.data_handling_pro._struct_preproc"
         strp = aa.StructurePreprocessor(verbose=False)
-        if shutil.which("msms") is None:
+        with patch(f"{MODULE}.is_msms_available", return_value=False):
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                d = strp.encode_pdb(df_seq=_df_one(),
+                                   pdb_folder=str(PDB_FIXTURES),
+                                   features=["bfactor", "depth"])
+            assert not np.isnan(d["P1"][:, 0]).all()   # bfactor kept
+            assert np.isnan(d["P1"][:, 1]).all()       # depth isolated
+            assert sum("depth" in str(x.message) and "msms" in str(x.message)
+                       for x in w) == 1
             with pytest.raises(RuntimeError, match="msms"):
                 strp.encode_pdb(df_seq=_df_one(),
                                pdb_folder=str(PDB_FIXTURES),
-                               features=["depth"])
-        else:
-            pytest.skip("msms available — skip absence assertion")
+                               features=["depth"], on_failure="raise")
 
     def test_invalid_unsafe_entry(self):
         df = pd.DataFrame({"entry": ["../etc"], "sequence": ["ACDE"]})

--- a/tests/unit/data_handling_pro_tests/test_structure_preprocessor_encode_router.py
+++ b/tests/unit/data_handling_pro_tests/test_structure_preprocessor_encode_router.py
@@ -1,0 +1,315 @@
+"""Tests for StructurePreprocessor per-feature failure isolation and the
+``encode`` feature/backend router (issue #340).
+
+The isolation tests MOCK per-feature encoders / ``is_msms_available`` so they
+run deterministically without the real ``mkdssp`` / ``msms`` binaries. The
+router-dispatch tests MOCK the four ``encode_*`` methods to assert each feature
+key is routed to its owning backend; a separate end-to-end test uses the
+bundled ``AF_TINY`` PDB + PAE fixtures (binary-free) to check the merged
+output matches manual composition.
+"""
+import shutil
+import tempfile
+import warnings
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import aaanalysis as aa
+from aaanalysis.data_handling_pro._backend.struct_preproc.feature_registry import (
+    REGISTRY)
+
+aa.options["verbose"] = False
+
+MODULE = "aaanalysis.data_handling_pro._struct_preproc"
+PDB_FIXTURES = Path(aa.__file__).resolve().parent / "_data" / "pdb_test"
+AF_SEQ = "ACDEFGHIKLMNPQRSTVWYACDEFGHIKL"   # AF_TINY (L=30)
+
+
+# I Helper Functions
+def _df_af():
+    return pd.DataFrame({"entry": ["AF_TINY"], "sequence": [AF_SEQ]})
+
+
+def _pae_dir():
+    """Temp dir holding the bundled AF_TINY PAE sidecar as <entry>.json."""
+    d = tempfile.mkdtemp()
+    shutil.copy(PDB_FIXTURES / "AF_TINY_pae.json", Path(d) / "AF_TINY.json")
+    return d
+
+
+def _const_sub(df_seq, feats, val):
+    """A valid ``(dict_num, df)`` sub-encoder result filled with ``val``.
+
+    Used to stand in for a real ``encode_*`` method so the router's dispatch +
+    reassembly can be checked without touching any structure files.
+    """
+    total = sum(REGISTRY[f]["num_dims"] for f in feats)
+    d = {}
+    for e, s in zip(df_seq["entry"].tolist(), df_seq["sequence"].tolist()):
+        d[e] = np.full((len(s), total), float(val), dtype=np.float64)
+    return d, df_seq.copy()
+
+
+# II Test Classes
+class TestEncodePdbDepthIsolation:
+    """encode_pdb 'depth' isolation when msms is unavailable (mocked)."""
+
+    def test_depth_isolated_nan_default(self):
+        strp = aa.StructurePreprocessor(verbose=False)
+        with patch(f"{MODULE}.is_msms_available", return_value=False):
+            with warnings.catch_warnings(record=True) as rec:
+                warnings.simplefilter("always")
+                d = strp.encode_pdb(df_seq=_df_af(), pdb_folder=str(PDB_FIXTURES),
+                                   features=["bfactor", "depth"])
+        v = d["AF_TINY"]
+        assert v.shape == (len(AF_SEQ), 2)
+        assert not np.isnan(v[:, 0]).all()      # bfactor kept
+        assert np.isnan(v[:, 1]).all()          # depth isolated to NaN
+
+    def test_depth_isolation_warns_exactly_once(self):
+        strp = aa.StructurePreprocessor(verbose=False)
+        with patch(f"{MODULE}.is_msms_available", return_value=False):
+            with warnings.catch_warnings(record=True) as rec:
+                warnings.simplefilter("always")
+                strp.encode_pdb(df_seq=_df_af(), pdb_folder=str(PDB_FIXTURES),
+                               features=["bfactor", "depth"])
+        depth_warns = [x for x in rec if issubclass(x.category, UserWarning)
+                       and "depth" in str(x.message) and "msms" in str(x.message)]
+        assert len(depth_warns) == 1
+        assert "other features kept" in str(depth_warns[0].message)
+
+    def test_depth_isolation_warns_once_across_two_entries(self):
+        # Two entries both missing depth -> still exactly ONE warning.
+        df = pd.DataFrame({"entry": ["AF_TINY", "P1"],
+                           "sequence": [AF_SEQ, "ACDEFGHIKLMNPQRS"]})
+        strp = aa.StructurePreprocessor(verbose=False)
+        with patch(f"{MODULE}.is_msms_available", return_value=False):
+            with warnings.catch_warnings(record=True) as rec:
+                warnings.simplefilter("always")
+                d = strp.encode_pdb(df_seq=df, pdb_folder=str(PDB_FIXTURES),
+                                   features=["bfactor", "depth"])
+        depth_warns = [x for x in rec if "depth" in str(x.message)
+                       and "msms" in str(x.message)]
+        assert len(depth_warns) == 1
+        assert np.isnan(d["AF_TINY"][:, 1]).all()
+        assert np.isnan(d["P1"][:, 1]).all()
+
+    def test_depth_isolation_keeps_pdb_ok_true(self):
+        strp = aa.StructurePreprocessor(verbose=False)
+        with patch(f"{MODULE}.is_msms_available", return_value=False):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                _, df_out = strp.encode_pdb(return_df=True, df_seq=_df_af(),
+                                           pdb_folder=str(PDB_FIXTURES),
+                                           features=["bfactor", "depth"])
+        assert bool(df_out["pdb_ok"].iloc[0]) is True
+
+    def test_depth_only_all_nan_but_no_raise(self):
+        # depth is the only feature -> whole tensor NaN, but still no raise.
+        strp = aa.StructurePreprocessor(verbose=False)
+        with patch(f"{MODULE}.is_msms_available", return_value=False):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                d = strp.encode_pdb(df_seq=_df_af(), pdb_folder=str(PDB_FIXTURES),
+                                   features=["depth"])
+        assert d["AF_TINY"].shape == (len(AF_SEQ), 1)
+        assert np.isnan(d["AF_TINY"]).all()
+
+    def test_depth_raises_under_on_failure_raise(self):
+        strp = aa.StructurePreprocessor(verbose=False)
+        with patch(f"{MODULE}.is_msms_available", return_value=False):
+            with pytest.raises(RuntimeError, match="msms"):
+                strp.encode_pdb(df_seq=_df_af(), pdb_folder=str(PDB_FIXTURES),
+                               features=["bfactor", "depth"], on_failure="raise")
+
+    def test_happy_path_when_msms_present_unchanged(self):
+        # msms mocked available AND encode_depth mocked to a finite block:
+        # the feature composes normally, no isolation warning.
+        block = (np.full((len(AF_SEQ), 1), 0.3), 1.0)
+        with patch(f"{MODULE}.is_msms_available", return_value=True), \
+             patch(f"{MODULE}.encode_depth", return_value=block):
+            strp = aa.StructurePreprocessor(verbose=False)
+            with warnings.catch_warnings(record=True) as rec:
+                warnings.simplefilter("always")
+                d = strp.encode_pdb(df_seq=_df_af(), pdb_folder=str(PDB_FIXTURES),
+                                   features=["bfactor", "depth"])
+        assert not np.isnan(d["AF_TINY"][:, 1]).any()   # depth finite
+        assert not any("unavailable" in str(x.message) for x in rec)
+
+
+class TestEncoderFailureIsolation:
+    """A per-entry encoder RuntimeError NaNs only its own feature column."""
+
+    def test_pdb_encoder_failure_isolated(self):
+        strp = aa.StructurePreprocessor(verbose=False)
+        with patch(f"{MODULE}.encode_contact_count_8A",
+                   side_effect=RuntimeError("synthetic")):
+            with warnings.catch_warnings(record=True) as rec:
+                warnings.simplefilter("always")
+                d = strp.encode_pdb(df_seq=_df_af(), pdb_folder=str(PDB_FIXTURES),
+                                   features=["plddt", "contact_count_8A"])
+        v = d["AF_TINY"]
+        assert not np.isnan(v[:, 0]).all()    # plddt kept
+        assert np.isnan(v[:, 1]).all()        # contact_count_8A isolated
+        warns = [x for x in rec if "contact_count_8A" in str(x.message)]
+        assert len(warns) == 1
+
+    def test_pdb_encoder_failure_raises_under_raise(self):
+        strp = aa.StructurePreprocessor(verbose=False)
+        with patch(f"{MODULE}.encode_contact_count_8A",
+                   side_effect=RuntimeError("synthetic")):
+            with pytest.raises(RuntimeError, match="synthetic"):
+                strp.encode_pdb(df_seq=_df_af(), pdb_folder=str(PDB_FIXTURES),
+                               features=["contact_count_8A"], on_failure="raise")
+
+    def test_pae_encoder_failure_isolated(self):
+        pae = _pae_dir()
+        strp = aa.StructurePreprocessor(verbose=False)
+        with patch(f"{MODULE}.encode_pae_asymmetry",
+                   side_effect=RuntimeError("synthetic")):
+            with warnings.catch_warnings(record=True) as rec:
+                warnings.simplefilter("always")
+                d = strp.encode_pae(df_seq=_df_af(), pae_folder=pae,
+                                   features=["pae_row_mean", "pae_asymmetry"])
+        v = d["AF_TINY"]
+        assert not np.isnan(v[:, 0]).all()    # pae_row_mean kept
+        assert np.isnan(v[:, 1]).all()        # pae_asymmetry isolated
+
+
+class TestEncodeRouterDispatch:
+    """encode() routes each feature key to its owning backend."""
+
+    def test_routes_each_key_to_right_backend(self):
+        recorded = {}
+
+        def _mk(name, val):
+            def _fake(self, df_seq, *a, features, **kw):
+                recorded[name] = list(features)
+                return _const_sub(df_seq, features, val)
+            return _fake
+
+        feats = ["bfactor", "ss3", "pae_row_mean", "domain_boundary"]
+        with patch.object(aa.StructurePreprocessor, "encode_pdb", _mk("pdb", 1.0)), \
+             patch.object(aa.StructurePreprocessor, "encode_dssp", _mk("dssp", 2.0)), \
+             patch.object(aa.StructurePreprocessor, "encode_pae", _mk("pae", 3.0)), \
+             patch.object(aa.StructurePreprocessor, "encode_domains",
+                          _mk("domains", 4.0)):
+            strp = aa.StructurePreprocessor(verbose=False)
+            d = strp.encode(df_seq=_df_af(), features=feats,
+                           pdb_folder="x", pae_folder="y", domain_folder="z")
+        assert recorded == {"pdb": ["bfactor"], "dssp": ["ss3"],
+                            "pae": ["pae_row_mean"], "domains": ["domain_boundary"]}
+        # Merged in requested order: bfactor(1) | ss3 x3 (2) | pae(3) | domain(4)
+        v = d["AF_TINY"]
+        assert v.shape == (len(AF_SEQ), 6)
+        np.testing.assert_array_equal(v[0], [1., 2., 2., 2., 3., 4.])
+
+    def test_router_matches_manual_composition(self):
+        # Binary-free end-to-end: bfactor+plddt (pdb) interleaved with
+        # pae_row_mean (pae) must equal manual per-encoder composition.
+        pae = _pae_dir()
+        strp = aa.StructurePreprocessor(verbose=False)
+        feats = ["bfactor", "pae_row_mean", "plddt"]
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            dn = strp.encode(df_seq=_df_af(), features=feats,
+                            pdb_folder=str(PDB_FIXTURES), pae_folder=pae)
+            d_pdb = strp.encode_pdb(df_seq=_df_af(), pdb_folder=str(PDB_FIXTURES),
+                                   features=["bfactor", "plddt"])
+            d_pae = strp.encode_pae(df_seq=_df_af(), pae_folder=pae,
+                                   features=["pae_row_mean"])
+        ref = np.concatenate([d_pdb["AF_TINY"][:, 0:1],
+                              d_pae["AF_TINY"][:, 0:1],
+                              d_pdb["AF_TINY"][:, 1:2]], axis=1)
+        np.testing.assert_allclose(dn["AF_TINY"], ref, equal_nan=True)
+
+    def test_router_return_df_has_encode_ok(self):
+        pae = _pae_dir()
+        strp = aa.StructurePreprocessor(verbose=False)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            dn, df_out = strp.encode(df_seq=_df_af(),
+                                    features=["bfactor", "pae_row_mean"],
+                                    pdb_folder=str(PDB_FIXTURES),
+                                    pae_folder=pae, return_df=True)
+        assert "encode_ok" in df_out.columns
+        assert bool(df_out["encode_ok"].iloc[0]) is True
+        assert df_out["entry"].tolist() == ["AF_TINY"]
+
+    def test_router_drop_keeps_intersection(self, tmp_path):
+        # AF_TINY has both pdb+pae; GONE has neither -> dropped from both.
+        (tmp_path / "AF_TINY.pdb").write_text(
+            (PDB_FIXTURES / "AF_TINY.pdb").read_text())
+        pae = _pae_dir()
+        df = pd.DataFrame({"entry": ["AF_TINY", "GONE"],
+                           "sequence": [AF_SEQ, "ACDE"]})
+        strp = aa.StructurePreprocessor(verbose=False)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            dn, df_out = strp.encode(df_seq=df,
+                                    features=["bfactor", "pae_row_mean"],
+                                    pdb_folder=str(tmp_path), pae_folder=pae,
+                                    on_failure="drop", return_df=True)
+        assert set(dn.keys()) == {"AF_TINY"}
+        assert df_out["entry"].tolist() == ["AF_TINY"]
+
+    def test_router_isolates_depth_across_backends(self):
+        # depth (pdb, msms-gated) mixed with a pae key: depth isolates, the
+        # rest are kept.
+        pae = _pae_dir()
+        strp = aa.StructurePreprocessor(verbose=False)
+        with patch(f"{MODULE}.is_msms_available", return_value=False):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                dn = strp.encode(df_seq=_df_af(),
+                                features=["bfactor", "depth", "pae_row_mean"],
+                                pdb_folder=str(PDB_FIXTURES), pae_folder=pae)
+        v = dn["AF_TINY"]
+        assert v.shape == (len(AF_SEQ), 3)
+        assert not np.isnan(v[:, 0]).all()   # bfactor kept
+        assert np.isnan(v[:, 1]).all()       # depth isolated
+        assert not np.isnan(v[:, 2]).all()   # pae_row_mean kept
+
+    # ----- negatives -----
+    def test_router_missing_pae_folder(self):
+        strp = aa.StructurePreprocessor(verbose=False)
+        with pytest.raises(ValueError, match="pae_folder"):
+            strp.encode(df_seq=_df_af(), features=["pae_row_mean"],
+                       pdb_folder=str(PDB_FIXTURES))
+
+    def test_router_missing_pdb_folder(self):
+        strp = aa.StructurePreprocessor(verbose=False)
+        with pytest.raises(ValueError, match="pdb_folder"):
+            strp.encode(df_seq=_df_af(), features=["bfactor"])
+
+    def test_router_missing_domain_folder(self):
+        strp = aa.StructurePreprocessor(verbose=False)
+        with pytest.raises(ValueError, match="domain_folder"):
+            strp.encode(df_seq=_df_af(), features=["domain_boundary"])
+
+    def test_router_unknown_feature(self):
+        strp = aa.StructurePreprocessor(verbose=False)
+        with pytest.raises(ValueError):
+            strp.encode(df_seq=_df_af(), features=["mystery"],
+                       pdb_folder=str(PDB_FIXTURES))
+
+    def test_router_empty_features(self):
+        strp = aa.StructurePreprocessor(verbose=False)
+        with pytest.raises(ValueError):
+            strp.encode(df_seq=_df_af(), features=[],
+                       pdb_folder=str(PDB_FIXTURES))
+
+    def test_router_domain_inline_chopping_no_folder(self):
+        # domain features route without a domain_folder when df_seq carries
+        # an inline 'chopping' column.
+        df = _df_af().copy()
+        df["chopping"] = ["1-10,11-30"]
+        strp = aa.StructurePreprocessor(verbose=False)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            dn = strp.encode(df_seq=df, features=["domain_boundary"])
+        assert dn["AF_TINY"].shape == (len(AF_SEQ), 1)


### PR DESCRIPTION
Closes #340 (part of usability epic #336). Two sharp edges hit running `StructurePreprocessor` on ~400 PDB chains.

## Fixes
1. **Silent whole-entry failure → per-feature isolation.** Previously, with `on_failure="nan"`, one unavailable feature (e.g. `depth`, which needs the external `msms` binary) NaN'd the **entire entry** — yielding a silent "0/1000 windows mapped" with no warning. Now only the failing feature's column is NaN'd, the entry is kept (`*_ok` stays True), and **one warning names the feature + cause**.
2. **Opaque dssp/pdb backend split → `encode()` router.** New public `StructurePreprocessor.encode(df_seq, *, features=[…], on_failure=…, return_df=…)` (`.. versionadded:: 1.1.0`) takes a **mixed feature list** and routes each key to the right backend (`encode_dssp`/`encode_pdb`/domain), hiding the cryptic "use the matching method" error. It **complements** the existing per-backend methods, not replaces them.

## Notes
- Keyword-only signature + `Literal` options + `on_failure` policy consistent with the other `encode_*` methods.
- New example notebook `strp_encode.ipynb`; 21 new router tests + updated edge/branch/pdb tests (all green locally: 155 passed).
- Rebased onto the post-rename master and reconciled to the new `strp` abbreviation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)