### PR TITLE
Add thin opt-in provenance record (effective resolved seed + versions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ and a suite of site-localization metrics and plotting helpers.
 - `Version Guard` CI workflow (`.github/scripts/check_version_ahead.py`): fails a
   build unless `[project] version` is strictly ahead of the latest release published
   on PyPI (git-tag fallback offline), so `master` never reports a published version.
+- `get_provenance(random_state, data)`: opt-in, JSON-serializable plain-`dict`
+  provenance record carrying the **effective resolved seed** (after the
+  `options['random_state']` override), a deterministic-vs-stochastic flag, the
+  package / Python / key-dependency versions, the git commit when resolvable, and
+  an optional `sha256` input hash. Nothing attaches it to outputs; no return type
+  changes.
 
 ### Changed
 - **Version bumped to `1.1.0`** (from the published `1.0.3`), so a development

--- a/aaanalysis/__init__.py
+++ b/aaanalysis/__init__.py
@@ -17,6 +17,7 @@ from .metrics import (comp_auc_adjusted, comp_bic_score, comp_kld,
                       comp_per_protein_ap, comp_detection_metrics,
                       comp_bootstrap_ci, comp_smooth_scores)
 from .config import options
+from ._provenance import get_provenance
 from ._constants import (COLOR_SAMPLES_POS, COLOR_SAMPLES_NEG,
                         COLOR_SAMPLES_UNL, COLOR_SAMPLES_REL_NEG)
 
@@ -88,7 +89,8 @@ __all__ = [
     "COLOR_SAMPLES_NEG",
     "COLOR_SAMPLES_UNL",
     "COLOR_SAMPLES_REL_NEG",
-    "options"
+    "options",
+    "get_provenance"
 ]
 
 

--- a/aaanalysis/_constants.py
+++ b/aaanalysis/_constants.py
@@ -649,3 +649,9 @@ STR_CMAP_CPP = "CPP"
 STR_CMAP_SHAP = "SHAP"
 STR_DICT_COLOR = "DICT_COLOR"
 STR_DICT_CAT = "DICT_CAT"
+
+
+# Provenance record — the runtime dependencies whose version can change a computed
+# result, so they are worth recording alongside the effective seed. Deliberately
+# narrow: presentation-only packages (matplotlib, seaborn) do not alter numbers.
+LIST_KEY_DEPENDENCIES = ["numpy", "pandas", "scikit-learn", "scipy"]

--- a/aaanalysis/_provenance.py
+++ b/aaanalysis/_provenance.py
@@ -1,0 +1,175 @@
+"""
+This is a script for the frontend of the opt-in provenance record.
+
+# DEV: The record is a plain dict on purpose. It is an extension of the
+# reproducibility (random_state) contract, not a result envelope: it never wraps or
+# replaces a return value, so every tool keeps returning plain numpy / pandas.
+"""
+from typing import Optional, Dict, Any, Union
+import hashlib
+import platform
+import subprocess
+from pathlib import Path
+from importlib.metadata import version as _dist_version, PackageNotFoundError
+
+import numpy as np
+import pandas as pd
+
+import aaanalysis.utils as ut
+
+
+# I Helper Functions
+def _get_package_version() -> str:
+    """Return ``aaanalysis.__version__``.
+
+    Imported lazily: ``__version__`` is defined in the top-level ``__init__``, which
+    imports this module, so a module-level import would be circular. Reading the
+    attribute (rather than re-deriving it) keeps the record and ``aa.__version__``
+    from ever disagreeing.
+    """
+    import aaanalysis
+    return aaanalysis.__version__
+
+
+def _get_dependency_versions() -> Dict[str, Optional[str]]:
+    """Return ``{name: version}`` for the key dependencies (``None`` when absent)."""
+    dict_versions = {}
+    for name in ut.LIST_KEY_DEPENDENCIES:
+        try:
+            dict_versions[name] = _dist_version(name)
+        except PackageNotFoundError:
+            dict_versions[name] = None
+    return dict_versions
+
+
+def _run_git(package_dir, *args) -> Optional[str]:
+    """Return stripped stdout of ``git -C <package_dir> <args>``, or ``None`` on failure."""
+    try:
+        proc = subprocess.run(["git", "-C", str(package_dir), *args],
+                              capture_output=True, text=True, timeout=5)
+    except (OSError, subprocess.SubprocessError):
+        # git missing, not executable, or timed out -- not a reproducibility error.
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip() or None
+
+
+def _get_git_commit() -> Optional[str]:
+    """Return the git commit of *this package's* checkout, or ``None``.
+
+    Resolvable only for a source / editable install inside a git repository; a regular
+    PyPI install yields ``None``, which is the honest answer rather than an error.
+
+    ``git`` searches upward for a repository, so asking from the package directory is
+    not enough: a virtualenv commonly lives *inside* the user's own repository (e.g.
+    ``<user-repo>/.venv/...``), and an unguarded query there answers with the **user's**
+    commit -- misleading provenance, which is worse than none. Being ignored via
+    ``.gitignore`` makes no difference. So the repository is accepted only when its root
+    is the directory that directly contains this package, which is true for a source
+    checkout and false for any install nested under an unrelated repository.
+    """
+    package_dir = Path(__file__).resolve().parent
+    top_level = _run_git(package_dir, "rev-parse", "--show-toplevel")
+    if top_level is None:
+        return None
+    if Path(top_level).resolve() != package_dir.parent:
+        return None
+    return _run_git(package_dir, "rev-parse", "HEAD")
+
+
+def _comp_input_hash(data) -> str:
+    """Return a stable ``sha256:<hex>`` digest over ``data``.
+
+    Stable across processes and sessions, so two runs of the same input agree.
+    Shape / dtype / column names are folded in, so frames that differ only in
+    labelling do not collide.
+    """
+    hasher = hashlib.sha256()
+    if isinstance(data, (pd.DataFrame, pd.Series)):
+        # hash_pandas_object uses a fixed default key, so it is process-stable
+        # (unlike the built-in hash() of a str, which is salted per process).
+        hashed = pd.util.hash_pandas_object(data, index=True).values
+        hasher.update(np.ascontiguousarray(hashed).tobytes())
+        if isinstance(data, pd.DataFrame):
+            hasher.update("|".join(map(str, data.columns)).encode("utf-8"))
+    else:
+        arr = np.asarray(data)
+        hasher.update(str(arr.shape).encode("utf-8"))
+        hasher.update(str(arr.dtype).encode("utf-8"))
+        if arr.dtype == object:
+            # Object arrays (e.g. sequence strings) have no stable buffer.
+            hasher.update("|".join(map(str, arr.ravel().tolist())).encode("utf-8"))
+        else:
+            hasher.update(np.ascontiguousarray(arr).tobytes())
+    return f"sha256:{hasher.hexdigest()}"
+
+
+# II Main Functions
+def get_provenance(random_state: Optional[int] = None,
+                   data: Optional[Union[ut.ArrayLike1D, ut.ArrayLike2D, pd.DataFrame]] = None,
+                   ) -> Dict[str, Any]:
+    """
+    Obtain a provenance record describing how a run can be reproduced.
+
+    Opt-in and side-effect free: nothing in AAanalysis attaches this record to its
+    output, and no return type changes. Call it next to a run and keep the record
+    with the results.
+
+    The one field external code cannot easily recover is the **effective resolved
+    seed**: ``random_state`` is resolved here through the very same check the tools
+    use, so the record reports the seed that actually takes effect, including when
+    ``options['random_state']`` overrides the value passed in.
+
+    .. versionadded:: 1.1.0
+
+    Parameters
+    ----------
+    random_state : int, optional
+        Seed as it would be passed to a tool (its constructor ``random_state`` or a
+        per-call ``seed``). Resolved through the global ``options['random_state']``
+        override, so the recorded value is the one that takes effect. ``None`` means
+        no seed is in effect (stochastic steps vary between runs).
+    data : array-like, pd.DataFrame, or pd.Series, optional
+        Input to fingerprint (e.g. ``df_seq``, ``X``, or ``labels``). When given, a
+        stable ``sha256`` digest is recorded so a later run can confirm it used the
+        same input. When ``None``, ``input_hash`` is ``None``.
+
+    Returns
+    -------
+    dict_provenance : dict
+        JSON-serializable record with the following keys:
+
+        - ``aaanalysis_version``: the installed package version.
+        - ``python_version``: the running interpreter version.
+        - ``dependencies``: ``{name: version}`` for the dependencies whose version
+          can change a computed result (``None`` for any not installed).
+        - ``git_commit``: commit of the package checkout, or ``None`` for a regular
+          (non-source) install.
+        - ``random_state``: the **effective resolved seed**, or ``None``.
+        - ``deterministic``: ``True`` when an effective seed is in force, so every
+          stochastic step is reproducible; ``False`` when no seed is in effect. A
+          tool that uses no randomness is reproducible either way.
+        - ``input_hash``: ``sha256:<hex>`` over ``data``, or ``None``.
+
+    Notes
+    -----
+    The record deliberately carries no timestamp or hostname: every field is
+    something that can change a result, which is what makes two records comparable
+    for equality as a reproducibility key.
+
+    Examples
+    --------
+    .. include:: examples/get_provenance.rst
+    """
+    # Validate (this call is also what resolves the effective seed)
+    random_state = ut.check_random_state(random_state=random_state)
+    # Build record
+    dict_provenance = {"aaanalysis_version": _get_package_version(),
+                       "python_version": platform.python_version(),
+                       "dependencies": _get_dependency_versions(),
+                       "git_commit": _get_git_commit(),
+                       "random_state": random_state,
+                       "deterministic": random_state is not None,
+                       "input_hash": None if data is None else _comp_input_hash(data=data)}
+    return dict_provenance

--- a/docs/_cheatsheet/content.py
+++ b/docs/_cheatsheet/content.py
@@ -431,7 +431,8 @@ GOTCHAS = [
     "count classes via df_seq['label'].",
     "Compositional vs positional is not a flag — it <b>emerges from split_kws</b>.",
     "Reproducibility: layered seeds — seed= ▸ random_state= ▸ "
-    "options['random_state'] ▸ default.",
+    "options['random_state'] ▸ default; <b>options wins</b>. "
+    "<b>get_provenance(random_state, data)</b> records which seed actually applied.",
     "<b>DOM_*</b> parts need tmd_start/tmd_stop in df_seq; <b>[pro]</b> features "
     "need <span style='font-family:\"AA Mono\",monospace'>pip install 'aaanalysis[pro]'</span>.",
 ]

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -139,6 +139,7 @@ Utility Functions
     comp_per_protein_ap
     comp_smooth_scores
     display_df
+    get_provenance
     options
     plot_gcfs
     plot_get_cdict

--- a/docs/source/index/release_notes.rst
+++ b/docs/source/index/release_notes.rst
@@ -46,6 +46,18 @@ Added
 - **get_labels**: Derives a binary ``int`` label vector from a sequence DataFrame's
   label column (``positive_label`` mapped to ``1``, everything else to ``0``) — the
   single-call form of the recurring ``(df[col] == x).astype(int).to_numpy()`` expression.
+- :func:`~aaanalysis.get_provenance`: An **opt-in**, JSON-serializable plain ``dict``
+  recording how a run can be reproduced. Its one field that external code cannot easily
+  recover is the **effective resolved seed** — ``random_state`` is resolved through the
+  same check the tools use, so the record reports the seed that actually takes effect,
+  including when ``options['random_state']`` overrides the value passed at the call site.
+  Alongside it: a ``deterministic`` flag, ``aaanalysis`` / Python / key-dependency
+  versions, the git commit when resolvable (``None`` for a regular install), and an
+  optional stable ``sha256`` fingerprint of the input via ``data``. It is **opt-in only**:
+  nothing attaches it to any output, no return type changes, and default results stay
+  byte-identical plain numpy / pandas. The record carries no timestamp or hostname —
+  every field is something that can change a result, which is what lets two records be
+  compared as a reproducibility key. No new dependency.
 - :func:`~aaanalysis.combine_dict_nums`: Concatenates per-residue tensors (embedding / structure /
   annotation) along the feature axis into one combined :meth:`~aaanalysis.CPP.run_num` input.
 - :meth:`~aaanalysis.SequencePreprocessor.pad_parts`: Pads the sequence-part columns of a

--- a/examples/options/get_provenance.ipynb
+++ b/examples/options/get_provenance.ipynb
@@ -1,0 +1,399 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "prov-md-intro",
+   "metadata": {},
+   "source": [
+    "The ``get_provenance`` function returns a plain, JSON-serializable ``dict`` recording how a run can be reproduced. It is **opt-in**: no AAanalysis function attaches it to its output and no return type changes, so results stay plain numpy and pandas. You call it next to a run and keep the record with the results.\n",
+    "\n",
+    "The one field external code cannot easily recover is the **effective resolved seed** — the seed that actually takes effect after the ``options['random_state']`` → constructor → per-call resolution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "prov-code-basic",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-16T15:41:13.771708Z",
+     "iopub.status.busy": "2026-07-16T15:41:13.771146Z",
+     "iopub.status.idle": "2026-07-16T15:41:15.476537Z",
+     "shell.execute_reply": "2026-07-16T15:41:15.476269Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"aaanalysis_version\": \"1.0.3\",\n",
+      "  \"python_version\": \"3.13.11\",\n",
+      "  \"dependencies\": {\n",
+      "    \"numpy\": \"2.4.4\",\n",
+      "    \"pandas\": \"3.0.3\",\n",
+      "    \"scikit-learn\": \"1.9.0\",\n",
+      "    \"scipy\": \"1.18.0\"\n",
+      "  },\n",
+      "  \"git_commit\": \"df679491ac1a5d70707faadd8d69c7e8f3d4deb4\",\n",
+      "  \"random_state\": 42,\n",
+      "  \"deterministic\": true,\n",
+      "  \"input_hash\": null\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "import aaanalysis as aa\n",
+    "aa.options[\"verbose\"] = False\n",
+    "\n",
+    "# 'random_state' is resolved through the same check the tools use, so the record\n",
+    "# reports the seed that actually takes effect.\n",
+    "provenance = aa.get_provenance(random_state=42)\n",
+    "print(json.dumps(provenance, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "prov-md-json",
+   "metadata": {},
+   "source": [
+    "Every value is JSON-native, so the record round-trips through ``json.dumps`` and can be written to disk next to the results it describes. ``deterministic`` says whether a seed is in force: with one, every stochastic step is reproducible; without one (``random_state=None``), stochastic steps vary between runs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "prov-code-json",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-16T15:41:15.477939Z",
+     "iopub.status.busy": "2026-07-16T15:41:15.477739Z",
+     "iopub.status.idle": "2026-07-16T15:41:15.493381Z",
+     "shell.execute_reply": "2026-07-16T15:41:15.493098Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "round-trips through JSON: True\n",
+      "random_state: None | deterministic: False\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"round-trips through JSON:\", json.loads(json.dumps(provenance)) == provenance)\n",
+    "\n",
+    "# Without a seed the run is stochastic, and the record says so.\n",
+    "unseeded = aa.get_provenance()\n",
+    "print(\"random_state:\", unseeded[\"random_state\"], \"| deterministic:\", unseeded[\"deterministic\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "prov-md-data",
+   "metadata": {},
+   "source": [
+    "Pass the run's input to ``data`` to fingerprint it. A stable ``sha256`` digest is recorded, so a later run can confirm it started from the same input. ``data`` accepts a ``DataFrame``, ``Series``, array, or list — e.g. ``df_seq``, the feature matrix ``X``, or ``labels``."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "prov-code-data-load",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-16T15:41:15.494459Z",
+     "iopub.status.busy": "2026-07-16T15:41:15.494385Z",
+     "iopub.status.idle": "2026-07-16T15:41:15.523457Z",
+     "shell.execute_reply": "2026-07-16T15:41:15.523261Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DataFrame shape: (10, 9)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "#T_c3e8b thead th {\n",
+       "  background-color: white;\n",
+       "  color: black;\n",
+       "}\n",
+       "#T_c3e8b tbody tr:nth-child(odd) {\n",
+       "  background-color: #f2f2f2;\n",
+       "}\n",
+       "#T_c3e8b tbody tr:nth-child(even) {\n",
+       "  background-color: white;\n",
+       "}\n",
+       "#T_c3e8b th {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "#T_c3e8b  td {\n",
+       "  padding: 5px;\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "</style>\n",
+       "<table id=\"T_c3e8b\" style='display:block; max-height: 300px; max-width: 100%; overflow-x: auto; overflow-y: auto;'>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_c3e8b_level0_col0\" class=\"col_heading level0 col0\" >entry</th>\n",
+       "      <th id=\"T_c3e8b_level0_col1\" class=\"col_heading level0 col1\" >gene</th>\n",
+       "      <th id=\"T_c3e8b_level0_col2\" class=\"col_heading level0 col2\" >sequence</th>\n",
+       "      <th id=\"T_c3e8b_level0_col3\" class=\"col_heading level0 col3\" >label</th>\n",
+       "      <th id=\"T_c3e8b_level0_col4\" class=\"col_heading level0 col4\" >tmd_start</th>\n",
+       "      <th id=\"T_c3e8b_level0_col5\" class=\"col_heading level0 col5\" >tmd_stop</th>\n",
+       "      <th id=\"T_c3e8b_level0_col6\" class=\"col_heading level0 col6\" >jmd_n</th>\n",
+       "      <th id=\"T_c3e8b_level0_col7\" class=\"col_heading level0 col7\" >tmd</th>\n",
+       "      <th id=\"T_c3e8b_level0_col8\" class=\"col_heading level0 col8\" >jmd_c</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_c3e8b_level0_row0\" class=\"row_heading level0 row0\" >1</th>\n",
+       "      <td id=\"T_c3e8b_row0_col0\" class=\"data row0 col0\" >Q14802</td>\n",
+       "      <td id=\"T_c3e8b_row0_col1\" class=\"data row0 col1\" >FXYD3</td>\n",
+       "      <td id=\"T_c3e8b_row0_col2\" class=\"data row0 col2\" >MQKVTLGLLVFLAGF...PGETPPLITPGSAQS</td>\n",
+       "      <td id=\"T_c3e8b_row0_col3\" class=\"data row0 col3\" >0</td>\n",
+       "      <td id=\"T_c3e8b_row0_col4\" class=\"data row0 col4\" >37</td>\n",
+       "      <td id=\"T_c3e8b_row0_col5\" class=\"data row0 col5\" >59</td>\n",
+       "      <td id=\"T_c3e8b_row0_col6\" class=\"data row0 col6\" >NSPFYYDWHS</td>\n",
+       "      <td id=\"T_c3e8b_row0_col7\" class=\"data row0 col7\" >LQVGGLICAGVLCAMGIIIVMSA</td>\n",
+       "      <td id=\"T_c3e8b_row0_col8\" class=\"data row0 col8\" >KCKCKFGQKS</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_c3e8b_level0_row1\" class=\"row_heading level0 row1\" >2</th>\n",
+       "      <td id=\"T_c3e8b_row1_col0\" class=\"data row1 col0\" >Q86UE4</td>\n",
+       "      <td id=\"T_c3e8b_row1_col1\" class=\"data row1 col1\" >MTDH</td>\n",
+       "      <td id=\"T_c3e8b_row1_col2\" class=\"data row1 col2\" >MAARSWQDELAQQAE...SPKQIKKKKKARRET</td>\n",
+       "      <td id=\"T_c3e8b_row1_col3\" class=\"data row1 col3\" >0</td>\n",
+       "      <td id=\"T_c3e8b_row1_col4\" class=\"data row1 col4\" >50</td>\n",
+       "      <td id=\"T_c3e8b_row1_col5\" class=\"data row1 col5\" >72</td>\n",
+       "      <td id=\"T_c3e8b_row1_col6\" class=\"data row1 col6\" >LGLEPKRYPG</td>\n",
+       "      <td id=\"T_c3e8b_row1_col7\" class=\"data row1 col7\" >WVILVGTGALGLLLLFLLGYGWA</td>\n",
+       "      <td id=\"T_c3e8b_row1_col8\" class=\"data row1 col8\" >AACAGARKKR</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_c3e8b_level0_row2\" class=\"row_heading level0 row2\" >3</th>\n",
+       "      <td id=\"T_c3e8b_row2_col0\" class=\"data row2 col0\" >Q969W9</td>\n",
+       "      <td id=\"T_c3e8b_row2_col1\" class=\"data row2 col1\" >PMEPA1</td>\n",
+       "      <td id=\"T_c3e8b_row2_col2\" class=\"data row2 col2\" >MHRLMGVNSTAAAAA...AIWSKEKDKQKGHPL</td>\n",
+       "      <td id=\"T_c3e8b_row2_col3\" class=\"data row2 col3\" >0</td>\n",
+       "      <td id=\"T_c3e8b_row2_col4\" class=\"data row2 col4\" >41</td>\n",
+       "      <td id=\"T_c3e8b_row2_col5\" class=\"data row2 col5\" >63</td>\n",
+       "      <td id=\"T_c3e8b_row2_col6\" class=\"data row2 col6\" >FQSMEITELE</td>\n",
+       "      <td id=\"T_c3e8b_row2_col7\" class=\"data row2 col7\" >FVQIIIIVVVMMVMVVVITCLLS</td>\n",
+       "      <td id=\"T_c3e8b_row2_col8\" class=\"data row2 col8\" >HYKLSARSFI</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_c3e8b_level0_row3\" class=\"row_heading level0 row3\" >4</th>\n",
+       "      <td id=\"T_c3e8b_row3_col0\" class=\"data row3 col0\" >P53801</td>\n",
+       "      <td id=\"T_c3e8b_row3_col1\" class=\"data row3 col1\" >PTTG1IP</td>\n",
+       "      <td id=\"T_c3e8b_row3_col2\" class=\"data row3 col2\" >MAPGVARGPTPYWRL...GLFKEENPYARFENN</td>\n",
+       "      <td id=\"T_c3e8b_row3_col3\" class=\"data row3 col3\" >0</td>\n",
+       "      <td id=\"T_c3e8b_row3_col4\" class=\"data row3 col4\" >97</td>\n",
+       "      <td id=\"T_c3e8b_row3_col5\" class=\"data row3 col5\" >119</td>\n",
+       "      <td id=\"T_c3e8b_row3_col6\" class=\"data row3 col6\" >RWGVCWVNFE</td>\n",
+       "      <td id=\"T_c3e8b_row3_col7\" class=\"data row3 col7\" >ALIITMSVVGGTLLLGIAICCCC</td>\n",
+       "      <td id=\"T_c3e8b_row3_col8\" class=\"data row3 col8\" >CCRRKRSRKP</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_c3e8b_level0_row4\" class=\"row_heading level0 row4\" >5</th>\n",
+       "      <td id=\"T_c3e8b_row4_col0\" class=\"data row4 col0\" >Q8IUW5</td>\n",
+       "      <td id=\"T_c3e8b_row4_col1\" class=\"data row4 col1\" >RELL1</td>\n",
+       "      <td id=\"T_c3e8b_row4_col2\" class=\"data row4 col2\" >MAPRALPGSAVLAAA...EVPATPVKRERSGTE</td>\n",
+       "      <td id=\"T_c3e8b_row4_col3\" class=\"data row4 col3\" >0</td>\n",
+       "      <td id=\"T_c3e8b_row4_col4\" class=\"data row4 col4\" >59</td>\n",
+       "      <td id=\"T_c3e8b_row4_col5\" class=\"data row4 col5\" >81</td>\n",
+       "      <td id=\"T_c3e8b_row4_col6\" class=\"data row4 col6\" >NDTGNGHPEY</td>\n",
+       "      <td id=\"T_c3e8b_row4_col7\" class=\"data row4 col7\" >IAYALVPVFFIMGLFGVLICHLL</td>\n",
+       "      <td id=\"T_c3e8b_row4_col8\" class=\"data row4 col8\" >KKKGYRCTTE</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_c3e8b_level0_row5\" class=\"row_heading level0 row5\" >6</th>\n",
+       "      <td id=\"T_c3e8b_row5_col0\" class=\"data row5 col0\" >P05067</td>\n",
+       "      <td id=\"T_c3e8b_row5_col1\" class=\"data row5 col1\" >APP</td>\n",
+       "      <td id=\"T_c3e8b_row5_col2\" class=\"data row5 col2\" >MLPGLALLLLAAWTA...GYENPTYKFFEQMQN</td>\n",
+       "      <td id=\"T_c3e8b_row5_col3\" class=\"data row5 col3\" >1</td>\n",
+       "      <td id=\"T_c3e8b_row5_col4\" class=\"data row5 col4\" >701</td>\n",
+       "      <td id=\"T_c3e8b_row5_col5\" class=\"data row5 col5\" >723</td>\n",
+       "      <td id=\"T_c3e8b_row5_col6\" class=\"data row5 col6\" >FAEDVGSNKG</td>\n",
+       "      <td id=\"T_c3e8b_row5_col7\" class=\"data row5 col7\" >AIIGLMVGGVVIATVIVITLVML</td>\n",
+       "      <td id=\"T_c3e8b_row5_col8\" class=\"data row5 col8\" >KKKQYTSIHH</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_c3e8b_level0_row6\" class=\"row_heading level0 row6\" >7</th>\n",
+       "      <td id=\"T_c3e8b_row6_col0\" class=\"data row6 col0\" >P14925</td>\n",
+       "      <td id=\"T_c3e8b_row6_col1\" class=\"data row6 col1\" >Pam</td>\n",
+       "      <td id=\"T_c3e8b_row6_col2\" class=\"data row6 col2\" >MAGRARSGLLLLLLG...EEEYSAPLPKPAPSS</td>\n",
+       "      <td id=\"T_c3e8b_row6_col3\" class=\"data row6 col3\" >1</td>\n",
+       "      <td id=\"T_c3e8b_row6_col4\" class=\"data row6 col4\" >868</td>\n",
+       "      <td id=\"T_c3e8b_row6_col5\" class=\"data row6 col5\" >890</td>\n",
+       "      <td id=\"T_c3e8b_row6_col6\" class=\"data row6 col6\" >KLSTEPGSGV</td>\n",
+       "      <td id=\"T_c3e8b_row6_col7\" class=\"data row6 col7\" >SVVLITTLLVIPVLVLLAIVMFI</td>\n",
+       "      <td id=\"T_c3e8b_row6_col8\" class=\"data row6 col8\" >RWKKSRAFGD</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_c3e8b_level0_row7\" class=\"row_heading level0 row7\" >8</th>\n",
+       "      <td id=\"T_c3e8b_row7_col0\" class=\"data row7 col0\" >P70180</td>\n",
+       "      <td id=\"T_c3e8b_row7_col1\" class=\"data row7 col1\" >Npr3</td>\n",
+       "      <td id=\"T_c3e8b_row7_col2\" class=\"data row7 col2\" >MRSLLLFTFSACVLL...RELREDSIRSHFSVA</td>\n",
+       "      <td id=\"T_c3e8b_row7_col3\" class=\"data row7 col3\" >1</td>\n",
+       "      <td id=\"T_c3e8b_row7_col4\" class=\"data row7 col4\" >477</td>\n",
+       "      <td id=\"T_c3e8b_row7_col5\" class=\"data row7 col5\" >499</td>\n",
+       "      <td id=\"T_c3e8b_row7_col6\" class=\"data row7 col6\" >PCKSSGGLEE</td>\n",
+       "      <td id=\"T_c3e8b_row7_col7\" class=\"data row7 col7\" >SAVTGIVVGALLGAGLLMAFYFF</td>\n",
+       "      <td id=\"T_c3e8b_row7_col8\" class=\"data row7 col8\" >RKKYRITIER</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_c3e8b_level0_row8\" class=\"row_heading level0 row8\" >9</th>\n",
+       "      <td id=\"T_c3e8b_row8_col0\" class=\"data row8 col0\" >Q03157</td>\n",
+       "      <td id=\"T_c3e8b_row8_col1\" class=\"data row8 col1\" >Aplp1</td>\n",
+       "      <td id=\"T_c3e8b_row8_col2\" class=\"data row8 col2\" >MGPTSPAARGQGRRW...HGYENPTYRFLEERP</td>\n",
+       "      <td id=\"T_c3e8b_row8_col3\" class=\"data row8 col3\" >1</td>\n",
+       "      <td id=\"T_c3e8b_row8_col4\" class=\"data row8 col4\" >585</td>\n",
+       "      <td id=\"T_c3e8b_row8_col5\" class=\"data row8 col5\" >607</td>\n",
+       "      <td id=\"T_c3e8b_row8_col6\" class=\"data row8 col6\" >APSGTGVSRE</td>\n",
+       "      <td id=\"T_c3e8b_row8_col7\" class=\"data row8 col7\" >ALSGLLIMGAGGGSLIVLSLLLL</td>\n",
+       "      <td id=\"T_c3e8b_row8_col8\" class=\"data row8 col8\" >RKKKPYGTIS</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_c3e8b_level0_row9\" class=\"row_heading level0 row9\" >10</th>\n",
+       "      <td id=\"T_c3e8b_row9_col0\" class=\"data row9 col0\" >Q06481</td>\n",
+       "      <td id=\"T_c3e8b_row9_col1\" class=\"data row9 col1\" >APLP2</td>\n",
+       "      <td id=\"T_c3e8b_row9_col2\" class=\"data row9 col2\" >MAATGTAAAAATGRL...GYENPTYKYLEQMQI</td>\n",
+       "      <td id=\"T_c3e8b_row9_col3\" class=\"data row9 col3\" >1</td>\n",
+       "      <td id=\"T_c3e8b_row9_col4\" class=\"data row9 col4\" >694</td>\n",
+       "      <td id=\"T_c3e8b_row9_col5\" class=\"data row9 col5\" >716</td>\n",
+       "      <td id=\"T_c3e8b_row9_col6\" class=\"data row9 col6\" >LREDFSLSSS</td>\n",
+       "      <td id=\"T_c3e8b_row9_col7\" class=\"data row9 col7\" >ALIGLLVIAVAIATVIVISLVML</td>\n",
+       "      <td id=\"T_c3e8b_row9_col8\" class=\"data row9 col8\" >RKRQYGTISH</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "df_seq = aa.load_dataset(name=\"DOM_GSEC\", n=5)\n",
+    "aa.display_df(df=df_seq, n_rows=10, show_shape=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "prov-code-data-hash",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-16T15:41:15.524411Z",
+     "iopub.status.busy": "2026-07-16T15:41:15.524352Z",
+     "iopub.status.idle": "2026-07-16T15:41:15.553686Z",
+     "shell.execute_reply": "2026-07-16T15:41:15.553452Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "input_hash: sha256:e9c8bdb622b17284b97cc352362556f4866e6b50d6042ac79a38dcf70e46f034\n",
+      "changed   : sha256:f620d7700c551e06f05907c1f56cbb329845a487c517e3200abae8119a729f08\n"
+     ]
+    }
+   ],
+   "source": [
+    "provenance = aa.get_provenance(random_state=42, data=df_seq)\n",
+    "print(\"input_hash:\", provenance[\"input_hash\"])\n",
+    "\n",
+    "# The digest tracks the input: a changed value gives a different hash.\n",
+    "df_changed = df_seq.copy()\n",
+    "df_changed.loc[0, \"sequence\"] = \"MKV\"\n",
+    "print(\"changed   :\", aa.get_provenance(data=df_changed)[\"input_hash\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "prov-md-options",
+   "metadata": {},
+   "source": [
+    "This is why the record is worth keeping. ``options['random_state']`` **overrides everything**, including a seed passed explicitly at the call site. The record reports the seed that actually took effect, which the call site alone does not tell you."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "prov-code-options",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-16T15:41:15.554816Z",
+     "iopub.status.busy": "2026-07-16T15:41:15.554726Z",
+     "iopub.status.idle": "2026-07-16T15:41:15.581049Z",
+     "shell.execute_reply": "2026-07-16T15:41:15.580782Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "passed random_state=42, but options wins -> 7\n",
+      "options back off, argument applies   -> 42\n"
+     ]
+    }
+   ],
+   "source": [
+    "aa.options[\"random_state\"] = 7\n",
+    "print(\"passed random_state=42, but options wins ->\", aa.get_provenance(random_state=42)[\"random_state\"])\n",
+    "\n",
+    "aa.options[\"random_state\"] = \"off\"\n",
+    "print(\"options back off, argument applies   ->\", aa.get_provenance(random_state=42)[\"random_state\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "prov-md-close",
+   "metadata": {},
+   "source": [
+    "Record it next to any seeded run — pass the tool the same ``random_state`` and its input to ``data`` — and store the dict with your results (e.g. ``json.dump``). Two runs that agree on the record reproduce the same output. The record deliberately carries no timestamp or hostname: every field is something that can change a result, which is what makes two records comparable."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/unit/provenance_tests/test_get_provenance.py
+++ b/tests/unit/provenance_tests/test_get_provenance.py
@@ -1,0 +1,312 @@
+"""This is a script to test aa.get_provenance()."""
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+from hypothesis import given, settings
+import hypothesis.strategies as some
+
+import aaanalysis as aa
+from aaanalysis import _provenance
+
+settings.register_profile("ci", deadline=None)
+settings.load_profile("ci")
+
+LIST_KEYS = ["aaanalysis_version", "python_version", "dependencies", "git_commit",
+             "random_state", "deterministic", "input_hash"]
+
+
+class TestGetProvenance:
+    """Test get_provenance() with one parameter per test."""
+
+    # Positive tests: random_state
+    def test_random_state_none(self):
+        dict_provenance = aa.get_provenance()
+        assert dict_provenance["random_state"] is None
+
+    def test_random_state_int(self):
+        dict_provenance = aa.get_provenance(random_state=42)
+        assert dict_provenance["random_state"] == 42
+
+    def test_random_state_zero(self):
+        """0 is a valid seed even though it is falsy."""
+        dict_provenance = aa.get_provenance(random_state=0)
+        assert dict_provenance["random_state"] == 0
+        assert dict_provenance["deterministic"] is True
+
+    @settings(max_examples=15)
+    @given(random_state=some.integers(min_value=0, max_value=2**31 - 1))
+    def test_random_state_hypothesis(self, random_state):
+        dict_provenance = aa.get_provenance(random_state=random_state)
+        assert dict_provenance["random_state"] == random_state
+
+    def test_deterministic_true_when_seeded(self):
+        assert aa.get_provenance(random_state=1)["deterministic"] is True
+
+    def test_deterministic_false_when_unseeded(self):
+        assert aa.get_provenance(random_state=None)["deterministic"] is False
+
+    # Positive tests: data
+    def test_data_none_gives_no_hash(self):
+        assert aa.get_provenance(data=None)["input_hash"] is None
+
+    def test_data_dataframe(self):
+        df = pd.DataFrame({"entry": ["P1"], "sequence": ["MKV"]})
+        assert aa.get_provenance(data=df)["input_hash"].startswith("sha256:")
+
+    def test_data_series(self):
+        assert aa.get_provenance(data=pd.Series([1, 2, 3]))["input_hash"].startswith("sha256:")
+
+    def test_data_ndarray(self):
+        assert aa.get_provenance(data=np.arange(6))["input_hash"].startswith("sha256:")
+
+    def test_data_list_of_str(self):
+        assert aa.get_provenance(data=["MKV", "AAC"])["input_hash"].startswith("sha256:")
+
+    def test_data_list_of_int(self):
+        assert aa.get_provenance(data=[0, 1, 1, 0])["input_hash"].startswith("sha256:")
+
+    def test_data_2d_array(self):
+        assert aa.get_provenance(data=np.ones((3, 2)))["input_hash"].startswith("sha256:")
+
+    @settings(max_examples=10)
+    @given(data=some.lists(some.integers(), min_size=1, max_size=20))
+    def test_data_hypothesis(self, data):
+        assert aa.get_provenance(data=data)["input_hash"].startswith("sha256:")
+
+    # Structural tests
+    def test_returns_plain_dict(self):
+        """The record must be a plain dict, never a bespoke envelope type."""
+        assert type(aa.get_provenance()) is dict
+
+    def test_record_keys(self):
+        assert sorted(aa.get_provenance().keys()) == sorted(LIST_KEYS)
+
+    def test_json_serializable(self):
+        """KPI: the record round-trips through json.dumps."""
+        dict_provenance = aa.get_provenance(random_state=42)
+        assert json.loads(json.dumps(dict_provenance)) == dict_provenance
+
+    def test_version_matches_package_attribute(self):
+        assert aa.get_provenance()["aaanalysis_version"] == aa.__version__
+
+    def test_python_version_is_str(self):
+        assert isinstance(aa.get_provenance()["python_version"], str)
+
+    def test_dependencies_reported(self):
+        dict_deps = aa.get_provenance()["dependencies"]
+        assert sorted(dict_deps) == sorted(["numpy", "pandas", "scikit-learn", "scipy"])
+
+    def test_dependency_versions_are_str(self):
+        """These are hard dependencies, so every one resolves in a real install."""
+        assert all(isinstance(v, str) for v in aa.get_provenance()["dependencies"].values())
+
+    def test_git_commit_str_or_none(self):
+        git_commit = aa.get_provenance()["git_commit"]
+        assert git_commit is None or isinstance(git_commit, str)
+
+    def test_no_timestamp_field(self):
+        """The record is a reproducibility key: no field may vary between runs."""
+        assert aa.get_provenance(random_state=1) == aa.get_provenance(random_state=1)
+
+    # Negative tests: random_state
+    def test_negative_random_state_raises(self):
+        with pytest.raises(ValueError):
+            aa.get_provenance(random_state=-1)
+
+    def test_float_random_state_raises(self):
+        with pytest.raises(ValueError):
+            aa.get_provenance(random_state=1.5)
+
+    def test_str_random_state_raises(self):
+        with pytest.raises(ValueError):
+            aa.get_provenance(random_state="42")
+
+    def test_list_random_state_raises(self):
+        with pytest.raises(ValueError):
+            aa.get_provenance(random_state=[1])
+
+    def test_dict_random_state_raises(self):
+        with pytest.raises(ValueError):
+            aa.get_provenance(random_state={"seed": 1})
+
+    def test_invalid_random_states_sweep(self):
+        for random_state in [-1, -100, 1.5, "a", "42", [1], (1,), {"a": 1}, np.nan]:
+            with pytest.raises(ValueError):
+                aa.get_provenance(random_state=random_state)
+
+    @settings(max_examples=10)
+    @given(random_state=some.integers(max_value=-1))
+    def test_negative_random_state_hypothesis(self, random_state):
+        with pytest.raises(ValueError):
+            aa.get_provenance(random_state=random_state)
+
+    # Negative tests: data
+    def test_ragged_data_raises(self):
+        """A ragged nested sequence has no well-defined array form."""
+        with pytest.raises(ValueError):
+            aa.get_provenance(data=[[1, 2], [3]])
+
+
+class TestGetProvenanceComplex:
+    """Test get_provenance() with interacting parameters and the options override."""
+
+    # Positive tests
+    def test_options_random_state_overrides_argument(self):
+        """The contract's surprise: options wins over the passed value.
+
+        This is the record's reason to exist -- the effective seed is not
+        recoverable from the call site alone.
+        """
+        aa.options["random_state"] = 7
+        assert aa.get_provenance(random_state=42)["random_state"] == 7
+
+    def test_options_random_state_used_when_no_argument(self):
+        aa.options["random_state"] = 7
+        assert aa.get_provenance()["random_state"] == 7
+
+    def test_options_off_falls_back_to_argument(self):
+        aa.options["random_state"] = "off"
+        assert aa.get_provenance(random_state=42)["random_state"] == 42
+
+    def test_options_random_state_makes_unseeded_call_deterministic(self):
+        aa.options["random_state"] = 0
+        dict_provenance = aa.get_provenance()
+        assert dict_provenance["random_state"] == 0
+        assert dict_provenance["deterministic"] is True
+
+    def test_same_seed_and_data_give_identical_record(self):
+        """KPI: two runs sharing provenance reproduce the same result."""
+        df = pd.DataFrame({"entry": ["P1", "P2"], "sequence": ["MKV", "AAC"]})
+        assert aa.get_provenance(random_state=42, data=df) == \
+               aa.get_provenance(random_state=42, data=df)
+
+    def test_seed_and_data_combine(self):
+        dict_provenance = aa.get_provenance(random_state=3, data=[1, 2])
+        assert dict_provenance["random_state"] == 3
+        assert dict_provenance["input_hash"].startswith("sha256:")
+
+    def test_json_round_trip_with_data(self):
+        df = pd.DataFrame({"a": [1, 2]})
+        dict_provenance = aa.get_provenance(random_state=1, data=df)
+        assert json.loads(json.dumps(dict_provenance)) == dict_provenance
+
+    def test_different_data_gives_different_hash(self):
+        hash_a = aa.get_provenance(data=[1, 2, 3])["input_hash"]
+        hash_b = aa.get_provenance(data=[1, 2, 4])["input_hash"]
+        assert hash_a != hash_b
+
+    def test_renamed_column_gives_different_hash(self):
+        """Column names are part of the input identity."""
+        hash_a = aa.get_provenance(data=pd.DataFrame({"a": [1, 2]}))["input_hash"]
+        hash_b = aa.get_provenance(data=pd.DataFrame({"b": [1, 2]}))["input_hash"]
+        assert hash_a != hash_b
+
+    def test_reordered_rows_give_different_hash(self):
+        df = pd.DataFrame({"a": [1, 2]})
+        hash_a = aa.get_provenance(data=df)["input_hash"]
+        hash_b = aa.get_provenance(data=df.iloc[::-1])["input_hash"]
+        assert hash_a != hash_b
+
+    def test_reshaped_array_gives_different_hash(self):
+        """Shape is folded in, so the same buffer at a different shape differs."""
+        hash_a = aa.get_provenance(data=np.arange(6))["input_hash"]
+        hash_b = aa.get_provenance(data=np.arange(6).reshape(2, 3))["input_hash"]
+        assert hash_a != hash_b
+
+    def test_seed_does_not_affect_input_hash(self):
+        assert aa.get_provenance(random_state=1, data=[1, 2])["input_hash"] == \
+               aa.get_provenance(random_state=2, data=[1, 2])["input_hash"]
+
+    # Negative tests
+    def test_invalid_option_rejected_at_assignment(self):
+        """``options`` validates on set, so a bad seed never reaches the record.
+
+        The record can therefore only ever report a seed that is valid to use.
+        """
+        for random_state in [-5, 1.5, "bad", [1]]:
+            with pytest.raises(ValueError):
+                aa.options["random_state"] = random_state
+        assert aa.get_provenance(random_state=42)["random_state"] == 42
+
+    def test_invalid_option_leaves_previous_value_intact(self):
+        aa.options["random_state"] = 7
+        with pytest.raises(ValueError):
+            aa.options["random_state"] = -5
+        assert aa.get_provenance()["random_state"] == 7
+
+    def test_invalid_seed_raises_even_with_valid_data(self):
+        with pytest.raises(ValueError):
+            aa.get_provenance(random_state=-1, data=[1, 2])
+
+    def test_invalid_data_raises_even_with_valid_seed(self):
+        with pytest.raises(ValueError):
+            aa.get_provenance(random_state=42, data=[[1, 2], [3]])
+
+    def test_invalid_seed_raises_before_hashing_data(self):
+        """Validation comes first, so a bad seed is reported, not a hash error."""
+        with pytest.raises(ValueError, match="random_state"):
+            aa.get_provenance(random_state=-1, data=[[1, 2], [3]])
+
+
+class TestGetProvenanceGitCommit:
+    """Test that git_commit reports *this package's* checkout and never a host repo.
+
+    ``git`` searches upward for a repository, so an install nested under an unrelated
+    repository (the common ``<user-repo>/.venv/...`` layout) would otherwise answer with
+    the user's commit -- misleading provenance, which is worse than none.
+    """
+
+    @staticmethod
+    def _fake_git(top_level=None, commit=None):
+        def _run_git(package_dir=None, *args):
+            if args == ("rev-parse", "--show-toplevel"):
+                return top_level
+            if args == ("rev-parse", "HEAD"):
+                return commit
+            return None
+        return _run_git
+
+    def test_commit_when_toplevel_is_the_package_parent(self, monkeypatch):
+        """A real source checkout: the repo root directly contains the package."""
+        package_parent = Path(_provenance.__file__).resolve().parent.parent
+        monkeypatch.setattr(_provenance, "_run_git",
+                            self._fake_git(top_level=str(package_parent), commit="abc123"))
+        assert _provenance._get_git_commit() == "abc123"
+
+    def test_none_when_toplevel_is_an_unrelated_host_repo(self, monkeypatch):
+        """The leak case: a venv inside the user's own repository."""
+        monkeypatch.setattr(_provenance, "_run_git",
+                            self._fake_git(top_level="/some/user/project",
+                                           commit="userrepocommit"))
+        assert _provenance._get_git_commit() is None
+
+    def test_none_when_not_in_a_repository(self, monkeypatch):
+        """A regular PyPI install: no repository at all."""
+        monkeypatch.setattr(_provenance, "_run_git", self._fake_git(top_level=None))
+        assert _provenance._get_git_commit() is None
+
+    def test_none_when_git_is_unavailable(self, monkeypatch):
+        """git missing / not executable must degrade to None, never raise."""
+        def _boom(*args, **kwargs):
+            raise OSError("git not found")
+        monkeypatch.setattr(_provenance.subprocess, "run", _boom)
+        assert _provenance._get_git_commit() is None
+
+    def test_none_when_git_returns_nonzero(self, monkeypatch):
+        class _Proc:
+            returncode = 128
+            stdout = ""
+        monkeypatch.setattr(_provenance.subprocess, "run", lambda *a, **k: _Proc())
+        assert _provenance._get_git_commit() is None
+
+    def test_record_never_raises_without_git(self, monkeypatch):
+        """The record must still be produced when git is unavailable."""
+        def _boom(*args, **kwargs):
+            raise OSError("git not found")
+        monkeypatch.setattr(_provenance.subprocess, "run", _boom)
+        dict_provenance = aa.get_provenance(random_state=42)
+        assert dict_provenance["git_commit"] is None
+        assert dict_provenance["random_state"] == 42


### PR DESCRIPTION
## Summary

Adds a thin, **opt-in** provenance record so an agent/user can capture exactly how a result was produced, without changing any existing return type.

- New public `aa.get_provenance(...)` returns a plain, **JSON-serializable dict**: the *effective resolved* random seed (computed by calling the same `ut.check_random_state` resolution the library uses, honoring `options` overrides) plus package/dependency versions.
- No timestamp (keeps the record deterministic/reproducible).
- No change to any existing method's return type — provenance is a separate call.

Note: adds one public symbol to `aaanalysis/__init__.py` / `__all__` (CONFIRM-FIRST surface), scoped by epic #449.

## Tests

- 54 provenance tests pass locally against the branch (seed-resolution honoring `options`, JSON-serializability, version fields).

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)