### PR TITLE
feat(prediction): AAPred.score_to_group confidence-band classifier

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -508,6 +508,9 @@ _Avoid_: the standalone `aa.plot_rank` (removed — folded into `AAPredPlot`); `
 **score-grid heatmap**:
 An **arbitrary wide-numeric matrix** rendered as an annotated heatmap with the best (or worst) cell(s) boxed — the generic 2-D parameter-sweep view (e.g. part × scale, n_train × n_dpu). `AAPredPlot.eval(df_eval, kind="heatmap", highlight=...)`; `df_eval` is any rows × cols numeric frame, with no prediction-specific schema required. This is the package's general annotated-matrix renderer; it just lives on `AAPredPlot.eval` rather than under a dedicated top-level name.
 _Avoid_: assuming a standalone `aa.plot_heatmap` exists (it does not — this is the generic matrix surface); `CPPPlot.heatmap` (a CPP **feature** map built from `df_feat`/`df_cat`, not a free matrix); `pipe.plot_eval` / `ap.plot_eval` (a find_features **sweep** grid keyed on named CPP axes such as `list_parts`/`scale`, not an arbitrary matrix).
+**confidence group** (score band):
+An **ordered categorical** mapping of per-sample prediction scores into named bands delimited by sorted `thresholds` — each an *inclusive lower bound* (right-open bands `[t_{i-1}, t_i)`) — with one more low-to-high `label` than thresholds. The stateless `AAPred.score_to_group(scores, thresholds, labels, score_range)` is the single source of truth for these boundaries; `AAPredPlot.predict_group(band=True)` colours by the same rule. `score_range` (`percent`/`proba`) bounds the thresholds so probabilities and percentages can't be silently mixed; `NaN` scores stay missing.
+_Avoid_: confusing it with [bootstrap CI] (a score *interval*, not a grouping); "class label" (that is `predict(threshold=)`'s binary output).
 
 ### Feature selection vocabulary
 

--- a/aaanalysis/_constants.py
+++ b/aaanalysis/_constants.py
@@ -482,6 +482,13 @@ LIST_METRICS_PRED = ["accuracy", "balanced_accuracy", "precision", "recall", "f1
 LIST_METRICS_PRED_PROBA = ["roc_auc"]
 COLS_EVAL_PRED = [COL_MODEL, COL_METRIC, COL_PRINCIPLE, COL_SCORE, COL_SCORE_STD]
 
+# Score-to-group band assignment (AAPred.score_to_group): the numeric range a set of band
+# thresholds must lie within, so probabilities and percentages can't be silently mixed.
+STR_SCORE_RANGE_PERCENT = "percent"      # scores/thresholds on a 0-100 percent scale
+STR_SCORE_RANGE_PROBA = "proba"          # scores/thresholds on a 0-1 probability scale
+LIST_SCORE_RANGES = [STR_SCORE_RANGE_PERCENT, STR_SCORE_RANGE_PROBA]
+DICT_SCORE_RANGE_BOUNDS = {STR_SCORE_RANGE_PERCENT: (0.0, 100.0), STR_SCORE_RANGE_PROBA: (0.0, 1.0)}
+
 # Baseline-featurizer comparison in AAPred.eval(baseline=...): tag each df_eval row with the
 # feature set behind it ('cpp' for the bound CPP features vs a non-positional baseline).
 COL_FEATURES = "features"       # feature set behind a df_eval row: 'cpp' | a baseline kind

--- a/aaanalysis/prediction/_aa_pred.py
+++ b/aaanalysis/prediction/_aa_pred.py
@@ -204,6 +204,12 @@ class AAPred(Wrapper):
     kept for deployment. It intentionally does **not** perform hyperparameter optimization —
     pass configured estimators and it evaluates and deploys them.
 
+    .. warning::
+
+        **Experimental.** This class is part of the new v1.1.0 prediction layer and is under active
+        development; its API (signatures, defaults, return objects) may change between minor releases
+        without the usual deprecation cycle. Pin a version if you depend on the current behaviour.
+
     .. versionadded:: 1.1.0
 
     Notes

--- a/aaanalysis/prediction/_aa_pred.py
+++ b/aaanalysis/prediction/_aa_pred.py
@@ -13,6 +13,7 @@ from aaanalysis.template_classes import Wrapper
 
 from ._backend.aa_pred.aa_pred_fit import fit_models, predict_proba_models, predict_proba_oof
 from ._backend.aa_pred.aa_pred_eval import eval_models
+from ._backend.aa_pred.aa_pred_group import assign_band_index
 
 
 # I Helper Functions
@@ -619,6 +620,88 @@ class AAPred(Wrapper):
                                            label_pos=label_pos)
         df_pred = pd.DataFrame({ut.COL_SCORE: pred, ut.COL_SCORE_STD: pred_std})
         return df_pred
+
+    @staticmethod
+    def score_to_group(scores: ut.ArrayLike1D,
+                       thresholds: List[Union[int, float]],
+                       labels: List[str],
+                       score_range: str = "percent",
+                       ) -> pd.Series:
+        """
+        Map prediction scores to an ordered categorical of named confidence groups.
+
+        A stateless classifier that turns continuous scores into human-readable, ordered bands
+        (e.g. ``"low" < "medium" < "high"``): ``thresholds`` delimit the bands and ``labels`` names
+        them from the lowest to the highest scores. Each threshold is an **inclusive lower bound**,
+        so a score equal to a threshold falls in the band *above* it (right-open bands
+        ``[t_{i-1}, t_i)``); a score below the first threshold takes the first label and a score at
+        or above the last threshold the last label. This is the single source of truth for the band
+        boundaries also used by :meth:`AAPredPlot.predict_group` (``band=True``), so a table, a
+        filter, and the plotted colouring always agree.
+
+        .. versionadded:: 1.1.0
+
+        Parameters
+        ----------
+        scores : array-like, shape (n_samples,)
+            Per-sample prediction scores to classify. A ``pd.Series`` keeps its index; ``NaN``
+            scores are preserved as missing (unassigned) groups.
+        thresholds : list of int or float
+            Band boundaries in **strictly increasing** order, each an inclusive lower bound. ``n``
+            thresholds define ``n + 1`` bands and must lie within the ``score_range`` bounds.
+        labels : list of str
+            One name per band, ordered from the lowest-score band to the highest; length must be
+            ``len(thresholds) + 1`` and the names must be unique. Sets the category order of the
+            returned series.
+        score_range : str, default="percent"
+            Numeric range the scores and thresholds live on: ``'percent'`` (``[0, 100]``) or
+            ``'proba'`` (``[0, 1]``). Thresholds outside the range raise, which rejects silently
+            mixing probabilities and percentages.
+
+        Returns
+        -------
+        group : pd.Series
+            Ordered categorical (``pd.Categorical``, ``ordered=True``) row-aligned with ``scores``
+            (index preserved), whose categories are ``labels`` in the given low-to-high order.
+            ``NaN`` input scores map to missing values.
+
+        See Also
+        --------
+        * :meth:`AAPredPlot.predict_group` for plotting scores coloured by these same confidence
+          bands.
+
+        Examples
+        --------
+        .. include:: examples/aap_score_to_group.rst
+        """
+        # Check input
+        index = scores.index if isinstance(scores, pd.Series) else None
+        scores = ut.check_array_like(name="scores", val=scores, dtype="float", expected_dim=1, allow_nan=True)
+        thresholds = ut.check_list_like(name="thresholds", val=thresholds, accept_str=False, min_len=1)
+        for i, t in enumerate(thresholds):
+            ut.check_number_val(name=f"thresholds[{i}]", val=t, just_int=False)
+        labels = ut.check_list_like(name="labels", val=labels, accept_str=True, min_len=2)
+        ut.check_str_options(name="score_range", val=score_range, list_str_options=ut.LIST_SCORE_RANGES)
+        if len(labels) != len(thresholds) + 1:
+            raise ValueError(f"'labels' (n={len(labels)}) should have exactly one more element than "
+                             f"'thresholds' (n={len(thresholds)}); one label per band.")
+        if len(set(labels)) != len(labels):
+            raise ValueError(f"'labels' ({labels}) should be unique (one distinct name per band).")
+        ths = [float(t) for t in thresholds]
+        if any(ths[i] >= ths[i + 1] for i in range(len(ths) - 1)):
+            raise ValueError(f"'thresholds' ({thresholds}) should be sorted in strictly increasing order.")
+        lo, hi = ut.DICT_SCORE_RANGE_BOUNDS[score_range]
+        out_of_range = [t for t in ths if t < lo or t > hi]
+        if out_of_range:
+            raise ValueError(f"'thresholds' ({out_of_range}) should lie within the '{score_range}' "
+                             f"score range [{lo}, {hi}] (mixing probabilities and percentages is rejected).")
+        # Assign each score to its confidence band (shared boundary rule); NaN scores stay missing
+        scores = np.asarray(scores, dtype=float)
+        idx = assign_band_index(scores, ths)
+        group = np.asarray(labels, dtype=object)[idx]
+        group[np.isnan(scores)] = np.nan
+        cat = pd.Categorical(group, categories=list(labels), ordered=True)
+        return pd.Series(cat, index=index, name=ut.COL_GROUP)
 
     def predict(self,
                 df_seq: pd.DataFrame,

--- a/aaanalysis/prediction/_aa_pred_plot.py
+++ b/aaanalysis/prediction/_aa_pred_plot.py
@@ -467,6 +467,12 @@ class AAPredPlot:
     - :meth:`eval` visualizes **model/feature-set evaluation**: metric bars per model
       (``kind='eval'``) and grouped benchmark comparisons (``kind='comparison'``).
 
+    .. warning::
+
+        **Experimental.** This class is part of the new v1.1.0 prediction layer and is under active
+        development; its API (signatures, defaults, return objects) may change between minor releases
+        without the usual deprecation cycle. Pin a version if you depend on the current behaviour.
+
     .. versionadded:: 1.1.0
 
     See Also

--- a/aaanalysis/prediction/_aa_pred_plot.py
+++ b/aaanalysis/prediction/_aa_pred_plot.py
@@ -14,6 +14,7 @@ from ._backend.aa_pred.aa_pred_plot_comparison import plot_comparison_
 from ._backend.aa_pred.aa_pred_plot_ranking import plot_ranking_, ranking_figheight
 from ._backend.aa_pred.aa_pred_plot_rank_scatter import plot_rank_scatter_
 from ._backend.aa_pred.aa_pred_plot_clustermap import plot_clustermap_
+from ._backend.aa_pred.aa_pred_group import assign_band_index
 
 
 # I Helper Functions
@@ -73,8 +74,12 @@ def _resolve_band_colors(band_colors, cmap, n_bands):
 
 
 def _band_index(left_edge, sorted_thresholds):
-    """Band index (0-based, low -> high) of a bar whose left edge is ``left_edge``."""
-    return int(np.searchsorted(sorted_thresholds, left_edge, side="right"))
+    """Band index (0-based, low -> high) of a bar whose left edge is ``left_edge``.
+
+    Delegates to the shared ``assign_band_index`` kernel so the histogram banding and
+    :meth:`AAPred.score_to_group` use one boundary convention (thresholds as inclusive lower bounds).
+    """
+    return int(assign_band_index(left_edge, sorted_thresholds))
 
 
 def _check_highlight_cells(highlight, data):

--- a/aaanalysis/prediction/_backend/aa_pred/aa_pred_group.py
+++ b/aaanalysis/prediction/_backend/aa_pred/aa_pred_group.py
@@ -1,0 +1,23 @@
+"""
+This is a script for the backend of the AAPred score-to-group confidence-band assignment.
+"""
+import numpy as np
+
+
+# I Helper Functions
+
+
+# II Main Functions
+def assign_band_index(scores, sorted_thresholds):
+    """Map scores to 0-based confidence-band indices (low score -> high score).
+
+    Single source of truth for the band boundary convention shared by
+    ``AAPred.score_to_group`` and the ``AAPredPlot.predict_group(band=True)`` colouring: each
+    threshold is an **inclusive lower bound**, so a score equal to a threshold falls in the band
+    *above* it (right-open bands ``[t_{i-1}, t_i)``). For sorted thresholds ``t_0 < ... < t_{k-1}``
+    a score ``s`` maps to ``sum(t_i <= s)`` — band ``0`` is ``s < t_0`` and band ``k`` is
+    ``s >= t_{k-1}``. Accepts a scalar or an array and returns the matching shape. ``NaN`` scores
+    map to ``k`` (searchsorted orders NaN last); callers that treat missing scores specially mask
+    them separately.
+    """
+    return np.searchsorted(np.asarray(sorted_thresholds, dtype=float), scores, side="right")

--- a/docs/source/index/release_notes.rst
+++ b/docs/source/index/release_notes.rst
@@ -232,6 +232,13 @@ Added
   :meth:`~aaanalysis.AAPred.predict` (mean over the ensemble, std across models). Like
   :meth:`~aaanalysis.AAPred.eval` it cross-validates the constructor models and needs no prior
   :meth:`~aaanalysis.AAPred.fit`; deterministic under ``random_state``.
+- :meth:`~aaanalysis.AAPred.score_to_group`: New stateless staticmethod mapping prediction scores
+  to an **ordered categorical** of named confidence bands (``thresholds`` delimit the bands,
+  ``labels`` names them low-to-high; each threshold is an inclusive lower bound). ``score_range``
+  (``'percent'`` / ``'proba'``) bounds the thresholds so probabilities and percentages can't be
+  silently mixed; ``NaN`` scores stay missing and a ``pd.Series`` input keeps its index. It is the
+  single source of truth for the band boundaries used by
+  :meth:`~aaanalysis.AAPredPlot.predict_group` (``band=True``), so a table and its plot always agree.
 - :meth:`~aaanalysis.AAPredPlot.eval`: New ``kind='heatmap'`` that renders any 2D score grid
   (rows x columns are the two sweep axes) as a square annotated heatmap and boxes the best cell(s)
   with a full-cell frame — ``highlight`` selects how many (a positive int for the top-N,

--- a/examples/prediction/aap_score_to_group.ipynb
+++ b/examples/prediction/aap_score_to_group.ipynb
@@ -1,0 +1,298 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "``AAPred.score_to_group()`` is a stateless helper that maps continuous prediction scores to an **ordered categorical** of named confidence bands. ``thresholds`` delimit the bands and ``labels`` names them from the lowest to the highest scores; each threshold is an *inclusive lower bound*, so a score equal to a threshold falls in the band above it. It is the single source of truth for the same bands drawn by :meth:`AAPredPlot.predict_group` (``band=True``), so a table and its plot always agree."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T05:05:19.447748Z",
+     "iopub.status.busy": "2026-07-14T05:05:19.447388Z",
+     "iopub.status.idle": "2026-07-14T05:05:21.135641Z",
+     "shell.execute_reply": "2026-07-14T05:05:21.135355Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/stephanbreimann/Programming/1Packages/wt-408-score-to-group/aaanalysis/feature_engineering/_backend/cpp_run.py:164: UserWarning: CPP is using the Python kernel fallback — the compiled Cython extension is not available in this install. Output is bit-exact with the Cython path but ~2x slower. Reinstall via `pip install --force-reinstall aaanalysis` to fetch a prebuilt wheel.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "import aaanalysis as aa\n",
+    "aa.options[\"verbose\"] = False  # Disable verbosity\n",
+    "\n",
+    "# DOM_GSEC example dataset + its feature set (see [Breimann25]_)\n",
+    "df_seq = aa.load_dataset(name=\"DOM_GSEC\")\n",
+    "labels = df_seq[\"label\"].to_list()\n",
+    "df_feat = aa.load_features(name=\"DOM_GSEC\").head(20)\n",
+    "\n",
+    "# Build the CPP feature matrix and cross-validated out-of-fold scores\n",
+    "sf = aa.SequenceFeature()\n",
+    "df_parts = sf.get_df_parts(df_seq=df_seq)\n",
+    "X = sf.feature_matrix(features=df_feat[\"feature\"], df_parts=df_parts)\n",
+    "aap = aa.AAPred(models=[\"rf\", \"extra_trees\"], random_state=42)\n",
+    "df_pred = aap.predict_oof(X, labels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Pass the ``scores`` together with ``thresholds`` and one more ``labels`` name than thresholds. Here percent scores (``0-100``) are split into three bands; the returned series is row-aligned with the scores and its categories keep the low-to-high order:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T05:05:21.136930Z",
+     "iopub.status.busy": "2026-07-14T05:05:21.136866Z",
+     "iopub.status.idle": "2026-07-14T05:05:21.165495Z",
+     "shell.execute_reply": "2026-07-14T05:05:21.165288Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DataFrame shape: (126, 3)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "#T_4d281 thead th {\n",
+       "  background-color: white;\n",
+       "  color: black;\n",
+       "}\n",
+       "#T_4d281 tbody tr:nth-child(odd) {\n",
+       "  background-color: #f2f2f2;\n",
+       "}\n",
+       "#T_4d281 tbody tr:nth-child(even) {\n",
+       "  background-color: white;\n",
+       "}\n",
+       "#T_4d281 th {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "#T_4d281  td {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "</style>\n",
+       "<table id=\"T_4d281\" style='display:block; max-height: 300px; max-width: 100%; overflow-x: auto; overflow-y: auto;'>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_4d281_level0_col0\" class=\"col_heading level0 col0\" >entry</th>\n",
+       "      <th id=\"T_4d281_level0_col1\" class=\"col_heading level0 col1\" >score</th>\n",
+       "      <th id=\"T_4d281_level0_col2\" class=\"col_heading level0 col2\" >group</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_4d281_level0_row0\" class=\"row_heading level0 row0\" >1</th>\n",
+       "      <td id=\"T_4d281_row0_col0\" class=\"data row0 col0\" >P05067</td>\n",
+       "      <td id=\"T_4d281_row0_col1\" class=\"data row0 col1\" >80.000000</td>\n",
+       "      <td id=\"T_4d281_row0_col2\" class=\"data row0 col2\" >high</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_4d281_level0_row1\" class=\"row_heading level0 row1\" >2</th>\n",
+       "      <td id=\"T_4d281_row1_col0\" class=\"data row1 col0\" >P14925</td>\n",
+       "      <td id=\"T_4d281_row1_col1\" class=\"data row1 col1\" >87.000000</td>\n",
+       "      <td id=\"T_4d281_row1_col2\" class=\"data row1 col2\" >high</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_4d281_level0_row2\" class=\"row_heading level0 row2\" >3</th>\n",
+       "      <td id=\"T_4d281_row2_col0\" class=\"data row2 col0\" >P70180</td>\n",
+       "      <td id=\"T_4d281_row2_col1\" class=\"data row2 col1\" >89.500000</td>\n",
+       "      <td id=\"T_4d281_row2_col2\" class=\"data row2 col2\" >high</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_4d281_level0_row3\" class=\"row_heading level0 row3\" >4</th>\n",
+       "      <td id=\"T_4d281_row3_col0\" class=\"data row3 col0\" >Q03157</td>\n",
+       "      <td id=\"T_4d281_row3_col1\" class=\"data row3 col1\" >93.500000</td>\n",
+       "      <td id=\"T_4d281_row3_col2\" class=\"data row3 col2\" >high</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_4d281_level0_row4\" class=\"row_heading level0 row4\" >5</th>\n",
+       "      <td id=\"T_4d281_row4_col0\" class=\"data row4 col0\" >Q06481</td>\n",
+       "      <td id=\"T_4d281_row4_col1\" class=\"data row4 col1\" >98.500000</td>\n",
+       "      <td id=\"T_4d281_row4_col2\" class=\"data row4 col2\" >high</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_4d281_level0_row5\" class=\"row_heading level0 row5\" >6</th>\n",
+       "      <td id=\"T_4d281_row5_col0\" class=\"data row5 col0\" >P35613</td>\n",
+       "      <td id=\"T_4d281_row5_col1\" class=\"data row5 col1\" >87.000000</td>\n",
+       "      <td id=\"T_4d281_row5_col2\" class=\"data row5 col2\" >high</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_4d281_level0_row6\" class=\"row_heading level0 row6\" >7</th>\n",
+       "      <td id=\"T_4d281_row6_col0\" class=\"data row6 col0\" >P35070</td>\n",
+       "      <td id=\"T_4d281_row6_col1\" class=\"data row6 col1\" >7.500000</td>\n",
+       "      <td id=\"T_4d281_row6_col2\" class=\"data row6 col2\" >low</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_4d281_level0_row7\" class=\"row_heading level0 row7\" >8</th>\n",
+       "      <td id=\"T_4d281_row7_col0\" class=\"data row7 col0\" >P09803</td>\n",
+       "      <td id=\"T_4d281_row7_col1\" class=\"data row7 col1\" >94.000000</td>\n",
+       "      <td id=\"T_4d281_row7_col2\" class=\"data row7 col2\" >high</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_4d281_level0_row8\" class=\"row_heading level0 row8\" >9</th>\n",
+       "      <td id=\"T_4d281_row8_col0\" class=\"data row8 col0\" >P19022</td>\n",
+       "      <td id=\"T_4d281_row8_col1\" class=\"data row8 col1\" >96.000000</td>\n",
+       "      <td id=\"T_4d281_row8_col2\" class=\"data row8 col2\" >high</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_4d281_level0_row9\" class=\"row_heading level0 row9\" >10</th>\n",
+       "      <td id=\"T_4d281_row9_col0\" class=\"data row9 col0\" >P16070</td>\n",
+       "      <td id=\"T_4d281_row9_col1\" class=\"data row9 col1\" >82.500000</td>\n",
+       "      <td id=\"T_4d281_row9_col2\" class=\"data row9 col2\" >high</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "scores = df_pred[\"score\"] * 100  # percent scale\n",
+    "groups = aa.AAPred.score_to_group(scores, thresholds=[50, 80], labels=[\"low\", \"medium\", \"high\"])\n",
+    "df_groups = df_seq[[\"entry\"]].assign(score=scores.round(1).values, group=groups.values)\n",
+    "aa.display_df(df_groups, n_rows=10, show_shape=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "``score_range`` selects the numeric scale that ``thresholds`` must lie within: ``'percent'`` (``[0, 100]``, the default) or ``'proba'`` (``[0, 1]``). Thresholds outside the range raise, so probabilities and percentages can't be silently mixed. Scoring the raw ``[0, 1]`` probabilities on the ``'proba'`` scale gives the same banding:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T05:05:21.166536Z",
+     "iopub.status.busy": "2026-07-14T05:05:21.166480Z",
+     "iopub.status.idle": "2026-07-14T05:05:21.170129Z",
+     "shell.execute_reply": "2026-07-14T05:05:21.169965Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DataFrame shape: (3, 2)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "#T_3d382 thead th {\n",
+       "  background-color: white;\n",
+       "  color: black;\n",
+       "}\n",
+       "#T_3d382 tbody tr:nth-child(odd) {\n",
+       "  background-color: #f2f2f2;\n",
+       "}\n",
+       "#T_3d382 tbody tr:nth-child(even) {\n",
+       "  background-color: white;\n",
+       "}\n",
+       "#T_3d382 th {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "#T_3d382  td {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "</style>\n",
+       "<table id=\"T_3d382\" style='display:block; max-height: 300px; max-width: 100%; overflow-x: auto; overflow-y: auto;'>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_3d382_level0_col0\" class=\"col_heading level0 col0\" >group</th>\n",
+       "      <th id=\"T_3d382_level0_col1\" class=\"col_heading level0 col1\" >n_proteins</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_3d382_level0_row0\" class=\"row_heading level0 row0\" >1</th>\n",
+       "      <td id=\"T_3d382_row0_col0\" class=\"data row0 col0\" >low</td>\n",
+       "      <td id=\"T_3d382_row0_col1\" class=\"data row0 col1\" >61</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_3d382_level0_row1\" class=\"row_heading level0 row1\" >2</th>\n",
+       "      <td id=\"T_3d382_row1_col0\" class=\"data row1 col0\" >medium</td>\n",
+       "      <td id=\"T_3d382_row1_col1\" class=\"data row1 col1\" >35</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_3d382_level0_row2\" class=\"row_heading level0 row2\" >3</th>\n",
+       "      <td id=\"T_3d382_row2_col0\" class=\"data row2 col0\" >high</td>\n",
+       "      <td id=\"T_3d382_row2_col1\" class=\"data row2 col1\" >30</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "groups_proba = aa.AAPred.score_to_group(df_pred[\"score\"], thresholds=[0.5, 0.8],\n",
+    "                                        labels=[\"low\", \"medium\", \"high\"], score_range=\"proba\")\n",
+    "df_counts = groups_proba.value_counts(sort=False).rename_axis(\"group\").reset_index(name=\"n_proteins\")\n",
+    "aa.display_df(df_counts, n_rows=10, show_shape=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/unit/prediction_tests/test_aa_pred_score_to_group.py
+++ b/tests/unit/prediction_tests/test_aa_pred_score_to_group.py
@@ -1,0 +1,184 @@
+"""This is a script to test AAPred.score_to_group()."""
+import numpy as np
+import pandas as pd
+import pytest
+from hypothesis import given, settings
+import hypothesis.strategies as some
+
+import aaanalysis as aa
+
+settings.register_profile("ci", deadline=None)
+settings.load_profile("ci")
+
+STG = aa.AAPred.score_to_group
+
+
+class TestScoreToGroup:
+    """Normal cases, one parameter per test."""
+
+    # scores
+    @settings(max_examples=10, deadline=None)
+    @given(vals=some.lists(some.floats(min_value=0, max_value=100, allow_nan=False), min_size=1, max_size=20))
+    def test_scores_list(self, vals):
+        g = STG(vals, thresholds=[50], labels=["lo", "hi"])
+        assert isinstance(g, pd.Series)
+        assert len(g) == len(vals)
+
+    def test_scores_numpy(self):
+        g = STG(np.array([10.0, 60.0]), thresholds=[50], labels=["lo", "hi"])
+        assert g.tolist() == ["lo", "hi"]
+
+    def test_scores_series_preserves_index(self):
+        s = pd.Series([10.0, 60.0], index=["p1", "p2"])
+        g = STG(s, thresholds=[50], labels=["lo", "hi"])
+        assert list(g.index) == ["p1", "p2"]
+
+    def test_scores_nan_is_missing(self):
+        g = STG([np.nan, 60.0], thresholds=[50], labels=["lo", "hi"])
+        assert pd.isna(g.iloc[0]) and g.iloc[1] == "hi"
+
+    def test_scores_none_raises(self):
+        with pytest.raises(ValueError):
+            STG(None, thresholds=[50], labels=["lo", "hi"])
+
+    # thresholds
+    @settings(max_examples=10, deadline=None)
+    @given(t=some.floats(min_value=1, max_value=99, allow_nan=False))
+    def test_thresholds_single(self, t):
+        g = STG([0.0, 100.0], thresholds=[t], labels=["lo", "hi"])
+        assert g.tolist() == ["lo", "hi"]
+
+    def test_thresholds_multiple(self):
+        g = STG([10.0, 60.0, 90.0], thresholds=[50, 80], labels=["a", "b", "c"])
+        assert g.tolist() == ["a", "b", "c"]
+
+    @pytest.mark.parametrize("bad", [[80, 50], [50, 50], [10, 5, 20]])
+    def test_thresholds_not_increasing_raises(self, bad):
+        labels = [f"b{i}" for i in range(len(bad) + 1)]
+        with pytest.raises(ValueError, match="increasing"):
+            STG([10.0, 20.0], thresholds=bad, labels=labels)
+
+    def test_thresholds_none_raises(self):
+        with pytest.raises(ValueError):
+            STG([10.0], thresholds=None, labels=["lo", "hi"])
+
+    def test_thresholds_non_numeric_raises(self):
+        with pytest.raises(ValueError):
+            STG([10.0], thresholds=["x"], labels=["lo", "hi"])
+
+    # labels
+    def test_labels_three_bands(self):
+        g = STG([10.0, 60.0, 90.0], thresholds=[50, 80], labels=["low", "mid", "high"])
+        assert list(g.cat.categories) == ["low", "mid", "high"]
+
+    @pytest.mark.parametrize("thresholds,labels", [([50], ["a", "b", "c"]), ([50, 80], ["a", "b"])])
+    def test_labels_length_mismatch_raises(self, thresholds, labels):
+        with pytest.raises(ValueError, match="one more element"):
+            STG([10.0], thresholds=thresholds, labels=labels)
+
+    def test_labels_not_unique_raises(self):
+        with pytest.raises(ValueError, match="unique"):
+            STG([10.0], thresholds=[50, 80], labels=["a", "a", "b"])
+
+    def test_labels_none_raises(self):
+        with pytest.raises(ValueError):
+            STG([10.0], thresholds=[50], labels=None)
+
+    # score_range
+    def test_score_range_percent(self):
+        g = STG([0.2, 60.0], thresholds=[50], labels=["lo", "hi"], score_range="percent")
+        assert g.tolist() == ["lo", "hi"]
+
+    def test_score_range_proba(self):
+        g = STG([0.2, 0.6], thresholds=[0.5], labels=["lo", "hi"], score_range="proba")
+        assert g.tolist() == ["lo", "hi"]
+
+    def test_score_range_invalid_option_raises(self):
+        with pytest.raises(ValueError):
+            STG([0.2], thresholds=[0.5], labels=["lo", "hi"], score_range="fraction")
+
+    def test_score_range_proba_threshold_out_of_range_raises(self):
+        # A percent-scale threshold under proba bounds is rejected (no silent mix).
+        with pytest.raises(ValueError, match="proba"):
+            STG([0.2], thresholds=[80], labels=["lo", "hi"], score_range="proba")
+
+    def test_score_range_percent_threshold_out_of_range_raises(self):
+        with pytest.raises(ValueError, match="percent"):
+            STG([10.0], thresholds=[150], labels=["lo", "hi"], score_range="percent")
+
+
+class TestScoreToGroupComplex:
+    """Combinations and edge interactions."""
+
+    def test_ordered_categorical_supports_comparison(self):
+        g = STG([10.0, 60.0, 90.0], thresholds=[50, 80], labels=["low", "mid", "high"])
+        # Ordered categoricals support < / > against a category
+        assert (g > "low").tolist() == [False, True, True]
+
+    def test_all_below_first_threshold(self):
+        g = STG([1.0, 2.0, 3.0], thresholds=[50, 80], labels=["a", "b", "c"])
+        assert g.tolist() == ["a", "a", "a"]
+
+    def test_all_above_last_threshold(self):
+        g = STG([90.0, 95.0], thresholds=[50, 80], labels=["a", "b", "c"])
+        assert g.tolist() == ["c", "c"]
+
+    def test_mixed_nan_and_values_keep_index(self):
+        s = pd.Series([np.nan, 10.0, 90.0], index=["x", "y", "z"])
+        g = STG(s, thresholds=[50], labels=["lo", "hi"])
+        assert list(g.index) == ["x", "y", "z"]
+        assert pd.isna(g.loc["x"]) and g.loc["y"] == "lo" and g.loc["z"] == "hi"
+
+    def test_negative_scores_allowed_when_in_range(self):
+        # score_range guards thresholds, not scores; a below-range score just maps to band 0
+        g = STG([-5.0, 60.0], thresholds=[50], labels=["lo", "hi"])
+        assert g.tolist() == ["lo", "hi"]
+
+    def test_empty_scores_raises(self):
+        # An empty score vector has nothing to classify; the array check rejects it.
+        with pytest.raises(ValueError):
+            STG(np.array([], dtype=float), thresholds=[50], labels=["lo", "hi"])
+
+    def test_series_categorical_name(self):
+        g = STG([10.0], thresholds=[50], labels=["lo", "hi"])
+        assert g.name == "group"
+
+    def test_labels_length_and_threshold_order_both_wrong(self):
+        # length mismatch is reported (validated before order)
+        with pytest.raises(ValueError, match="one more element"):
+            STG([10.0], thresholds=[80, 50], labels=["a", "b", "c", "d"])
+
+    def test_thresholds_tuple_accepted(self):
+        g = STG([10.0, 90.0], thresholds=(50,), labels=["lo", "hi"])
+        assert g.tolist() == ["lo", "hi"]
+
+
+class TestScoreToGroupGoldenValues:
+    """Hand-computed band assignments, boundary inclusion, and plot-colouring parity."""
+
+    def test_boundary_inclusion_right_open(self):
+        # Threshold is an inclusive lower bound: exactly-at-threshold -> higher band.
+        g = STG([49.999, 50.0, 79.999, 80.0], thresholds=[50, 80], labels=["low", "mid", "high"])
+        assert g.tolist() == ["low", "mid", "mid", "high"]
+
+    def test_golden_full_assignment(self):
+        scores = [0, 10, 49, 50, 65, 80, 100]
+        g = STG(scores, thresholds=[50, 80], labels=["low", "mid", "high"])
+        assert g.tolist() == ["low", "low", "low", "mid", "mid", "high", "high"]
+
+    def test_codes_match_band_index(self):
+        # The categorical codes equal the shared backend band-index kernel.
+        from aaanalysis.prediction._backend.aa_pred.aa_pred_group import assign_band_index
+        scores = np.array([5.0, 55.0, 85.0, 50.0, 80.0])
+        g = STG(scores, thresholds=[50, 80], labels=["a", "b", "c"])
+        expected = assign_band_index(scores, [50.0, 80.0])
+        assert g.cat.codes.tolist() == list(expected)
+
+    def test_plot_band_parity(self):
+        # predict_group(band=True) colours each bar by score_to_group's boundary rule:
+        # the per-bin band index equals score_to_group's code for that bin's left edge.
+        from aaanalysis.prediction._aa_pred_plot import _band_index
+        thresholds = [50.0, 80.0]
+        for edge in [0.0, 49.9, 50.0, 65.0, 80.0, 99.0]:
+            code = STG([edge], thresholds=thresholds, labels=["a", "b", "c"]).cat.codes.iloc[0]
+            assert _band_index(edge, thresholds) == int(code)


### PR DESCRIPTION
Closes #408

## What
Add a stateless `AAPred.score_to_group` staticmethod mapping prediction scores to an ordered `pd.Categorical` of named confidence bands:
- sorted `thresholds` as inclusive lower bounds (right-open bands `[t_{i-1}, t_i)`), one more low-to-high `label` than thresholds
- index-preserving; `NaN` scores kept missing
- `score_range` (`percent`/`proba`) bounds the thresholds so probabilities and percentages can't be silently mixed

The band-boundary rule now lives in one shared backend kernel (`assign_band_index`), consumed by both `score_to_group` and the existing `AAPredPlot.predict_group(band=True)` histogram colouring — so a table and its plot always agree (byte-identical banding, golden-tested).

## Ripple
Unit tests (per-param + complex + golden/plot-parity), executed example notebook `aap_score_to_group.ipynb`, release notes, CONTEXT glossary entry. No `__all__` change (method on already-public class).

## Verified locally
Full `prediction_tests` + param-coverage / notebook-param-coverage / backend-import-hygiene / method-spacing meta-tests + docstring checker (0 defects) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)