### PR TITLE
docs(examples): demonstrate all AnnotationPreprocessor params (part of #345)

### DIFF
--- a/examples/data_handling_pro/annp_build_cat.ipynb
+++ b/examples/data_handling_pro/annp_build_cat.ipynb
@@ -16,10 +16,10 @@
    "id": "86a2f7ef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T10:50:04.034546Z",
-     "iopub.status.busy": "2026-06-04T10:50:04.034439Z",
-     "iopub.status.idle": "2026-06-04T10:50:05.631524Z",
-     "shell.execute_reply": "2026-06-04T10:50:05.631211Z"
+     "iopub.execute_input": "2026-07-14T11:06:50.384633Z",
+     "iopub.status.busy": "2026-07-14T11:06:50.384221Z",
+     "iopub.status.idle": "2026-07-14T11:06:51.935411Z",
+     "shell.execute_reply": "2026-07-14T11:06:51.935134Z"
     }
    },
    "outputs": [
@@ -115,6 +115,88 @@
    "metadata": {},
    "source": [
     "**Further parameters.** ``AnnotationPreprocessor.build_cat`` also accepts: ``dim_names_override`` — Replacement names for the D columns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f20e08fe",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T11:06:51.936622Z",
+     "iopub.status.busy": "2026-07-14T11:06:51.936530Z",
+     "iopub.status.idle": "2026-07-14T11:06:51.962505Z",
+     "shell.execute_reply": "2026-07-14T11:06:51.962264Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DataFrame shape: (1, 5)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "#T_976bd thead th {\n",
+       "  background-color: white;\n",
+       "  color: black;\n",
+       "}\n",
+       "#T_976bd tbody tr:nth-child(odd) {\n",
+       "  background-color: #f2f2f2;\n",
+       "}\n",
+       "#T_976bd tbody tr:nth-child(even) {\n",
+       "  background-color: white;\n",
+       "}\n",
+       "#T_976bd th {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "#T_976bd  td {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "</style>\n",
+       "<table id=\"T_976bd\" style='display:block; max-height: 300px; max-width: 100%; overflow-x: auto; overflow-y: auto;'>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_976bd_level0_col0\" class=\"col_heading level0 col0\" >scale_id</th>\n",
+       "      <th id=\"T_976bd_level0_col1\" class=\"col_heading level0 col1\" >category</th>\n",
+       "      <th id=\"T_976bd_level0_col2\" class=\"col_heading level0 col2\" >subcategory</th>\n",
+       "      <th id=\"T_976bd_level0_col3\" class=\"col_heading level0 col3\" >scale_name</th>\n",
+       "      <th id=\"T_976bd_level0_col4\" class=\"col_heading level0 col4\" >scale_description</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_976bd_level0_row0\" class=\"row_heading level0 row0\" >1</th>\n",
+       "      <td id=\"T_976bd_row0_col0\" class=\"data row0 col0\" >hotspot_dim</td>\n",
+       "      <td id=\"T_976bd_row0_col1\" class=\"data row0 col1\" >Functional sites</td>\n",
+       "      <td id=\"T_976bd_row0_col2\" class=\"data row0 col2\" >FUNC_hotspot</td>\n",
+       "      <td id=\"T_976bd_row0_col3\" class=\"data row0 col3\" >hotspot_dim</td>\n",
+       "      <td id=\"T_976bd_row0_col4\" class=\"data row0 col4\" >Functional sites/FUNC_hotspot</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Further parameter: rename the D annotation dimensions via ``dim_names_override``\n",
+    "# (length must equal D; here D = 1).\n",
+    "df_cat_named = annp.build_cat(features=['hotspot'],\n",
+    "                              dim_names_override=['hotspot_dim'])\n",
+    "aa.display_df(df_cat_named, n_rows=10, show_shape=True)"
    ]
   }
  ],

--- a/examples/data_handling_pro/annp_build_scales.ipynb
+++ b/examples/data_handling_pro/annp_build_scales.ipynb
@@ -16,10 +16,10 @@
    "id": "8fac6f1d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T10:50:01.471386Z",
