### PR TITLE
feat(prediction): capability-based estimator validation for AAPred

### DIFF
--- a/aaanalysis/_constants.py
+++ b/aaanalysis/_constants.py
@@ -476,6 +476,10 @@ STR_PRINCIPLE_CV_POOLED = "cv_pooled"    # custom-splitter cross-validation, eac
 STR_PRINCIPLE_HOLDOUT = "holdout"
 LIST_PRINCIPLES = [STR_PRINCIPLE_CV, STR_PRINCIPLE_CV_POOLED, STR_PRINCIPLE_HOLDOUT]
 LIST_METRICS_PRED = ["accuracy", "balanced_accuracy", "precision", "recall", "f1", "roc_auc"]
+# Probability metrics — need class probabilities (predict_proba), not just hard labels. Hard-label
+# metrics (accuracy/balanced_accuracy/precision/recall/f1) only need predict, so an estimator
+# without predict_proba (e.g. LinearSVC, SVC(probability=False)) can still be evaluated on them.
+LIST_METRICS_PRED_PROBA = ["roc_auc"]
 COLS_EVAL_PRED = [COL_MODEL, COL_METRIC, COL_PRINCIPLE, COL_SCORE, COL_SCORE_STD]
 
 # Baseline-featurizer comparison in AAPred.eval(baseline=...): tag each df_eval row with the

