### PR TITLE
ci(release): retire the legacy token publisher so OIDC release.yml is the only path

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,8 +1,10 @@
 name: Build wheels
 
+# Manual wheel-build / parity sanity check only (workflow_dispatch). Publishing
+# on a release is owned solely by the canonical OIDC path in `release.yml` — this
+# workflow no longer triggers on `release` and no longer publishes, so there is
+# one release path and no long-lived PyPI tokens.
 on:
-  release:
-    types: [published]
   workflow_dispatch:
 
 jobs:
@@ -89,28 +91,3 @@ jobs:
         with:
           name: sdist_files
           path: dist/*.tar.gz
-
-  publish_wheels:
-    name: Publish wheels on PyPI
-    needs: [build_wheels, build_sdist]
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags')
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          pattern: bdist_*
-          path: dist
-          merge-multiple: true
-      - uses: actions/download-artifact@v8
-        with:
-          name: sdist_files
-          path: dist
-      - name: Publish package to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
-          repository-url: https://test.pypi.org/legacy/
-      - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -482,15 +482,14 @@ AAanalysis is packaged with the setuptools build backend (for the Cython kernel)
 
    This creates the source distribution and wheel files in the ``dist`` directory.
 
-4. **Publish to PyPI**
+4. **Publish to PyPI (automated via trusted publishing, no tokens)**
 
-   Upload the package to PyPI:
-
-   .. code-block:: bash
-
-      uv publish
-
-   You will need valid PyPI credentials or an API token configured for uv (for example via ``UV_PUBLISH_TOKEN`` or ``--token``).
+   Publishing is owned by the canonical release workflow
+   (``.github/workflows/release.yml``): publishing a GitHub Release for the tag
+   builds the wheels and source distribution and uploads them to PyPI via **OIDC
+   trusted publishing**, so there are no long-lived API tokens and no manual
+   ``uv publish`` step. Do not publish manually; the token-based ``uv publish`` /
+   ``UV_PUBLISH_TOKEN`` path has been retired.
 
 5. **Verify the upload**
 

--- a/docs/guides/project_cheat_sheet.md
+++ b/docs/guides/project_cheat_sheet.md
@@ -85,7 +85,7 @@ Install extras (works with uv, pip, and poetry):
 6. `uv pip install -e .[dev]`: Install in editable mode with dev extras.
 7. `uv lock`: Update the lockfile.
 8. `uv build`: Build the package.
-9. `uv publish`: Publish to PyPI.
+9. Publishing to PyPI is automated: publish a GitHub Release and the OIDC `release.yml` workflow uploads via trusted publishing (no manual `uv publish`, no tokens).
 
 ### pip (alternative)
 

--- a/docs/source/index/CONTRIBUTING_COPY.rst
+++ b/docs/source/index/CONTRIBUTING_COPY.rst
@@ -485,15 +485,14 @@ AAanalysis is packaged with the setuptools build backend (for the Cython kernel)
 
    This creates the source distribution and wheel files in the ``dist`` directory.
 
-4. **Publish to PyPI**
+4. **Publish to PyPI (automated via trusted publishing, no tokens)**
 
-   Upload the package to PyPI:
-
-   .. code-block:: bash
-
-      uv publish
-
-   You will need valid PyPI credentials or an API token configured for uv (for example via ``UV_PUBLISH_TOKEN`` or ``--token``).
+   Publishing is owned by the canonical release workflow
+   (``.github/workflows/release.yml``): publishing a GitHub Release for the tag
+   builds the wheels and source distribution and uploads them to PyPI via **OIDC
+   trusted publishing**, so there are no long-lived API tokens and no manual
+   ``uv publish`` step. Do not publish manually; the token-based ``uv publish`` /
+   ``UV_PUBLISH_TOKEN`` path has been retired.
 
 5. **Verify the upload**
 


### PR DESCRIPTION
Retires the legacy token-based publisher so there is a single canonical release path.

- **`build_wheels.yml`**: removes the `release: [published]` trigger and the `publish_wheels` job (TestPyPI + PyPI token uploads). It stays as a manual `workflow_dispatch` wheel-build / parity sanity check.
- **`release.yml`** (merged in #463) is now the **only** path that publishes, via OIDC trusted publishing — no stored tokens, no double-publish.
- Redirects the manual `uv publish` / `UV_PUBLISH_TOKEN` instructions in `CONTRIBUTING.rst`, its rendered copy, and the cheat sheet to the automated workflow.

Touches no library or test code; behavior of the package is unchanged.

**Operator actions before the first 1.1.0 publish (cannot be done in-repo):**
1. Register the repo as a **PyPI trusted publisher** (workflow `release.yml`, environment `pypi`) at the project's PyPI *Publishing* settings.
2. Create the **`pypi` GitHub Environment**.
3. **Revoke** the now-unused `PYPI_TOKEN` and `TEST_PYPI_TOKEN` repository secrets.

Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)