-     "iopub.status.busy": "2026-06-04T10:50:01.471256Z",
-     "iopub.status.idle": "2026-06-04T10:50:03.097555Z",
-     "shell.execute_reply": "2026-06-04T10:50:03.097264Z"
+     "iopub.execute_input": "2026-07-14T11:06:53.744607Z",
+     "iopub.status.busy": "2026-07-14T11:06:53.744011Z",
+     "iopub.status.idle": "2026-07-14T11:06:55.285542Z",
+     "shell.execute_reply": "2026-07-14T11:06:55.285311Z"
     }
    },
    "outputs": [
@@ -117,6 +117,117 @@
    "metadata": {},
    "source": [
     "**Further parameters.** ``AnnotationPreprocessor.build_scales`` also accepts: ``return_std`` — If ``True``, also return per-AA standard deviations; ``dim_names_override`` — Replacement names for the D columns; length must equal ``D``."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d52591d3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T11:06:55.286726Z",
+     "iopub.status.busy": "2026-07-14T11:06:55.286654Z",
+     "iopub.status.idle": "2026-07-14T11:06:55.311678Z",
+     "shell.execute_reply": "2026-07-14T11:06:55.311453Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DataFrame shape: (20, 1)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "#T_a5767 thead th {\n",
+       "  background-color: white;\n",
+       "  color: black;\n",
+       "}\n",
+       "#T_a5767 tbody tr:nth-child(odd) {\n",
+       "  background-color: #f2f2f2;\n",
+       "}\n",
+       "#T_a5767 tbody tr:nth-child(even) {\n",
+       "  background-color: white;\n",
+       "}\n",
+       "#T_a5767 th {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "#T_a5767  td {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "</style>\n",
+       "<table id=\"T_a5767\" style='display:block; max-height: 300px; max-width: 100%; overflow-x: auto; overflow-y: auto;'>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_a5767_level0_col0\" class=\"col_heading level0 col0\" >hotspot_dim</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a5767_level0_row0\" class=\"row_heading level0 row0\" >A</th>\n",
+       "      <td id=\"T_a5767_row0_col0\" class=\"data row0 col0\" >0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a5767_level0_row1\" class=\"row_heading level0 row1\" >C</th>\n",
+       "      <td id=\"T_a5767_row1_col0\" class=\"data row1 col0\" >0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a5767_level0_row2\" class=\"row_heading level0 row2\" >D</th>\n",
+       "      <td id=\"T_a5767_row2_col0\" class=\"data row2 col0\" >0.460000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a5767_level0_row3\" class=\"row_heading level0 row3\" >E</th>\n",
+       "      <td id=\"T_a5767_row3_col0\" class=\"data row3 col0\" >0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a5767_level0_row4\" class=\"row_heading level0 row4\" >F</th>\n",
+       "      <td id=\"T_a5767_row4_col0\" class=\"data row4 col0\" >0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a5767_level0_row5\" class=\"row_heading level0 row5\" >G</th>\n",
+       "      <td id=\"T_a5767_row5_col0\" class=\"data row5 col0\" >0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a5767_level0_row6\" class=\"row_heading level0 row6\" >H</th>\n",
+       "      <td id=\"T_a5767_row6_col0\" class=\"data row6 col0\" >0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a5767_level0_row7\" class=\"row_heading level0 row7\" >I</th>\n",
+       "      <td id=\"T_a5767_row7_col0\" class=\"data row7 col0\" >0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a5767_level0_row8\" class=\"row_heading level0 row8\" >K</th>\n",
+       "      <td id=\"T_a5767_row8_col0\" class=\"data row8 col0\" >0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a5767_level0_row9\" class=\"row_heading level0 row9\" >L</th>\n",
+       "      <td id=\"T_a5767_row9_col0\" class=\"data row9 col0\" >0.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Further parameters: ``return_std=True`` also returns the per-AA standard\n",
+    "# deviations, and ``dim_names_override`` renames the D columns.\n",
+    "df_scales_named, df_scales_std = annp.build_scales(\n",
+    "    df_seq=df_seq, dict_num=dict_num, features=['hotspot'],\n",
+    "    return_std=True, dim_names_override=['hotspot_dim'])\n",
+    "aa.display_df(df_scales_std, n_rows=10, show_shape=True)"
    ]
   }
  ],

