### PR TITLE
TEST: docs-only probe for the docs-gate (do not merge)

### DIFF
--- a/docs/source/protocols.rst
+++ b/docs/source/protocols.rst
@@ -76,3 +76,5 @@ selection, modelling, explanation, and validation.
    generated/protocol8_prediction
    generated/protocol9_interpretability
    generated/protocol10_validation
+
+.. ci docs-gate validation probe (PR is a throwaway, will be closed unmerged)


### PR DESCRIPTION
Throwaway PR: a single docs-only change to confirm PR #459 lets a docs-only PR reach a mergeable state (required contexts report success via the `changes` gate) without an admin bypass. Will be closed unmerged.