### PR TITLE
docs: predict_proba score_range clarity + g-sec n_filter warning note

### DIFF
--- a/aaanalysis/prediction/_aa_pred.py
+++ b/aaanalysis/prediction/_aa_pred.py
@@ -874,6 +874,9 @@ class AAPred(Wrapper):
         score_range : str, default="proba"
             Scale of the returned ``score`` / ``score_std`` columns: ``'proba'`` for the native
             probabilities in ``[0, 1]``, ``'percent'`` for the same values scaled to ``[0, 100]``.
+            The output column is the generic ``score`` (shared with :meth:`predict` /
+            :meth:`predict_oof`), so ``'percent'`` returns a 0-100 score even though this method
+            computes probabilities.
 
         Returns
         -------

--- a/use_cases/use_case1_gamma_secretase.ipynb
+++ b/use_cases/use_case1_gamma_secretase.ipynb
@@ -685,6 +685,14 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "id": "nfilter-warning-note",
+   "source": [
+    "> **Learning — the ``UserWarning`` above.** ``CPP.run`` / ``CPPGrid`` select up to ``n_filter`` (=150) features, but the number of *candidate* features a configuration can actually produce is ``parts × splits × scales``. The **TMD (wo CPP)** baseline uses a single segment (one feature per scale), so on **scale set 5** (133 scales) it can only generate 133 candidates — fewer than ``n_filter``. CPP then keeps every candidate and warns that ``n_filter`` exceeds what the configuration can produce. This is **informational, not an error**: the smaller feature space is used as-is and the benchmark is unaffected. Lower ``n_filter`` (or use a larger scale set / richer ``split_kws``) to avoid the warning."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "8af19c2d",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## Summary
Docs-only cleanup follow-up to the API PR (#430). Two clarifications, no code/behavior change:

1. **`AAPred.predict_proba` docstring** — `score_range="percent"` returns a 0–100 `score` despite the "proba" name; note the output column is the generic `score` (shared with `predict`/`predict_oof`).
2. **γ-secretase notebook** — a "learning" markdown note explaining the benign `n_filter=150 > 133` `UserWarning` from the CPP feature-space benchmark: `CPP.run`/`CPPGrid` keep up to `n_filter` features, but the single-segment "TMD (wo CPP)" baseline on scale set 5 (133 scales) can only generate 133 candidates, so CPP caps to what's available and warns — informational, not an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)