--- a/examples/data_handling_pro/annp_encode.ipynb
+++ b/examples/data_handling_pro/annp_encode.ipynb
@@ -16,10 +16,10 @@
    "id": "3cee241b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T10:49:53.696970Z",
-     "iopub.status.busy": "2026-06-04T10:49:53.696890Z",
-     "iopub.status.idle": "2026-06-04T10:49:55.320284Z",
-     "shell.execute_reply": "2026-06-04T10:49:55.319955Z"
+     "iopub.execute_input": "2026-07-14T11:06:56.757130Z",
+     "iopub.status.busy": "2026-07-14T11:06:56.756702Z",
+     "iopub.status.idle": "2026-07-14T11:06:58.251013Z",
+     "shell.execute_reply": "2026-07-14T11:06:58.250729Z"
     }
    },
    "outputs": [
@@ -57,6 +57,86 @@
     "print('shape (L, D):', arr.shape)\n",
     "print('annotated positions (1-based):',\n",
     "      list(np.where(arr[:, 0] > 0)[0] + 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e25cc6bd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T11:06:58.252544Z",
+     "iopub.status.busy": "2026-07-14T11:06:58.252394Z",
+     "iopub.status.idle": "2026-07-14T11:06:58.279407Z",
+     "shell.execute_reply": "2026-07-14T11:06:58.279183Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DataFrame shape: (1, 3)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "#T_835bf thead th {\n",
+       "  background-color: white;\n",
+       "  color: black;\n",
+       "}\n",
+       "#T_835bf tbody tr:nth-child(odd) {\n",
+       "  background-color: #f2f2f2;\n",
+       "}\n",
+       "#T_835bf tbody tr:nth-child(even) {\n",
+       "  background-color: white;\n",
+       "}\n",
+       "#T_835bf th {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "#T_835bf  td {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "</style>\n",
+       "<table id=\"T_835bf\" style='display:block; max-height: 300px; max-width: 100%; overflow-x: auto; overflow-y: auto;'>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_835bf_level0_col0\" class=\"col_heading level0 col0\" >entry</th>\n",
+       "      <th id=\"T_835bf_level0_col1\" class=\"col_heading level0 col1\" >sequence</th>\n",
+       "      <th id=\"T_835bf_level0_col2\" class=\"col_heading level0 col2\" >encode_ok</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_835bf_level0_row0\" class=\"row_heading level0 row0\" >1</th>\n",
+       "      <td id=\"T_835bf_row0_col0\" class=\"data row0 col0\" >AF_TINY</td>\n",
+       "      <td id=\"T_835bf_row0_col1\" class=\"data row0 col1\" >ACDEFGHIKLMNPQRSTVWYACDEFGHIKL</td>\n",
+       "      <td id=\"T_835bf_row0_col2\" class=\"data row0 col2\" >True</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Further parameters: ``on_mismatch`` sets the off-by-isoform policy\n",
+    "# ('raise' | 'drop' | 'warn'), and ``return_df=True`` additionally returns a\n",
+    "# tidy long-form table of the mapped annotations.\n",
+    "dict_num, df_encoded = annp.encode(\n",
+    "    df_seq=df_seq, df_annot=df_annot, features=['hotspot'],\n",
+    "    on_mismatch='warn', return_df=True)\n",
+    "aa.display_df(df_encoded, n_rows=10, show_shape=True)"
    ]
   },
   {

--- a/examples/data_handling_pro/annp_fetch_uniprot.ipynb
+++ b/examples/data_handling_pro/annp_fetch_uniprot.ipynb
@@ -18,15 +18,7 @@
    "id": "6c625a24",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import aaanalysis as aa\n",
-    "\n",
-    "# annp = aa.AnnotationPreprocessor()\n",
-    "# df_annot = annp.fetch_uniprot(df_seq=df_seq,\n",
-    "#     features=['phospho', 'disulfide', 'binding'],\n",
-    "#     evidence='manual')\n",
-    "# # df_annot then feeds annp.encode(df_seq=df_seq, df_annot=df_annot, ...)\n"
-   ]
+   "source": "import aaanalysis as aa\n\n# annp = aa.AnnotationPreprocessor()\n# df_annot = annp.fetch_uniprot(df_seq=df_seq,\n#     features=['phospho', 'disulfide', 'binding'],\n#     evidence='manual', timeout=30.0, max_workers=1)\n# # ``timeout`` bounds each REST request (seconds); ``max_workers`` > 1 fetches on\n# # a thread pool with input-order, byte-identical results (opt-in: parallel\n# # UniProt requests risk HTTP-429 throttling).\n# # df_annot then feeds annp.encode(df_seq=df_seq, df_annot=df_annot, ...)"
   },
   {
    "cell_type": "markdown",

--- a/examples/data_handling_pro/annp_register_feature.ipynb
+++ b/examples/data_handling_pro/annp_register_feature.ipynb
@@ -16,10 +16,10 @@
    "id": "bd724bf3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T10:49:58.921854Z",
-     "iopub.status.busy": "2026-06-04T10:49:58.921777Z",
-     "iopub.status.idle": "2026-06-04T10:50:00.532083Z",
-     "shell.execute_reply": "2026-06-04T10:50:00.531744Z"
+     "iopub.execute_input": "2026-07-14T11:06:59.729561Z",
+     "iopub.status.busy": "2026-07-14T11:06:59.729247Z",
+     "iopub.status.idle": "2026-07-14T11:07:01.281045Z",
+     "shell.execute_reply": "2026-07-14T11:07:01.280788Z"
     }
    },
    "outputs": [
@@ -49,6 +49,36 @@
     "                    subcategory='Kinase site (predictor)')\n",
     "print('registered:', 'kinase_site' in annp._registry)\n",
     "print(annp._registry['kinase_site'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "66a16bde",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T11:07:01.282306Z",
+     "iopub.status.busy": "2026-07-14T11:07:01.282194Z",
+     "iopub.status.idle": "2026-07-14T11:07:01.284073Z",
+     "shell.execute_reply": "2026-07-14T11:07:01.283865Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "normalization registered for: ['kinase_site']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Further parameter: attach a custom ``normalization`` callable (default: identity,\n",
+    "# so inputs must already lie in [0, 1]). Re-registering the same key overrides it.\n",
+    "annp.register_feature(key='kinase_site',\n",
+    "                      subcategory='Kinase site (predictor)',\n",
+    "                      normalization=lambda x: np.clip(x, 0.0, 1.0))\n",
+    "print('normalization registered for:', annp._registry['kinase_site']['dim_names'])"
    ]
   }
  ],

