### PR TITLE
ci(deps): add advisory pip-audit dependency-scanning workflow

### DIFF
--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -1,0 +1,36 @@
+name: Dependency Audit (advisory)
+
+# Runs pip-audit over the installed dependency set and reports known
+# vulnerabilities. ADVISORY only (continue-on-error) so it never gates a merge on
+# a transitive/dev-tool CVE; the report is in the step log. Weekly + on demand.
+# Dependency-review and Dependabot automation are planned follow-ups (issue #444).
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'   # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pip-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
+        with:
+          python-version: '3.11'
+
+      - name: Install package + pip-audit
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pip-audit
+
+      - name: Audit installed dependencies (advisory report; never gates)
+        continue-on-error: true
+        run: pip-audit --desc --progress-spinner off


### PR DESCRIPTION
Adds an advisory `pip-audit` dependency-scanning workflow (weekly + `workflow_dispatch`), with SHA-pinned actions and least-privilege `contents: read`. It reports known vulnerabilities without gating, so it never blocks a PR on a transitive or dev-tool CVE.

A manual audit of the 1.1.0 candidate found **no vulnerability forced by the declared dependencies**: the only runtime finding was `Pillow` (fixed in 12.3.0, which already satisfies the existing `Pillow>=12.0.0` floor, so a fresh install resolves to a patched build), and `pip` is not a dependency (dev-venv tooling only).

_Optional hardening not in this PR (CONFIRM-FIRST pyproject edit):_ bump the floor to `Pillow>=12.3.0` so even a minimum-version resolver skips the vulnerable window.

Dependency-review + Dependabot automation are planned follow-ups.

Closes #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)