--- a/aaanalysis/prediction/_aa_pred.py
+++ b/aaanalysis/prediction/_aa_pred.py
@@ -95,6 +95,50 @@ def featurize_seq(df_feat=None, df_scales=None, df_seq=None, list_parts=None, **
     return np.asarray(X)
 
 
+def _estimators_missing_method(list_estimators=None, method=None):
+    """Class names of estimator *instances* that don't implement ``method``.
+
+    Checks the configured instances (not the classes), so a capability toggled at construction
+    is honored — e.g. ``SVC(probability=False)`` has no ``predict_proba`` while
+    ``SVC(probability=True)`` does.
+    """
+    return sorted({type(e).__name__ for e in list_estimators if not hasattr(e, method)})
+
+
+def check_estimators_predict(list_estimators=None):
+    """Every estimator must implement ``predict`` (hard-label prediction is always required)."""
+    missing = _estimators_missing_method(list_estimators=list_estimators, method="predict")
+    if missing:
+        raise ValueError(f"Estimators {missing} do not implement 'predict'; 'AAPred' needs each "
+                         f"model to support hard-label prediction.")
+
+
+def check_estimators_proba(list_estimators=None, metrics=None, context=None):
+    """Require ``predict_proba`` only where class probabilities are actually needed.
+
+    Capability-based validation: pass ``metrics`` to enforce it **only** when a probability metric
+    (``ut.LIST_METRICS_PRED_PROBA``, e.g. ``roc_auc``) is requested — the error then names that
+    metric. Pass ``context`` (e.g. ``'predict_oof'``) for a path that always scores a positive-class
+    probability, where ``predict_proba`` is unconditionally required.
+    """
+    if metrics is not None:
+        proba_metrics = [m for m in metrics if m in ut.LIST_METRICS_PRED_PROBA]
+        if not proba_metrics:
+            return
+        missing = _estimators_missing_method(list_estimators=list_estimators, method="predict_proba")
+        if missing:
+            raise ValueError(f"'metrics' ({proba_metrics}) need class probabilities ('predict_proba'), "
+                             f"but estimators {missing} do not implement it; drop the probability "
+                             f"metric(s) or pass estimators with 'predict_proba' (e.g. "
+                             f"'SVC(probability=True)').")
+    else:
+        missing = _estimators_missing_method(list_estimators=list_estimators, method="predict_proba")
+        if missing:
+            raise ValueError(f"'{context}' scores a positive-class probability and needs "
+                             f"'predict_proba', but estimators {missing} do not implement it; pass "
+                             f"estimators with 'predict_proba' (e.g. 'SVC(probability=True)').")
+
+
 def check_baseline(baseline=None):
     """Resolve the ``baseline`` selector into an ordered, de-duplicated list of kinds (or None).
 
@@ -190,10 +234,13 @@ class AAPred(Wrapper):
             ``"svm"``, ``"rf"``; see ``aaanalysis.utils.LIST_PRED_MODELS``) and/or configured
             scikit-learn estimator instances, in any mix. This is the recommended way to
             select models; it is mutually exclusive with ``list_model_classes``. Each model
-            must implement ``predict_proba``.
+            must implement ``predict``; ``predict_proba`` is required only for probability
+            metrics (e.g. ``roc_auc``) and the :meth:`predict` / :meth:`predict_oof` scoring
+            paths, so a hard-label estimator such as ``SVC(kernel="linear")`` is accepted.
         list_model_classes : list of Type[ClassifierMixin or BaseEstimator], default=[RandomForestClassifier]
             Model classes to evaluate and deploy (legacy alternative to ``models``). Each
-            must implement ``predict_proba``.
+            must implement ``predict`` (``predict_proba`` only where a probability is scored,
+            as for ``models``).
         list_model_kwargs : list of dict, optional
             Keyword arguments for each model in ``list_model_classes`` (same length).
         list_metrics : list of str, default=["accuracy", "balanced_accuracy", "f1", "roc_auc"]
@@ -242,7 +289,7 @@ class AAPred(Wrapper):
                     est = _set_random_state_if_supported(m(), random_state, only_if_unset=False)
                 else:  # a configured estimator instance: clone + seed only if the user left it unset
                     est = _set_random_state_if_supported(clone(m), random_state, only_if_unset=True)
-                ut.check_mode_class(model_class=type(est))  # ensure predict_proba
+                ut.check_mode_class(model_class=type(est))  # ensure it is a model class
                 list_estimators.append(est)
             list_model_classes = [type(e) for e in list_estimators]
             _list_model_kwargs = [{} for _ in list_estimators]  # introspection placeholder
@@ -263,9 +310,12 @@ class AAPred(Wrapper):
             for model_class, model_kwargs in zip(list_model_classes, list_model_kwargs):
                 ut.check_mode_class(model_class=model_class)
                 model_kwargs = ut.check_model_kwargs(model_class=model_class, model_kwargs=model_kwargs,
-                                                     method_to_check="predict_proba", random_state=random_state)
+                                                     method_to_check="predict", random_state=random_state)
                 _list_model_kwargs.append(model_kwargs)
             list_estimators = [cls(**kw) for cls, kw in zip(list_model_classes, _list_model_kwargs)]
+        # Every model must support hard-label prediction; predict_proba is validated per operation
+        # (probability metrics in eval, and the predict / predict_oof scoring paths) instead.
+        check_estimators_predict(list_estimators=list_estimators)
         # Metric parameters
         if list_metrics is None:
             list_metrics = ["accuracy", "balanced_accuracy", "f1", "roc_auc"]
@@ -462,6 +512,9 @@ class AAPred(Wrapper):
         ut.check_match_X_labels(X=X, labels=labels)
         check_binary_labels(labels=labels)
         metrics = check_metrics(metrics=metrics) if metrics is not None else self._list_metrics
+        # predict_proba is required only for probability metrics (e.g. roc_auc); hard-label metrics
+        # score fine on any estimator with predict.
+        check_estimators_proba(list_estimators=self._list_estimators, metrics=metrics)
         # A custom splitter defines its own folds (pooled scoring), so it bypasses the
         # smallest-class-count cap that the integer n_cv path enforces.
         if cv is not None:
@@ -558,6 +611,7 @@ class AAPred(Wrapper):
         if label_pos not in classes:
             raise ValueError(f"'label_pos' ({label_pos}) should be one of the labels: {classes}")
         check_n_cv(n_cv=n_cv, labels=labels)
+        check_estimators_proba(list_estimators=self._list_estimators, context="predict_oof")
         # Out-of-fold scoring: clone the constructor's estimators and cross-validate (no prior fit)
         pred, pred_std = predict_proba_oof(X=X, labels=labels,
                                            list_estimators=self._list_estimators,
@@ -641,6 +695,7 @@ class AAPred(Wrapper):
         # Check input
         check_is_fitted(list_models=self.list_models_)
         check_featurizer(df_feat=self._df_feat)
+        check_estimators_proba(list_estimators=self._list_estimators, context="predict")
         ut.check_df_seq(df_seq=df_seq)
         if level not in ("sequence", "domain", "window"):
             raise ValueError(f"'level' ('{level}') must be 'sequence', 'domain', or 'window'.")

--- a/docs/source/index/release_notes.rst
+++ b/docs/source/index/release_notes.rst
@@ -469,6 +469,14 @@ Added
 Changed
 ~~~~~~~
 
+- :class:`~aaanalysis.AAPred`: **capability-based estimator validation** — the constructor now
+  requires only ``predict`` (hard-label prediction), so a probability-free estimator such as
+  ``SVC(kernel="linear")`` is accepted. ``predict_proba`` is validated *per operation*: it is
+  required only when :meth:`~aaanalysis.AAPred.eval` is asked for a probability metric (``roc_auc``)
+  and by the probability-scoring paths (:meth:`~aaanalysis.AAPred.predict` /
+  :meth:`~aaanalysis.AAPred.predict_oof`), with an actionable error naming the metric when it is
+  missing. Estimators that support ``predict_proba`` are unaffected (default RandomForest paths
+  unchanged).
 - :class:`~aaanalysis.TreeModel`: **per-round seeding fix** — with a fixed ``random_state`` (or the
   global ``options["random_state"]``), :meth:`~aaanalysis.TreeModel.fit` now reseeds each round to
   ``random_state + i`` so the rounds are independent. Previously every round fit identical estimators,

--- a/tests/unit/prediction_tests/test_aa_pred.py
+++ b/tests/unit/prediction_tests/test_aa_pred.py
@@ -58,10 +58,18 @@ class TestAAPredInit:
         with pytest.raises(ValueError):
             aa.AAPred(list_metrics=["not_a_metric"])
 
-    def test_model_without_predict_proba_raises(self):
+    def test_model_without_predict_proba_constructs(self):
+        # Capability-based validation: a hard-label estimator (no predict_proba) is now accepted
+        # at construction; predict_proba is validated per operation instead.
         from sklearn.svm import LinearSVC
-        with pytest.raises(ValueError):
-            aa.AAPred(list_model_classes=[LinearSVC])
+        aap = aa.AAPred(list_model_classes=[LinearSVC])
+        assert aap is not None
+
+    def test_model_without_predict_raises(self):
+        # An object with no predict at all cannot be a prediction model.
+        from sklearn.preprocessing import StandardScaler
+        with pytest.raises(ValueError, match="predict"):
+            aa.AAPred(models=[StandardScaler()])
 
     def test_mismatched_kwargs_length_raises(self):
         with pytest.raises(ValueError):
@@ -720,3 +728,75 @@ class TestAAPredPredictOOFComplex:
                             random_state=rs).predict_oof(X, labels)
         assert np.allclose(df_pred["score"].to_numpy(), oof, atol=1e-9)
         assert 0.0 <= roc_auc_score(labels, df_pred["score"].to_numpy()) <= 1.0
+
+
+class TestAAPredCapabilityValidation:
+    """Capability-based estimator validation (#409): predict_proba required only where scored."""
+
+    def test_hard_label_estimator_constructs_via_models(self):
+        aap = aa.AAPred(models=[SVC(kernel="linear")], random_state=0)
+        assert aap is not None
+
+    def test_eval_hard_metric_without_predict_proba(self):
+        # KPI: SVC(kernel="linear") (no predict_proba) evaluates a hard-label metric under LOO.
+        X, labels = _data()
+        df_eval = aa.AAPred(models=[SVC(kernel="linear")], random_state=0).eval(
+            X, labels, cv=LeaveOneOut(), metrics=["balanced_accuracy"])
+        assert (df_eval["metric"] == "balanced_accuracy").all()
+        assert df_eval["score"].between(0, 1).all()
+
+    def test_eval_hard_metric_kfold_without_predict_proba(self):
+        X, labels = _data()
+        df_eval = aa.AAPred(models=[SVC(kernel="linear")], random_state=0).eval(
+            X, labels, n_cv=3, metrics=["accuracy", "f1"])
+        assert df_eval["score"].between(0, 1).all()
+
+    def test_eval_proba_metric_without_predict_proba_raises(self):
+        # KPI: requesting a probability metric on a proba-less estimator raises, naming the metric.
+        X, labels = _data()
+        with pytest.raises(ValueError, match="roc_auc"):
+            aa.AAPred(models=[SVC(kernel="linear")], random_state=0).eval(
+                X, labels, metrics=["roc_auc"])
+
+    def test_eval_proba_metric_error_mentions_predict_proba(self):
+        X, labels = _data()
+        with pytest.raises(ValueError, match="predict_proba"):
+            aa.AAPred(models=[SVC(kernel="linear")], random_state=0).eval(
+                X, labels, metrics=["balanced_accuracy", "roc_auc"])
+
+    def test_eval_proba_metric_with_proba_estimator_ok(self):
+        # Regression: proba paths unchanged for estimators that support predict_proba.
+        X, labels = _data()
+        df_eval = aa.AAPred(models=[SVC(kernel="linear", probability=True)], random_state=0).eval(
+            X, labels, n_cv=3, metrics=["roc_auc"])
+        assert df_eval["score"].between(0, 1).all()
+
+    def test_default_rf_roc_auc_unchanged(self):
+        # Regression: the default RandomForest (has predict_proba) still evaluates roc_auc.
+        X, labels = _data()
+        df_eval = aa.AAPred(random_state=0).eval(X, labels, metrics=["roc_auc"])
+        assert (df_eval["metric"] == "roc_auc").all()
+
+    def test_predict_oof_without_predict_proba_raises(self):
+        X, labels = _data()
+        with pytest.raises(ValueError, match="predict_proba"):
+            aa.AAPred(models=[SVC(kernel="linear")], random_state=0).predict_oof(X, labels)
+
+    def test_predict_oof_with_proba_estimator_ok(self):
+        X, labels = _data()
+        df_pred = aa.AAPred(models=[SVC(kernel="linear", probability=True)],
+                            random_state=0).predict_oof(X, labels, n_cv=3)
+        assert df_pred["score"].between(0, 1).all()
+
+    def test_error_names_offending_estimator(self):
+        X, labels = _data()
+        with pytest.raises(ValueError, match="SVC"):
+            aa.AAPred(models=[SVC(kernel="linear")], random_state=0).eval(
+                X, labels, metrics=["roc_auc"])
+
+    def test_mixed_ensemble_missing_proba_raises(self):
+        # One proba-less model in an ensemble is enough to block a probability metric.
+        X, labels = _data()
+        with pytest.raises(ValueError, match="roc_auc"):
+            aa.AAPred(models=["rf", SVC(kernel="linear")], random_state=0).eval(
+                X, labels, metrics=["roc_auc"])


### PR DESCRIPTION
Closes #409

## What
Validate estimators by the operation requested instead of demanding `predict_proba` up front:
- constructor now requires only `predict` (hard-label prediction), so `SVC(kernel="linear")` is accepted
- `predict_proba` is validated *per operation*: only when `eval` is asked for a probability metric (`roc_auc`), and by the probability-scoring paths (`predict` / `predict_oof`), with an actionable `ValueError` naming the offending metric and estimator
- estimators that support `predict_proba` are unaffected (default RandomForest paths unchanged)

## Ripple
Flipped the obsolete constructor test; added a capability-validation test class (hard-label eval under LeaveOneOut, proba-metric rejection, ensemble mix, regression on proba estimators); `__init__` docstring; release notes.

## Verified locally
Full `prediction_tests` (108 in file) + param-coverage + docstring checker — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)