### PR TITLE
docs(changelog): reconcile the removed plot_rank entry against the public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and a suite of site-localization metrics and plotting helpers.
 - `AAWindowSampler` sequence-window sampler and `scan_motif` (`[pro]`, MEME/FIMO).
 - `aa.metrics` site-localization helpers: `comp_per_protein_ap`,
   `comp_detection_metrics`, `comp_bootstrap_ci`, `comp_smooth_scores`.
-- `plot_rank` per-protein max-score-vs-rank scatter.
+- Per-protein max-score-vs-rank scatter via `AAPredPlot.predict_group(kind="rank_scatter")`.
 - `aa.__version__` top-level attribute.
 - `aaanalysis.utils.deprecated(reason, version_removed)` decorator helper for
   marking public symbols deprecated under the strict-semver policy (internal


### PR DESCRIPTION
Reconciles the terse changelog against the public API. The `[Unreleased]` Added list still named `plot_rank`, a symbol removed during the v1.1 cycle and folded into `AAPredPlot.predict_group(kind="rank_scatter")` — repointed to the current symbol (`release_notes.rst` already documents it).

Verified no other `[Unreleased]` entry names a symbol absent from `aaanalysis.__all__`. The remaining bare-symbol candidates are method/param names (members of classes that are in `__all__`) or immutable past-release history (e.g. the `ShapExplainer` mentions live in the 0.1.3 and 1.0.0 sections, correct for those releases).

The `[Unreleased]` → `[1.1.0]` + date stamp is deliberately left for release-cut time.

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)
