### PR TITLE
Fix version truth: bump to 1.1.0 + version-ahead-of-PyPI guard + tag hygiene

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -63,25 +63,33 @@ python dev_scripts/dev_aa_window_sampler.py
   labels use `df_seq["label"].to_list()`, not `len(df_seq)`-based assumptions.
 - **Coverage is measured on the package only** — `--cov=aaanalysis`, never
   `--cov=./` (that counts the test files and inflates the number). See ADR-0016.
-- **Pushing to `master` triggers up to 5 code-gated workflows** (Unit Tests, Test
-  Coverage, CodeQL, Integration & E2E Tests, and the Perf A/B regression gate);
-  the same five run on PRs to master, while feature-branch *pushes* trigger none
-  (CI is gated to master push/PR). The exact-value CPP regression anchor
-  (`-m regression`) runs only in the nightly, not the blocking matrix (ADR-0015);
-  the Perf gate benchmarks current-vs-latest-release on one runner (ADR-0037). A
-  6th workflow, **ADR hygiene** (`adr_hygiene.yml`), is path-*scoped* the other
-  way — it carries `paths: ['docs/adr/**']`, so it fires **only** when a push/PR
-  touches an ADR (running `check_adrs.py`: duplicate-number / cross-ref / index
-  gate) and is skipped otherwise.
-- **Docs-only pushes skip the 4 code-gated workflows.** Unit Tests (`main.yml`),
-  CodeQL, Integration & E2E, and the Perf gate (`perf_nightly.yml`) all carry
-  `paths-ignore: ['docs/**', '**/*.md', '**/*.rst']`, so a commit touching only
-  those paths runs **none** of them. Test Coverage (`test_coverage.yml`)
-  deliberately has **no `paths-ignore`** and runs on every master push (the
-  Codecov badge must stay current). So a docs-only push that **doesn't** touch
-  `docs/adr/**` triggers exactly **one** workflow (Test Coverage); one that
-  **does** touch an ADR triggers **two** (Test Coverage + ADR hygiene). Don't
-  tell the user "all 5 will run" for a docs-only change.
+- **A push/PR to `master` triggers up to 8 workflows**, in two groups. Feature-branch
+  *pushes* trigger none (CI is gated to master push/PR). **Verify against
+  `.github/workflows/*` before quoting this — it drifts.**
+  - **Code-gated (6)** — each carries `paths-ignore: ['docs/**', '**/*.md',
+    '**/*.rst']`: **Unit Tests** (`main.yml`), **CodeQL** (`codeql_analysis.yml`),
+    **Integration & E2E Tests** (`integration_e2e.yml`), **Perf (A/B regression gate)**
+    (`perf_nightly.yml`), **Version Guard** (`version_guard.yml`), and **Type Check
+    (advisory)** (`pyright.yml` — reports, never gates).
+  - **Always-run (2)** — deliberately **no `paths-ignore`**, so they run on *every*
+    master push including docs-only: **Test Coverage** (`test_coverage.yml`; the
+    Codecov badge must stay current) and **Packaging** (`packaging.yml`; required
+    checks must not be "skipped-but-required", ADR-0060).
+
+  The exact-value CPP regression anchor (`-m regression`) runs only in the nightly,
+  not the blocking matrix (ADR-0015); the Perf gate benchmarks
+  current-vs-latest-release on one runner (ADR-0037); Version Guard asserts the
+  pyproject version is ahead of the latest PyPI release.
+- **Two more are path-*scoped* the other way** (they fire only for their paths):
+  **ADR hygiene** (`adr_hygiene.yml`, `paths: ['docs/adr/**']` — `check_adrs.py`:
+  duplicate-number / cross-ref / index gate) and **Visual Regression**
+  (`visual_regression.yml`, PR-only, scoped to `aaanalysis/**/*.py` +
+  `tests/unit/plotting_tests/**`).
+- **A docs-only push does NOT skip everything.** It skips all 6 code-gated workflows
+  but still runs the 2 always-run ones — so a docs-only push that **doesn't** touch
+  `docs/adr/**` triggers **two** (Test Coverage + Packaging); one that **does** touch
+  an ADR triggers **three** (+ ADR hygiene). Don't tell the user "all of CI will run"
+  for a docs-only change — nor that nothing will.
 
 ## Git / PR workflow
 

