### PR TITLE
ci: stop docs-only PRs from being permanently blocked by required checks

### DIFF
--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -13,10 +13,10 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
-      - '**/*.rst'
+    # NO paths-ignore on the PR trigger: `code-quality` is a REQUIRED check, and a
+    # path-skipped workflow never reports it, so a docs-only PR would block forever. The
+    # `changes` job skips it on a docs-only diff (its checks read only .py, so nothing is
+    # lost). The `push` trigger keeps its paths-ignore below.
   schedule:
     - cron: '0 0 * * 0'
 
@@ -26,6 +26,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # On a docs-only PR the required `code-quality` job below skips (its checks read only
+  # .py, so nothing is lost) yet still reports success. Fail-safe: anything not purely
+  # docs (docs/**, *.md, *.rst), a non-PR event, or a detection failure runs it in full.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: filter
+        shell: bash
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          files="$(git diff --name-only "${BASE}...${HEAD}" || true)"
+          echo "Changed files:"; printf '%s\n' "$files"
+          # Count files that are NOT docs (docs/**, *.md, *.rst). Use -c (a count), not
+          # -vq: BSD and GNU grep disagree on the exit status of `-vq`, but the count is
+          # identical on both. Fail-safe: an empty list, or any doubt, runs the full check.
+          if [ -z "$files" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            n_code=$(printf '%s\n' "$files" | grep -vcE '^(docs/|.*\.md$|.*\.rst$)' || true)
+            if [ "${n_code:-1}" -gt 0 ]; then
+              echo "code=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "code=false" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
   analyze:
     name: Analyze
     # CodeQL is a security scan, not a correctness gate, and adds several minutes.
@@ -45,6 +81,9 @@ jobs:
         uses: github/codeql-action/analyze@v3
 
   code-quality:
+    needs: changes
+    # Skipped on a docs-only PR (reports skipped = passing); its checks read only .py.
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/integration_e2e.yml
+++ b/.github/workflows/integration_e2e.yml
@@ -19,17 +19,55 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
-      - '**/*.rst'
+    # NO paths-ignore on the PR trigger: these are REQUIRED status checks, and a
+    # path-skipped workflow never reports its contexts, so a docs-only PR would block
+    # forever. The workflow always runs on PRs; the `changes` job skips the heavy work on
+    # a docs-only diff so the contexts still report success. The `push` trigger keeps its
+    # paths-ignore (a docs-only master push is not merge-gated).
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # On a docs-only PR the required job below runs but skips its heavy steps, reporting
+  # success without the tiers. Fail-safe: anything not purely docs (docs/**, *.md, *.rst),
+  # a non-PR event, or a detection failure, runs the full check.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: filter
+        shell: bash
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          files="$(git diff --name-only "${BASE}...${HEAD}" || true)"
+          echo "Changed files:"; printf '%s\n' "$files"
+          # Count files that are NOT docs (docs/**, *.md, *.rst). Use -c (a count), not
+          # -vq: BSD and GNU grep disagree on the exit status of `-vq`, but the count is
+          # identical on both. Fail-safe: an empty list, or any doubt, runs the full check.
+          if [ -z "$files" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            n_code=$(printf '%s\n' "$files" | grep -vcE '^(docs/|.*\.md$|.*\.rst$)' || true)
+            if [ "${n_code:-1}" -gt 0 ]; then
+              echo "code=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "code=false" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
   integration-e2e:
+    needs: changes
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -53,6 +91,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install package and test dependencies
+      if: needs.changes.outputs.code == 'true'
       # Core install only — the integration/e2e tiers import no `pro` features.
       run: |
         python -m pip install --upgrade pip
@@ -60,6 +99,7 @@ jobs:
         pip install pytest hypothesis pytest-xdist
 
     - name: Run integration & e2e tiers
+      if: needs.changes.outputs.code == 'true'
       # One combined check over both directories. The network-marked live-endpoint
       # file (test_online_fetches.py) is skipped by default and would need the `pro`
       # extra just to import, so it is ignored here; it stays collected (and skipped)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,12 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
-      - '**/*.rst'
+    # NO paths-ignore on the PR trigger, on purpose. These matrix jobs are REQUIRED
+    # status checks: a workflow skipped by a path filter never reports its contexts, so
+    # a docs-only PR would sit blocked forever "waiting for status". Instead the workflow
+    # always runs on PRs and the `changes` job below skips the heavy work on a docs-only
+    # diff, so the required contexts still report success. The `push` trigger keeps its
+    # paths-ignore (a docs-only master push is not merge-gated and can skip to save runners).
 
 # Cancel a superseded in-progress run on PR branches (saves runner minutes), but
 # NOT on master: a cancelled run's conclusion renders as red "failing" on the
@@ -45,8 +47,45 @@ jobs:
             echo 'matrix={"include":[{"os":"ubuntu-latest","python-version":"3.10"},{"os":"ubuntu-latest","python-version":"3.11"},{"os":"ubuntu-latest","python-version":"3.12"},{"os":"ubuntu-latest","python-version":"3.13"},{"os":"ubuntu-latest","python-version":"3.14"},{"os":"windows-2022","python-version":"3.10"},{"os":"windows-2022","python-version":"3.14"}]}' >> "$GITHUB_OUTPUT"
           fi
 
+  # Is there anything in this PR a code check cares about? On a docs-only diff the
+  # required jobs below run but skip their heavy steps, reporting success without the
+  # matrix. Fail-safe: anything that is not purely docs (docs/**, *.md, *.rst), a
+  # non-PR event, or any detection failure, runs the full check.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: filter
+        shell: bash
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          files="$(git diff --name-only "${BASE}...${HEAD}" || true)"
+          echo "Changed files:"; printf '%s\n' "$files"
+          # Count files that are NOT docs (docs/**, *.md, *.rst). Use -c (a count), not
+          # -vq: BSD and GNU grep disagree on the exit status of `-vq`, but the count is
+          # identical on both. Fail-safe: an empty list, or any doubt, runs the full check.
+          if [ -z "$files" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            n_code=$(printf '%s\n' "$files" | grep -vcE '^(docs/|.*\.md$|.*\.rst$)' || true)
+            if [ "${n_code:-1}" -gt 0 ]; then
+              echo "code=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "code=false" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
   test:
-    needs: configure
+    needs: [configure, changes]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
@@ -71,19 +110,20 @@ jobs:
           ${{ runner.os }}-pip-${{ matrix.python-version }}-
 
     - name: Install package and test dependencies
+      if: needs.changes.outputs.code == 'true'
       run: |
         python -m pip install --upgrade pip
         pip install -e .[pro]
         pip install pytest hypothesis ipython pytest-xdist
 
     - name: Install cd-hit (Ubuntu)
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && needs.changes.outputs.code == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y cd-hit
 
     - name: Install mmseqs2 (Ubuntu)
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && needs.changes.outputs.code == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mmseqs2
@@ -93,7 +133,7 @@ jobs:
     # built from source on Linux and cached on the version key. @fimo_required
     # tests skip on Windows.
     - name: Cache MEME suite (FIMO)
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && needs.changes.outputs.code == 'true'
       id: cache-meme
       uses: actions/cache@v5
       with:
@@ -101,7 +141,7 @@ jobs:
         key: ${{ runner.os }}-meme-5.5.8
 
     - name: Build FIMO from MEME suite (Ubuntu)
-      if: runner.os == 'Linux' && steps.cache-meme.outputs.cache-hit != 'true'
+      if: runner.os == 'Linux' && steps.cache-meme.outputs.cache-hit != 'true' && needs.changes.outputs.code == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y build-essential zlib1g-dev
@@ -114,10 +154,11 @@ jobs:
         make install
 
     - name: Add FIMO to PATH (Ubuntu)
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && needs.changes.outputs.code == 'true'
       run: echo "$HOME/meme-install/bin" >> "$GITHUB_PATH"
 
     - name: Run Tests
+      if: needs.changes.outputs.code == 'true'
       # Fast PR gate: the exact-value regression anchor (-m regression, ADR-0015),
       # the integration/e2e tiers (own `Integration & E2E Tests` workflow,
       # ADR-0031), and the heavy `slow` tier (multi-minute pipe sweeps; run by the

--- a/.github/workflows/perf_nightly.yml
+++ b/.github/workflows/perf_nightly.yml
@@ -26,10 +26,10 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
-      - '**/*.rst'
+    # NO paths-ignore on the PR trigger: the benchmark is a REQUIRED check, and a
+    # path-skipped workflow never reports it, so a docs-only PR would block forever. The
+    # `changes` job skips it on a docs-only diff (docs can't affect timings) while still
+    # reporting success. The `push` trigger keeps its paths-ignore below.
   schedule:
     - cron: "0 5 * * *"   # 05:00 UTC daily heartbeat (after the 04:00 nightly)
   workflow_dispatch: {}
@@ -39,7 +39,46 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # On a docs-only PR the benchmark below skips (docs can't affect timings) yet still
+  # reports success. Fail-safe: anything not purely docs (docs/**, *.md, *.rst), a non-PR
+  # event (schedule / dispatch / push), or a detection failure runs the full benchmark.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: filter
+        shell: bash
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          files="$(git diff --name-only "${BASE}...${HEAD}" || true)"
+          echo "Changed files:"; printf '%s\n' "$files"
+          # Count files that are NOT docs (docs/**, *.md, *.rst). Use -c (a count), not
+          # -vq: BSD and GNU grep disagree on the exit status of `-vq`, but the count is
+          # identical on both. Fail-safe: an empty list, or any doubt, runs the full check.
+          if [ -z "$files" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            n_code=$(printf '%s\n' "$files" | grep -vcE '^(docs/|.*\.md$|.*\.rst$)' || true)
+            if [ "${n_code:-1}" -gt 0 ]; then
+              echo "code=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "code=false" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
   benchmark:
+    needs: changes
+    # Skipped on a docs-only PR (reports skipped = passing); docs can't affect timings.
+    if: needs.changes.outputs.code == 'true'
     name: A/B benchmark hot paths (Linux/py3.11)
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Problem
All 8 required status checks come from the four workflows that carry `paths-ignore: ['docs/**', '**/*.md', '**/*.rst']` — Unit Tests (`test ×4`), Integration & E2E (`integration-e2e ×2`), CodeQL (`code-quality`), and the Perf A/B gate. On a **docs-only PR** those workflows don't trigger, so the required contexts never report, and GitHub blocks the merge forever "waiting for status." Every docs-only PR (e.g. #452 this week) needs an admin bypass — which is a blunt instrument that skips *all* protection.

## Fix
Keep `paths-ignore` on the **`push`** trigger (a docs-only master push isn't merge-gated, so skipping still saves runners) and remove it from the **`pull_request`** trigger. Each workflow gains a lightweight `changes` job that diffs the PR against its base:

- **purely-docs diff** (`docs/**`, `*.md`, `*.rst`) → heavy work is skipped, but the required contexts still **report success**, so the PR is mergeable without admin.
- **any non-docs file**, an empty diff, a non-PR event, or any detection failure → **full check runs**, so code PRs are gated exactly as before.

## Why it's safe (the dangerous direction is "code PR skips tests")
- The dynamic **Unit Tests** matrix guards its heavy *steps* (install / FIMO / pytest), so all four `test (…)` legs always post a **real** success — no reliance on how GitHub reports a skipped dynamic-matrix job.
- Single/static jobs (`code-quality`, `A/B benchmark`, `integration-e2e`) use a job-level skip (skipped = passing).
- Detection uses `grep -vc` (a count), not `grep -vq` — BSD and GNU grep disagree on the exit status of `-vq`, but the count is identical. Verified against mixed/pure/empty file lists, including the mixed docs+code case that **must** run.
- This PR itself touches `.github/**` (non-docs), so it exercises the **code path**: the full matrix runs here, proving code PRs stay gated.

The docs-skip path will be validated with a throwaway docs-only PR once this lands (a `pull_request` uses the base branch's merged workflow definition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)