### PR TITLE
Docs-version coherence: derive conf.py version from the package + unreleased-dev banner

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,24 @@ build:
 sphinx:
   configuration: docs/source/conf.py
 
+# Versioned docs (what a reader lands on)
+# ---------------------------------------
+# conf.py derives `version` / `release` from aaanalysis.__version__, so every build
+# is labelled with the version it actually documents, and a non-tag build renders the
+# "unreleased development version" banner (docs/source/_templates/layout.html).
+#
+# The rest is Read the Docs PROJECT ADMIN, not repo config -- it cannot be set from
+# this file and has to be done once in the RTD dashboard:
+#   1. Admin > Versions: activate the release tag versions (v1.0.3, ...). RTD only
+#      builds tags it has been told to activate; without this there is nothing for
+#      `stable` to point at.
+#   2. Admin > Settings > Default version: `stable` (not `latest`), so the bare
+#      https://aaanalysis.readthedocs.io/ URL and search results land readers on the
+#      newest *release* rather than the dev branch. RTD maintains the `stable` alias
+#      automatically from the highest active semver tag.
+#   3. Admin > Settings > Default branch: `master` (the `latest` alias).
+# Tag naming is `vX.Y.Z`; RTD sorts `stable` by semver, so consistent tags matter.
+
 python:
   install:
     - method: pip

--- a/docs/source/_static/css/style.css
+++ b/docs/source/_static/css/style.css
@@ -166,3 +166,13 @@ a:visited {
     margin-top: 24px;
     margin-bottom: 24px;
 }
+
+/* ------ Unreleased development-version banner ------ */
+/* Rendered by _templates/layout.html on every page of a non-tag build (the
+ * "latest" branch build, a PR preview, or a local build). Sits above the page
+ * body, so it must not inherit the indentation the theme gives admonitions
+ * nested in content. */
+.rst-content .aa-dev-banner,
+.aa-dev-banner {
+    margin: 0 0 24px 0;
+}

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,0 +1,29 @@
+{# Development-version banner.
+
+   Rendered on every page of a build that is NOT from a release tag: the "latest"
+   branch build on Read the Docs, a PR preview, and any local build. A reader (or an
+   agent) can otherwise land on docs describing unreleased capabilities while running
+   the released package, with nothing on the page to say so.
+
+   `is_dev_build` and `aa_release` come from html_context in conf.py. Extending the
+   theme's layout keeps the banner out of the reST sources, so it cannot interfere
+   with the notebook-derived pages the way an rst_prolog would.
+#}
+{% extends "!layout.html" %}
+
+{% block document %}
+{% if is_dev_build %}
+<div class="admonition warning aa-dev-banner">
+  <p class="admonition-title">Unreleased development version</p>
+  <p>
+    You are reading the documentation for the <strong>unreleased development
+    version</strong> of AAanalysis ({{ aa_release }}). It describes work that is not
+    on PyPI yet, so features documented here may be missing from the version you
+    installed, and may still change.
+    For the documentation matching the latest release, switch to
+    <a href="https://aaanalysis.readthedocs.io/en/stable/">stable</a>.
+  </p>
+</div>
+{% endif %}
+{{ super() }}
+{% endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,8 +32,25 @@ sys.path.insert(0, os.path.abspath('.'))
 project = 'AAanalysis'
 copyright = f'{datetime.now():%Y}, Stephan Breimann'
 author = 'Stephan Breimann'
-version = "latest"
-release = '2023'
+
+# Single source of the version: the package itself. ``aaanalysis.__version__`` reads
+# the installed distribution metadata, which setuptools takes from [project] version
+# in pyproject.toml -- so the docs can never disagree with the package they document.
+# These were previously the hardcoded literals version="latest" / release='2023',
+# which is exactly how the rendered docs came to advertise a 2023 build while the
+# package moved on. Never hardcode them again.
+from aaanalysis import __version__ as _aa_version   # noqa: E402
+
+release = _aa_version                                  # full, e.g. "1.1.0"
+version = ".".join(release.split(".")[:2])             # short X.Y, e.g. "1.1"
+
+# Read the Docs identifies the build via these; a *tag* build is the only build of a
+# published release. The "latest" branch build, a PR preview, and any local build all
+# document unreleased work, so they carry the development banner (_templates/layout.html).
+rtd_version = os.environ.get("READTHEDOCS_VERSION", "")
+rtd_version_type = os.environ.get("READTHEDOCS_VERSION_TYPE", "")
+is_dev_build = rtd_version_type != "tag"
+
 repository_url = "https://github.com/breimanntools/aaanalysis"
 pygments_style = "sphinx"
 todo_include_todos = False
@@ -169,6 +186,10 @@ html_context = {
     'github_repo': 'aaanalysis',
     'github_version': 'master/',
     'conf_py_path': 'docs/source/',  # path from repo root to the dir holding the .rst sources
+    # Consumed by _templates/layout.html to render the unreleased-version banner on
+    # every page of a non-tag build.
+    'is_dev_build': is_dev_build,
+    'aa_release': release,
 }
 
 html_meta = {

--- a/docs/source/index/release_notes.rst
+++ b/docs/source/index/release_notes.rst
@@ -509,6 +509,15 @@ Added
 
 **Documentation**
 
+- **Docs-version coherence**: the rendered docs now say which version they document.
+  ``conf.py`` derives Sphinx's ``version`` / ``release`` from ``aaanalysis.__version__``
+  (a single source, ultimately ``pyproject.toml``) instead of the hardcoded
+  ``version="latest"`` / ``release='2023'`` literals, which had left the pages
+  advertising a 2023-era build while the package moved on. Any build that is **not**
+  from a release tag — the ``latest`` branch build, a pull-request preview, or a local
+  build — now carries an *unreleased development version* banner on every page, naming
+  the version and linking to ``stable``, so a reader (or an agent) can no longer mistake
+  documentation of unreleased capabilities for the release they installed.
 - **Prediction tasks** concept page (*Usage Principles*): maps a biological question to
   the right workflow via a task table keyed on unit of comparison and reference
   construction, across the residue / domain / protein levels — the front door to the


### PR DESCRIPTION
## Summary

Makes the documentation's version single-sourced from the package instead of a hardcoded literal.

- `docs/source/conf.py` derives `version`/`release` from the installed package version rather than a manual string.
- RTD stable-vs-latest handling + an **unreleased-dev banner** that shows on a branch build (dev) and is absent on a tagged release build.

## Tests

- Docs build verified both ways: tag → no banner, branch → banner shown.

Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)