--- a/examples/data_handling_pro/annp_to_df_seq.ipynb
+++ b/examples/data_handling_pro/annp_to_df_seq.ipynb
@@ -16,10 +16,10 @@
    "id": "5c17cfe0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T10:50:06.596356Z",
-     "iopub.status.busy": "2026-06-04T10:50:06.596259Z",
-     "iopub.status.idle": "2026-06-04T10:50:08.241921Z",
-     "shell.execute_reply": "2026-06-04T10:50:08.241582Z"
+     "iopub.execute_input": "2026-07-14T11:07:02.953690Z",
+     "iopub.status.busy": "2026-07-14T11:07:02.953340Z",
+     "iopub.status.idle": "2026-07-14T11:07:04.458230Z",
+     "shell.execute_reply": "2026-07-14T11:07:04.458012Z"
     }
    },
    "outputs": [
@@ -100,6 +100,87 @@
    "metadata": {},
    "source": [
     "**Further parameters.** ``AnnotationPreprocessor.to_df_seq`` also accepts: ``exclude_other_annotations`` — Exclude residues carrying any other ``feature_type`` from the reference pool; ``pos_col`` — Name of the emitted positives column; defaults to ``ut.COL_POS``; ``aa_context_col`` — Name of the emitted per-residue eligibility-mask column."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d8caf916",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T11:07:04.459394Z",
+     "iopub.status.busy": "2026-07-14T11:07:04.459327Z",
+     "iopub.status.idle": "2026-07-14T11:07:04.483768Z",
+     "shell.execute_reply": "2026-07-14T11:07:04.483564Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DataFrame shape: (1, 3)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "#T_8d2de thead th {\n",
+       "  background-color: white;\n",
+       "  color: black;\n",
+       "}\n",
+       "#T_8d2de tbody tr:nth-child(odd) {\n",
+       "  background-color: #f2f2f2;\n",
+       "}\n",
+       "#T_8d2de tbody tr:nth-child(even) {\n",
+       "  background-color: white;\n",
+       "}\n",
+       "#T_8d2de th {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "#T_8d2de  td {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "</style>\n",
+       "<table id=\"T_8d2de\" style='display:block; max-height: 300px; max-width: 100%; overflow-x: auto; overflow-y: auto;'>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_8d2de_level0_col0\" class=\"col_heading level0 col0\" >entry</th>\n",
+       "      <th id=\"T_8d2de_level0_col1\" class=\"col_heading level0 col1\" >annot_pos</th>\n",
+       "      <th id=\"T_8d2de_level0_col2\" class=\"col_heading level0 col2\" >eligible</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_8d2de_level0_row0\" class=\"row_heading level0 row0\" >1</th>\n",
+       "      <td id=\"T_8d2de_row0_col0\" class=\"data row0 col0\" >AF_TINY</td>\n",
+       "      <td id=\"T_8d2de_row0_col1\" class=\"data row0 col1\" >[3, 16]</td>\n",
+       "      <td id=\"T_8d2de_row0_col2\" class=\"data row0 col2\" >110111111111111011111111111111</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Further parameters: relax residue-type matching and the reference-pool filter,\n",
+    "# and rename the emitted positives / eligibility-mask columns.\n",
+    "df_pos_custom = annp.to_df_seq(\n",
+    "    df_seq=df_seq, df_annot=df_annot, feature_type='hotspot',\n",
+    "    match_residue_type=False, exclude_other_annotations=False,\n",
+    "    pos_col='annot_pos', aa_context_col='eligible')\n",
+    "aa.display_df(df_pos_custom[['entry', 'annot_pos', 'eligible']],\n",
+    "              n_rows=10, show_shape=True)"
    ]
   }
  ],