--- a/.github/scripts/check_version_ahead.py
+++ b/.github/scripts/check_version_ahead.py
@@ -1,0 +1,199 @@
+"""
+This is a script for the version-truth guard.
+
+``master`` must never report a version that is already published on PyPI. Both a
+development checkout and a released install otherwise answer ``1.0.3`` to
+``importlib.metadata.version("aaanalysis")``, which makes two materially
+different trees indistinguishable to humans, agents, bug reports, cached
+workflows, and scientific reproducibility.
+
+The scheme is a **plain manual version** in ``pyproject.toml`` plus this CI
+divergence guard: after each release the maintainer bumps ``[project] version``
+to the next unreleased number, and this script asserts that the number is
+strictly greater than the latest release published on PyPI. Deriving the version
+from git tags (setuptools-scm) was rejected: it produces ``.devN`` / ``+g<sha>``
+proliferation.
+
+The published version is resolved from the PyPI JSON API, falling back to the
+latest ``vX.Y.Z`` git tag when the network is unavailable (so the guard still
+works offline). Requires ``fetch-depth: 0`` in CI for the tag fallback to see
+any tags.
+
+This is CI tooling, not library code, so it prints to stdout for the CI log
+(the package itself never calls ``print`` -- it uses ``ut.print_out``).
+
+Local use::
+
+    python .github/scripts/check_version_ahead.py             # PyPI, git-tag fallback
+    python .github/scripts/check_version_ahead.py --offline    # git tags only
+
+Exit codes: ``0`` the version is ahead (or the check is inconclusive), ``1`` the
+version is behind or equal to the latest published release -- bump
+``[project] version`` in ``pyproject.toml``.
+"""
+import sys
+import re
+import json
+import subprocess
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+from packaging.version import Version, InvalidVersion
+
+# The repo root is two levels up from ``.github/scripts/``.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+DIST_NAME = "aaanalysis"
+PYPI_JSON_URL = "https://pypi.org/pypi/{name}/json"
+PYPI_TIMEOUT_S = 10
+
+# Release tags are ``vX.Y.Z``; the leading ``v`` is optional so the legacy
+# ``0.1.1`` tag (predating the convention) still parses instead of being
+# silently skipped.
+TAG_PATTERN = re.compile(r"^v?(\d+(?:\.\d+)*.*)$")
+
+# ``pyproject.toml`` carries both a ``[project]`` and a ``[tool.poetry]`` block.
+# Only ``[project]`` is authoritative, so the fallback parser is section-scoped
+# rather than grepping the file for any ``version =`` line.
+SECTION_HEADER_PATTERN = re.compile(r"^\s*\[([^\]]+)\]\s*$")
+VERSION_ASSIGN_PATTERN = re.compile(r"""^\s*version\s*=\s*["']([^"']+)["']""")
+
+
+# I Helper Functions
+def parse_project_version(path=PYPROJECT_PATH):
+    """Return the ``[project] version`` string declared in ``pyproject.toml``.
+
+    Uses ``tomllib`` where available (Python >= 3.11) and falls back to a
+    section-scoped scan on the 3.10 floor, so the guard stays stdlib-only across
+    the whole supported matrix.
+    """
+    text = Path(path).read_text(encoding="utf-8")
+    try:
+        import tomllib
+    except ImportError:                     # Python 3.10 -- no tomllib in stdlib
+        return _parse_project_version_fallback(text, path)
+    data = tomllib.loads(text)
+    try:
+        return data["project"]["version"]
+    except KeyError:
+        raise RuntimeError(f"no [project] version declared in {path}")
+
+
+def _parse_project_version_fallback(text, path):
+    """Return the ``version`` assigned inside the ``[project]`` section of ``text``."""
+    in_project = False
+    for line in text.splitlines():
+        header = SECTION_HEADER_PATTERN.match(line)
+        if header:
+            in_project = header.group(1).strip() == "project"
+            continue
+        if in_project:
+            match = VERSION_ASSIGN_PATTERN.match(line)
+            if match:
+                return match.group(1)
+    raise RuntimeError(f"no [project] version declared in {path}")
+
+
+def fetch_latest_pypi_version(name=DIST_NAME, timeout=PYPI_TIMEOUT_S):
+    """Return the latest version published on PyPI, or ``None`` if unreachable.
+
+    ``info.version`` is PyPI's own "latest release" pointer, so yanked and
+    pre-release uploads do not have to be filtered out by hand.
+    """
+    url = PYPI_JSON_URL.format(name=name)
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as e:
+        print(f"[version-guard] PyPI unreachable ({e!r}); falling back to git tags.")
+        return None
+    return payload["info"]["version"]
+
+
+def latest_git_tag_version(repo_root=REPO_ROOT):
+    """Return the highest release version among the repo's git tags, or ``None``.
+
+    Tags are sorted by parsed version rather than by name so ``v1.0.10`` beats
+    ``v1.0.9``. Non-release tags that do not parse are skipped.
+    """
+    try:
+        proc = subprocess.run(["git", "tag", "--list"], cwd=str(repo_root),
+                              capture_output=True, text=True, check=True)
+    except (OSError, subprocess.CalledProcessError) as e:
+        print(f"[version-guard] could not list git tags ({e!r}).")
+        return None
+    versions = []
+    for tag in proc.stdout.split():
+        match = TAG_PATTERN.match(tag)
+        if not match:
+            continue
+        try:
+            versions.append(Version(match.group(1)))
+        except InvalidVersion:
+            continue
+    if not versions:
+        return None
+    return str(max(versions))
+
+
+def resolve_published_version(offline=False, name=DIST_NAME, repo_root=REPO_ROOT):
+    """Return ``(version_str, source)`` for the latest published release.
+
+    Prefers PyPI (the actual publication record) and falls back to git tags when
+    the network is unavailable. ``(None, "unavailable")`` when neither resolves.
+    """
+    if not offline:
+        published = fetch_latest_pypi_version(name=name)
+        if published is not None:
+            return published, "PyPI"
+    published = latest_git_tag_version(repo_root=repo_root)
+    if published is not None:
+        return published, "git tag"
+    return None, "unavailable"
+
+
+def is_ahead(project_version, published_version):
+    """Return True when ``project_version`` is strictly newer than ``published_version``."""
+    return Version(project_version) > Version(published_version)
+
+
+# II Main Functions
+def main(argv=None):
+    argv = sys.argv[1:] if argv is None else argv
+    offline = "--offline" in argv
+
+    # Pass the paths explicitly rather than relying on the def-time default
+    # bindings, so the module-level constants are read at call time.
+    project_version = parse_project_version(PYPROJECT_PATH)
+    published_version, source = resolve_published_version(offline=offline,
+                                                          repo_root=REPO_ROOT)
+
+    if published_version is None:
+        # Neither PyPI nor a git tag resolved. That is an infrastructure failure,
+        # not a version error, so it must not block every merge in the repo --
+        # report loudly and pass.
+        print(f"[version-guard] INCONCLUSIVE: pyproject is {project_version} but no "
+              f"published version could be resolved (PyPI unreachable and no git "
+              f"tags). Not failing the build on an infrastructure error.")
+        return 0
+
+    print(f"[version-guard] pyproject: {project_version} | "
+          f"latest published ({source}): {published_version}")
+
+    if not is_ahead(project_version, published_version):
+        print(f"FAIL: pyproject version {project_version} is not ahead of the latest "
+              f"published release {published_version}. The development tree would "
+              f"report an already-published version, making two different installs "
+              f"indistinguishable.\n"
+              f"      Fix: bump [project] version in pyproject.toml above "
+              f"{published_version}.")
+        return 1
+
+    print(f"OK: {project_version} > {published_version} (development tree reports an "
+          f"unreleased version).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/version_guard.yml
+++ b/.github/workflows/version_guard.yml
@@ -1,0 +1,53 @@
+name: Version Guard
+
+# Asserts that [project] version in pyproject.toml is strictly ahead of the latest
+# release published on PyPI, so a development tree never reports an already-published
+# version (both would otherwise answer the same string to importlib.metadata, making
+# two materially different installs indistinguishable).
+#
+# Code-gated: docs-only changes cannot alter the declared version, so they carry the
+# same paths-ignore as the other code-gated workflows. pyproject.toml is not a docs
+# path, so every version edit still runs this guard.
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '**/*.rst'
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '**/*.rst'
+
+# Cancel a superseded in-progress run on the same branch/PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  version-ahead:
+    name: Version ahead of PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history + tags: the guard falls back to the latest vX.Y.Z tag when
+          # the PyPI API is unreachable, and the default shallow checkout fetches
+          # no tags at all.
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Install packaging
+        run: python -m pip install --upgrade packaging
+      - name: Check the version is ahead of the latest PyPI release
+        run: python .github/scripts/check_version_ahead.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,15 @@ and a suite of site-localization metrics and plotting helpers.
   marking public symbols deprecated under the strict-semver policy (internal
   helper; not part of the public API).
 - This `CHANGELOG.md`.
+- `Version Guard` CI workflow (`.github/scripts/check_version_ahead.py`): fails a
+  build unless `[project] version` is strictly ahead of the latest release published
+  on PyPI (git-tag fallback offline), so `master` never reports a published version.
 
 ### Changed
+- **Version bumped to `1.1.0`** (from the published `1.0.3`), so a development
+  checkout is distinguishable from a released install. The version stays manually
+  maintained and always names the next unreleased number; see *Version truth* in
+  `CONTRIBUTING.rst`.
 - **Uniform plot return contract: every `*Plot` method now returns a `(fig, ax)`
   pair.** Previously the methods returned three inconsistent shapes (`(fig, ax)`,
   a bare `Axes`, or `(ax, df)`). The returned object is a thin tuple subclass that

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -363,6 +363,30 @@ AAanalysis follows `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_
 is exactly the set of symbols re-exported by ``aaanalysis/__init__.py`` (anything
 starting with ``_`` is private and may change without notice).
 
+Version truth
+-------------
+
+``master`` must **never** report a version that is already published on PyPI. The
+version in ``pyproject.toml`` is maintained by hand and always names the *next,
+unreleased* number, so a development checkout and a released install are never
+indistinguishable to ``importlib.metadata`` (and therefore to bug reports, cached
+environments, coding agents, and reproducibility records).
+
+CI enforces this: the ``Version Guard`` workflow runs
+``.github/scripts/check_version_ahead.py``, which fails when the declared version is
+not strictly greater than the latest release published on PyPI (falling back to the
+latest ``vX.Y.Z`` git tag when the network is unavailable). Run it locally with:
+
+.. code-block:: bash
+
+   python .github/scripts/check_version_ahead.py
+   python .github/scripts/check_version_ahead.py --offline   # git tags only
+
+The version is deliberately **not** derived from git tags (e.g. setuptools-scm),
+which would attach ``.devN`` / ``+g<sha>`` suffixes to every commit. Release tags are
+named ``vX.Y.Z``; the pre-1.0 ``0.1.1`` tag predates that convention and the guard
+accepts both spellings.
+
 Deprecation policy
 ------------------
 
@@ -422,9 +446,11 @@ AAanalysis is packaged with the setuptools build backend (for the Cython kernel)
 
       pip install uv
 
-2. **Update the version**
+2. **Confirm the version to release**
 
-   Update the version number (**MAJOR.MINOR.PATCH**) in ``pyproject.toml``.
+   ``master`` already carries the next unreleased version (see `Version truth`_), so
+   the number in ``pyproject.toml`` is normally the one you are about to release.
+   Confirm it still matches the change set instead of bumping it a second time.
 
    Versioning follows semantic versioning:
 
@@ -432,7 +458,8 @@ AAanalysis is packaged with the setuptools build backend (for the Cython kernel)
    - **MINOR**: backward-compatible new functionality
    - **PATCH**: backward-compatible bug fixes
 
-   Alternatively, uv can update the version automatically:
+   If the number needs to change, edit ``[project] version`` in ``pyproject.toml``
+   (uv can do it for you):
 
    .. code-block:: bash
 
@@ -441,6 +468,9 @@ AAanalysis is packaged with the setuptools build backend (for the Cython kernel)
       uv version --bump minor
       # or
       uv version --bump major
+
+   Then rename the ``Unreleased`` heading in ``CHANGELOG.md`` and
+   ``docs/source/index/release_notes.rst`` to this version with its release date.
 
 3. **Build the package**
 
@@ -465,3 +495,19 @@ AAanalysis is packaged with the setuptools build backend (for the Cython kernel)
 5. **Verify the upload**
 
    After publishing, verify that the package appears correctly on PyPI and that the metadata and files are accurate.
+
+6. **Tag the release, then bump master ahead again**
+
+   Tag the released commit and push the tag:
+
+   .. code-block:: bash
+
+      git tag -a v1.1.0 -m "v1.1.0"
+      git push origin v1.1.0
+
+   Then **immediately** bump ``[project] version`` in ``pyproject.toml`` to the next
+   unreleased number (e.g. ``1.2.0``) and open a fresh ``Unreleased`` section in
+   ``CHANGELOG.md`` and ``docs/source/index/release_notes.rst``. This is the step that
+   keeps `Version truth`_ intact: until it lands, ``master`` reports a version that is
+   already on PyPI and the ``Version Guard`` workflow fails -- by design, as the
+   reminder that the bump is still owed.

--- a/docs/adr/XXXX-manual-version-truth-guard.md
+++ b/docs/adr/XXXX-manual-version-truth-guard.md
@@ -1,0 +1,96 @@
+# ADR-XXXX — Version truth: a manual version kept ahead of PyPI, enforced by a CI divergence guard
+
+Status: Accepted — 2026-07-16
+
+## Context
+
+`pyproject.toml` on `master` declared `version = "1.0.3"` — byte-identical to the PyPI 1.0.3 release
+(Apr 2026) — while `master` carried substantial unreleased work (AAPred, SeqOpt, ReliabilityModel,
+the golden pipelines, and more). Both trees therefore answered `1.0.3` to
+`importlib.metadata.version("aaanalysis")`, so a development checkout and a released install were
+**indistinguishable from the outside**. That breaks bug triage (a reported "1.0.3" could be either
+tree), cached environments, coding agents reasoning about capabilities, and scientific
+reproducibility — the version string is the one identifier a published analysis records. It also
+made the "Production/Stable" classifier premature, and it is the state ADR-0060 worked around when
+it noted "v1.1 unreleased (`pyproject` at `1.0.3`)".
+
+Nothing detected the divergence: the version is a hand-edited constant touched only at release time,
+and no check compared it against what was actually published.
+
+## Decision
+
+**D1 — The declared version is manual and must always name the *next, unreleased* number.** It stays
+a plain hand-edited `[project] version` string in `pyproject.toml`. The invariant is
+`pyproject_version > latest_published_release`, held at all times on `master`, not just at release
+time. `master` is bumped to `1.1.0`, matching the `v1.1.0 (Unreleased)` section the release notes
+already declared.
+
+**D2 — A dedicated `version_guard.yml` workflow enforces the invariant.**
+`.github/scripts/check_version_ahead.py` parses `[project] version`, resolves the latest published
+release, and exits non-zero unless the declared version is strictly greater. It is its own workflow
+rather than a step bolted onto an existing job so the failure is legible on its own status line, and
+so it can be made a required check independently. It is **code-gated** (the same
+`paths-ignore: docs/**, **/*.md, **/*.rst` as the other code-gated workflows): a docs-only change
+cannot alter the declared version, and `pyproject.toml` is not a docs path, so every version edit
+still runs it.
+
+**D3 — PyPI is the source of truth for "published", with git tags as an offline fallback.** The
+guard reads PyPI's `info.version` (its own latest-release pointer, so yanked and pre-release uploads
+need no hand-filtering). When the API is unreachable it falls back to the highest `vX.Y.Z` git tag,
+which keeps the guard usable locally and offline; CI checks out with `fetch-depth: 0` so tags are
+present. Tags are compared by *parsed version*, not by name, so `v1.0.10` beats `v1.0.9`.
+
+**D4 — An unresolvable "published" version reports loudly and passes.** If PyPI is unreachable *and*
+no git tags exist, the guard prints `INCONCLUSIVE` and exits 0. A PyPI outage is an infrastructure
+failure, not a version error, and must not block every merge in the repo; the real defect this guard
+exists to catch (a forgotten bump) is always detectable when either source resolves.
+
+**D5 — Release tags are `vX.Y.Z`; the guard tolerates the legacy unprefixed spelling.** The tag regex
+accepts an optional leading `v`, so the pre-1.0 `0.1.1` tag (which predates the convention) still
+parses and counts instead of being silently skipped. This is the "set the tag regex the guard reads"
+half of the tag-hygiene requirement: it makes the guard correct today without a tag rename, which
+would mean deleting a published remote tag. Renaming `0.1.1` → `v0.1.1` is left to the maintainer as
+cosmetic cleanup, not a correctness fix.
+
+## Rejected alternatives
+
+- **Derive the version from git tags (setuptools-scm / hatch-vcs).** The obvious "single source of
+  truth" answer, and it makes divergence structurally impossible. Rejected because it attaches
+  `.devN` / `+g<sha>` suffixes to every non-tagged commit: every dev install reports a distinct
+  noisy string, the version stops being a stable thing a human can quote in an issue, and the build
+  gains a VCS dependency (a `pip install` from a tarball without `.git` has no version at all). For
+  a package with infrequent, deliberate, manual releases, the cost outweighs the benefit — the same
+  guarantee is obtainable from one CI check over a hand-edited constant.
+- **`.devN` / pre-release suffixes on `master` (e.g. `1.1.0.dev0`).** Truthful, and conventional in
+  many projects. Rejected for the proliferation it invites (which commit is `dev7`?) and because it
+  buys nothing the strict `>` comparison does not already give: `1.1.0` on `master` is *already*
+  distinguishable from the published `1.0.3`.
+- **Fail the build when the published version cannot be resolved.** Strictly safer in theory, but it
+  converts every PyPI outage into a repo-wide merge freeze. Rejected; see D4.
+- **Fold the check into an existing workflow (e.g. the packaging or unit-test job).** Fewer
+  workflows, but the failure would be buried inside an unrelated job's log and could not be required
+  on its own. Rejected; see D2.
+- **Compare against the newest git tag only, never touching the network.** Simpler and hermetic, but
+  a tag is a *local claim* about a release while PyPI is the *actual* publication record; the two can
+  drift (a tag pushed without a publish, or a publish from an untagged commit). Rejected as the
+  primary source, kept as the fallback.
+
+## Consequences
+
+- `master` now reports `1.1.0`; `python -c "import aaanalysis; print(aaanalysis.__version__)"` no
+  longer collides with the published release.
+- The release procedure gains a closing step: after publishing `X.Y.Z` and tagging `vX.Y.Z`,
+  immediately bump `master` to the next unreleased number. Until that lands the guard fails — by
+  design, as the reminder that the bump is owed. Documented under *Version truth* in
+  `CONTRIBUTING.rst` and its RTD port.
+- The comparison logic is pinned by unit tests with fixtures (`test_check_version_ahead.py`),
+  including the exact regression (declared == published must fail) and the dual
+  `[project]` / `[tool.poetry]` block sharp edge.
+
+## Out of scope
+
+- **Docs-version coherence** (`conf.py` `version` / `release`, RTD stable-vs-latest, the dev banner)
+  — tracked separately; this ADR covers only the package version string.
+- **Renaming the `0.1.1` tag** to `v0.1.1` — maintainer cleanup; the guard already handles it (D5).
+- **Trusted publishing / release-job hardening / a single canonical release path** — separate
+  release-maturity work.

--- a/docs/source/index/CONTRIBUTING_COPY.rst
+++ b/docs/source/index/CONTRIBUTING_COPY.rst
@@ -366,6 +366,30 @@ AAanalysis follows `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_
 is exactly the set of symbols re-exported by ``aaanalysis/__init__.py`` (anything
 starting with ``_`` is private and may change without notice).
 
+Version truth
+-------------
+
+``master`` must **never** report a version that is already published on PyPI. The
+version in ``pyproject.toml`` is maintained by hand and always names the *next,
+unreleased* number, so a development checkout and a released install are never
+indistinguishable to ``importlib.metadata`` (and therefore to bug reports, cached
+environments, coding agents, and reproducibility records).
+
+CI enforces this: the ``Version Guard`` workflow runs
+``.github/scripts/check_version_ahead.py``, which fails when the declared version is
+not strictly greater than the latest release published on PyPI (falling back to the
+latest ``vX.Y.Z`` git tag when the network is unavailable). Run it locally with:
+
+.. code-block:: bash
+
+   python .github/scripts/check_version_ahead.py
+   python .github/scripts/check_version_ahead.py --offline   # git tags only
+
+The version is deliberately **not** derived from git tags (e.g. setuptools-scm),
+which would attach ``.devN`` / ``+g<sha>`` suffixes to every commit. Release tags are
+named ``vX.Y.Z``; the pre-1.0 ``0.1.1`` tag predates that convention and the guard
+accepts both spellings.
+
 Deprecation policy
 ------------------
 
@@ -425,9 +449,11 @@ AAanalysis is packaged with the setuptools build backend (for the Cython kernel)
 
       pip install uv
 
-2. **Update the version**
+2. **Confirm the version to release**
 
-   Update the version number (**MAJOR.MINOR.PATCH**) in ``pyproject.toml``.
+   ``master`` already carries the next unreleased version (see `Version truth`_), so
+   the number in ``pyproject.toml`` is normally the one you are about to release.
+   Confirm it still matches the change set instead of bumping it a second time.
 
    Versioning follows semantic versioning:
 
@@ -435,7 +461,8 @@ AAanalysis is packaged with the setuptools build backend (for the Cython kernel)
    - **MINOR**: backward-compatible new functionality
    - **PATCH**: backward-compatible bug fixes
 
-   Alternatively, uv can update the version automatically:
+   If the number needs to change, edit ``[project] version`` in ``pyproject.toml``
+   (uv can do it for you):
 
    .. code-block:: bash
 
@@ -444,6 +471,9 @@ AAanalysis is packaged with the setuptools build backend (for the Cython kernel)
       uv version --bump minor
       # or
       uv version --bump major
+
+   Then rename the ``Unreleased`` heading in ``CHANGELOG.md`` and
+   ``docs/source/index/release_notes.rst`` to this version with its release date.
 
 3. **Build the package**
 
@@ -468,6 +498,22 @@ AAanalysis is packaged with the setuptools build backend (for the Cython kernel)
 5. **Verify the upload**
 
    After publishing, verify that the package appears correctly on PyPI and that the metadata and files are accurate.
+
+6. **Tag the release, then bump master ahead again**
+
+   Tag the released commit and push the tag:
+
+   .. code-block:: bash
+
+      git tag -a v1.1.0 -m "v1.1.0"
+      git push origin v1.1.0
+
+   Then **immediately** bump ``[project] version`` in ``pyproject.toml`` to the next
+   unreleased number (e.g. ``1.2.0``) and open a fresh ``Unreleased`` section in
+   ``CHANGELOG.md`` and ``docs/source/index/release_notes.rst``. This is the step that
+   keeps `Version truth`_ intact: until it lands, ``master`` reports a version that is
+   already on PyPI and the ``Version Guard`` workflow fails -- by design, as the
+   reminder that the bump is still owed.
 
 Agentic Engineering
 ===================

--- a/docs/source/index/release_notes.rst
+++ b/docs/source/index/release_notes.rst
@@ -653,6 +653,16 @@ Changed
   load — across the min + max supported Python (3.10, 3.14). It catches a missing package-data file,
   a broken re-export, or a sdist that cannot build before a release reaches PyPI, where the editable
   dev matrix cannot. No public-API change.
+- **Version truth**: ``aaanalysis.__version__`` on ``master`` is now ``1.1.0`` and no longer collides
+  with the published ``1.0.3`` release, so a development checkout and a released install are
+  distinguishable — for bug reports, cached environments, and reproducibility records alike. A
+  ``Version Guard`` workflow (``.github/workflows/version_guard.yml``) enforces the invariant on every
+  push / PR to ``master``: ``.github/scripts/check_version_ahead.py`` fails the build unless the
+  declared version is strictly ahead of the latest release published on PyPI (falling back to the
+  latest ``vX.Y.Z`` git tag offline). The version stays a hand-edited ``pyproject.toml`` string —
+  deriving it from git tags was rejected to avoid ``.devN`` / ``+g<sha>`` proliferation. Release
+  procedure gains one closing step: after publishing, bump ``master`` to the next unreleased number
+  (see *Version truth* in ``CONTRIBUTING.rst``). No public-API change.
 - **Named logger for library output**: all package messages now flow through
   ``logging.getLogger("aaanalysis")``. ``print_out`` (``ut.print_out``) is a thin, permanent
   shim over ``logger.info(...)`` — the function name and signature are unchanged, so every

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,11 @@ build-backend = "setuptools.build_meta"
 # -------------------------
 [project]
 name = "aaanalysis"
-version = "1.0.3"
+# Manually maintained and always AHEAD of the latest PyPI release, so a development
+# tree never reports an already-published version. After publishing X.Y.Z (and
+# tagging vX.Y.Z), bump this to the next unreleased number in the same step.
+# Enforced by .github/workflows/version_guard.yml.
+version = "1.1.0"
 description = "Python framework for interpretable protein prediction"
 readme = "README.rst"
 requires-python = ">=3.10"

--- a/tests/unit/api_tests/test_check_version_ahead.py
+++ b/tests/unit/api_tests/test_check_version_ahead.py
@@ -1,0 +1,231 @@
+"""Tests for the version-truth guard (``.github/scripts/check_version_ahead.py``).
+
+These exercise the comparison *logic* with fixtures, so no network call is made in
+the unit matrix. The KPI pinned here is the issue-#441 acceptance criterion: the
+guard fails a build when the pyproject version is <= the latest published PyPI
+release, and passes when it is strictly ahead.
+
+The guard is CI tooling rather than library code, so it is loaded from its script
+path the same way the perf-regression guard's tests load theirs.
+"""
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / ".github" / "scripts" / "check_version_ahead.py"
+
+PYPROJECT_TEMPLATE = """\
+[build-system]
+requires = ["setuptools"]
+
+[project]
+name = "aaanalysis"
+version = "{version}"
+description = "Python framework for interpretable protein prediction"
+
+[tool.poetry]
+name = "aaanalysis"
+version = "{poetry_version}"
+"""
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_version_ahead", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def mod():
+    return _load_module()
+
+
+def _write_pyproject(tmp_path, version, poetry_version="0.0.1"):
+    path = tmp_path / "pyproject.toml"
+    path.write_text(PYPROJECT_TEMPLATE.format(version=version,
+                                              poetry_version=poetry_version),
+                    encoding="utf-8")
+    return path
+
+
+# I is_ahead() -- the core comparison the guard gates on
+class TestIsAhead:
+    """Test the version comparison in isolation."""
+
+    def test_equal_version_is_not_ahead(self, mod):
+        """KPI: the exact bug -- master declaring the published version."""
+        assert mod.is_ahead("1.0.3", "1.0.3") is False
+
+    def test_older_version_is_not_ahead(self, mod):
+        assert mod.is_ahead("1.0.2", "1.0.3") is False
+
+    def test_minor_bump_is_ahead(self, mod):
+        """KPI: the fix -- 1.1.0 on master against the published 1.0.3."""
+        assert mod.is_ahead("1.1.0", "1.0.3") is True
+
+    def test_patch_bump_is_ahead(self, mod):
+        assert mod.is_ahead("1.0.4", "1.0.3") is True
+
+    def test_major_bump_is_ahead(self, mod):
+        assert mod.is_ahead("2.0.0", "1.0.3") is True
+
+    def test_comparison_is_numeric_not_lexicographic(self, mod):
+        """``1.0.10`` beats ``1.0.9`` numerically but loses as a string."""
+        assert mod.is_ahead("1.0.10", "1.0.9") is True
+
+    def test_prerelease_is_ahead_of_published_release(self, mod):
+        assert mod.is_ahead("1.1.0rc1", "1.0.3") is True
+
+    def test_prerelease_of_published_version_is_not_ahead(self, mod):
+        """``1.1.0rc1`` sorts *below* the final ``1.1.0`` under PEP 440."""
+        assert mod.is_ahead("1.1.0rc1", "1.1.0") is False
+
+
+# II parse_project_version() -- reads [project], never [tool.poetry]
+class TestParseProjectVersion:
+    """Test the pyproject parsing, including the dual-block sharp edge."""
+
+    def test_reads_project_version(self, mod, tmp_path):
+        path = _write_pyproject(tmp_path, "1.1.0")
+        assert mod.parse_project_version(path) == "1.1.0"
+
+    def test_ignores_tool_poetry_version(self, mod, tmp_path):
+        """``pyproject.toml`` carries both blocks; only ``[project]`` is authoritative."""
+        path = _write_pyproject(tmp_path, "1.1.0", poetry_version="9.9.9")
+        assert mod.parse_project_version(path) == "1.1.0"
+
+    def test_fallback_parser_reads_project_version(self, mod, tmp_path):
+        """The 3.10 path (no ``tomllib``) must agree with the ``tomllib`` path."""
+        path = _write_pyproject(tmp_path, "1.1.0", poetry_version="9.9.9")
+        text = path.read_text(encoding="utf-8")
+        assert mod._parse_project_version_fallback(text, path) == "1.1.0"
+
+    def test_missing_project_version_raises(self, mod, tmp_path):
+        path = tmp_path / "pyproject.toml"
+        path.write_text("[project]\nname = \"aaanalysis\"\n", encoding="utf-8")
+        with pytest.raises(RuntimeError, match="no \\[project\\] version"):
+            mod.parse_project_version(path)
+
+    def test_fallback_missing_project_version_raises(self, mod, tmp_path):
+        text = "[tool.poetry]\nversion = \"9.9.9\"\n"
+        with pytest.raises(RuntimeError, match="no \\[project\\] version"):
+            mod._parse_project_version_fallback(text, tmp_path / "pyproject.toml")
+
+
+# III latest_git_tag_version() -- the offline fallback + tag-naming tolerance
+class TestLatestGitTagVersion:
+    """Test the git-tag fallback used when PyPI is unreachable."""
+
+    def test_tag_pattern_accepts_v_prefix(self, mod):
+        assert mod.TAG_PATTERN.match("v1.0.3").group(1) == "1.0.3"
+
+    def test_tag_pattern_accepts_legacy_unprefixed_tag(self, mod):
+        """The legacy ``0.1.1`` tag predates the ``vX.Y.Z`` convention."""
+        assert mod.TAG_PATTERN.match("0.1.1").group(1) == "0.1.1"
+
+    def test_tag_pattern_rejects_non_release_tag(self, mod):
+        assert mod.TAG_PATTERN.match("nightly") is None
+
+    def test_picks_highest_version_not_highest_string(self, mod, monkeypatch):
+        """Tags sort by parsed version: ``v1.0.10`` > ``v1.0.9``."""
+        monkeypatch.setattr(mod.subprocess, "run",
+                            lambda *a, **k: _FakeProc("v1.0.9\nv1.0.10\nv1.0.3\n"))
+        assert mod.latest_git_tag_version() == "1.0.10"
+
+    def test_mixed_and_unparseable_tags(self, mod, monkeypatch):
+        """Non-release tags are skipped; the legacy tag still counts."""
+        monkeypatch.setattr(mod.subprocess, "run",
+                            lambda *a, **k: _FakeProc("0.1.1\nnightly\nv1.0.3\n"))
+        assert mod.latest_git_tag_version() == "1.0.3"
+
+    def test_no_tags_returns_none(self, mod, monkeypatch):
+        monkeypatch.setattr(mod.subprocess, "run", lambda *a, **k: _FakeProc(""))
+        assert mod.latest_git_tag_version() is None
+
+
+class _FakeProc:
+    """Minimal stand-in for ``subprocess.run``'s CompletedProcess."""
+
+    def __init__(self, stdout):
+        self.stdout = stdout
+        self.returncode = 0
+
+
+# IV main() -- exit codes (the actual CI gate)
+class TestMainExitCodes:
+    """Test the pass/fail contract CI depends on."""
+
+    def _patch(self, mod, monkeypatch, tmp_path, project_version, published):
+        path = _write_pyproject(tmp_path, project_version)
+        monkeypatch.setattr(mod, "PYPROJECT_PATH", path)
+        monkeypatch.setattr(mod, "resolve_published_version",
+                            lambda **kwargs: (published, "PyPI"))
+
+    def test_fails_when_version_equals_latest_release(self, mod, monkeypatch, tmp_path):
+        """KPI: the guard fails a build when pyproject version <= latest PyPI release."""
+        self._patch(mod, monkeypatch, tmp_path, "1.0.3", "1.0.3")
+        assert mod.main([]) == 1
+
+    def test_fails_when_version_behind_latest_release(self, mod, monkeypatch, tmp_path):
+        self._patch(mod, monkeypatch, tmp_path, "1.0.2", "1.0.3")
+        assert mod.main([]) == 1
+
+    def test_passes_when_version_ahead(self, mod, monkeypatch, tmp_path):
+        self._patch(mod, monkeypatch, tmp_path, "1.1.0", "1.0.3")
+        assert mod.main([]) == 0
+
+    def test_inconclusive_when_nothing_resolves_does_not_block(self, mod, monkeypatch,
+                                                               tmp_path):
+        """An infra failure (no PyPI, no tags) must not fail every build."""
+        path = _write_pyproject(tmp_path, "1.1.0")
+        monkeypatch.setattr(mod, "PYPROJECT_PATH", path)
+        monkeypatch.setattr(mod, "resolve_published_version",
+                            lambda **kwargs: (None, "unavailable"))
+        assert mod.main([]) == 0
+
+
+# V resolve_published_version() -- PyPI preferred, git tags as fallback
+class TestResolvePublishedVersion:
+    """Test the source precedence between PyPI and git tags."""
+
+    def test_prefers_pypi_when_reachable(self, mod, monkeypatch):
+        monkeypatch.setattr(mod, "fetch_latest_pypi_version", lambda **k: "1.0.3")
+        monkeypatch.setattr(mod, "latest_git_tag_version", lambda **k: "0.9.0")
+        assert mod.resolve_published_version() == ("1.0.3", "PyPI")
+
+    def test_falls_back_to_git_tag_when_pypi_unreachable(self, mod, monkeypatch):
+        monkeypatch.setattr(mod, "fetch_latest_pypi_version", lambda **k: None)
+        monkeypatch.setattr(mod, "latest_git_tag_version", lambda **k: "1.0.3")
+        assert mod.resolve_published_version() == ("1.0.3", "git tag")
+
+    def test_offline_skips_pypi(self, mod, monkeypatch):
+        """``--offline`` must not touch the network at all."""
+        def _boom(**kwargs):
+            raise AssertionError("PyPI must not be queried when offline=True")
+        monkeypatch.setattr(mod, "fetch_latest_pypi_version", _boom)
+        monkeypatch.setattr(mod, "latest_git_tag_version", lambda **k: "1.0.3")
+        assert mod.resolve_published_version(offline=True) == ("1.0.3", "git tag")
+
+    def test_unavailable_when_neither_resolves(self, mod, monkeypatch):
+        monkeypatch.setattr(mod, "fetch_latest_pypi_version", lambda **k: None)
+        monkeypatch.setattr(mod, "latest_git_tag_version", lambda **k: None)
+        assert mod.resolve_published_version() == (None, "unavailable")
+
+
+# VI The live repo invariant -- the guard's own subject
+class TestRepoVersionIsAhead:
+    """Test that this repo's committed version satisfies the guard."""
+
+    def test_committed_version_is_ahead_of_latest_git_tag(self, mod):
+        """KPI: master reports an unreleased version, not a published one.
+
+        Compared against git tags rather than PyPI so the unit matrix stays offline.
+        Skipped in a tagless (shallow) checkout, where there is nothing to compare.
+        """
+        published = mod.latest_git_tag_version()
+        if published is None:
+            pytest.skip("no git tags available (shallow checkout)")
+        assert mod.is_ahead(mod.parse_project_version(), published)


### PR DESCRIPTION
## Summary

Closes the version-truth gap: the package advertised `1.1.0` (docs, `.. versionadded:: 1.1.0` directives) while `pyproject.toml` still declared `1.0.3`.

- Bump `pyproject.toml` `1.0.3` → `1.1.0` so the declared version matches the shipped API.
- Add a **version-ahead-of-PyPI CI guard** (`.github/scripts/check_version_ahead.py` + `.github/workflows/version_guard.yml`): fails the build if the declared version is not strictly ahead of the latest PyPI release, catching a stale bump before release. Keys off the version regex, not a rename.
- Docs updated to match: CHANGELOG, CONTRIBUTING (+ RST copy), release notes, and the CI workflow map.

## Tests

- New `tests/unit/api_tests/test_check_version_ahead.py` — 28 tests over the guard's comparison logic.
- Full `api_tests` meta-suite green (233 passed) after rebase onto current master.

Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)