--- a/tests/unit/api_tests/notebook_param_coverage_baseline.txt
+++ b/tests/unit/api_tests/notebook_param_coverage_baseline.txt
@@ -1,17 +1,5 @@
 # Known undemonstrated example-notebook params (backlog to burn down; NEVER add rows).
 # Enforced by test_notebook_param_coverage.py. Prediction notebooks are excluded (held to zero).
-AnnotationPreprocessor::build_cat::dim_names_override
-AnnotationPreprocessor::build_scales::dim_names_override
-AnnotationPreprocessor::build_scales::return_std
-AnnotationPreprocessor::encode::on_mismatch
-AnnotationPreprocessor::encode::return_df
-AnnotationPreprocessor::fetch_uniprot::max_workers
-AnnotationPreprocessor::fetch_uniprot::timeout
-AnnotationPreprocessor::register_feature::normalization
-AnnotationPreprocessor::to_df_seq::aa_context_col
-AnnotationPreprocessor::to_df_seq::exclude_other_annotations
-AnnotationPreprocessor::to_df_seq::match_residue_type
-AnnotationPreprocessor::to_df_seq::pos_col
 CPPStructurePlot::__init__::df_scales
 CPPStructurePlot::explore::chain
 CPPStructurePlot::explore::col_imp


### PR DESCRIPTION
Part of #345 (example-notebook parameter-coverage burn-down).

Demonstrates every public parameter of `AnnotationPreprocessor`'s documented methods by name in its example notebook, and removes the 12 corresponding rows from `notebook_param_coverage_baseline.txt` (baseline 93 → 81 on this branch).

Params now demonstrated:
- `build_cat`: `dim_names_override`
- `build_scales`: `return_std`, `dim_names_override`
- `encode`: `on_mismatch`, `return_df`
- `fetch_uniprot`: `timeout`, `max_workers` (commented network stub)
- `register_feature`: `normalization`
- `to_df_seq`: `match_residue_type`, `exclude_other_annotations`, `pos_col`, `aa_context_col`

The 5 offline notebooks are re-executed with saved outputs; `annp_fetch_uniprot` stays a commented network stub. Notebook + baseline only, no library behaviour changes.

Verified locally: `test_notebook_param_coverage.py` (6/6) and `pytest --nbmake` on all 6 touched notebooks.

This PR intentionally omits a closing keyword so #345 stays open for the remaining subpackages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
