### PR TITLE
test(contracts): golden-pipeline + CPP/AAPred failure-path contract tests (#477)

### DIFF
--- a/aaanalysis/pipe/_find_features.py
+++ b/aaanalysis/pipe/_find_features.py
@@ -534,6 +534,10 @@ def find_features(labels: ut.ArrayLike1D,
     ut.check_str_options(name="selection_scope", val=selection_scope,
                          list_str_options=["global", "fold"])
     ut.check_df_seq(df_seq=df_seq)
+    # Validate labels up front (one per df_seq row) so a single-class, misaligned, or empty
+    # label vector raises a precise ValueError naming 'labels' here, instead of surfacing later
+    # as an opaque "produced no valid configurations" runtime error from the internal search.
+    ut.check_labels(labels=labels, len_required=len(df_seq))
     ut.check_bool(name="simplify", val=simplify)
     for m in (model if isinstance(model, (list, tuple)) else [model]):
         if isinstance(m, str):

--- a/aaanalysis/prediction/_aa_pred.py
+++ b/aaanalysis/prediction/_aa_pred.py
@@ -65,6 +65,22 @@ def check_is_fitted(list_models=None):
         raise ValueError("'AAPred' is not fitted; call 'AAPred.fit' first.")
 
 
+def check_match_X_fitted(X=None, list_models=None):
+    """Check that X's feature count matches the fitted deployment models.
+
+    The fitted estimators expose ``n_features_in_`` (set by scikit-learn during ``fit``). A width
+    mismatch is a caller error (wrong feature matrix) that would otherwise surface as scikit-learn's
+    internal ``"X has N features, but <Estimator> is expecting M ..."`` — this raises a message that
+    names ``'X'`` in the package's own voice instead.
+    """
+    n_expected = getattr(list_models[0], "n_features_in_", None)
+    n_got = np.asarray(X).shape[1]
+    if n_expected is not None and n_got != n_expected:
+        raise ValueError(f"'X' n_features ({n_got}) should match the fitted model's n_features "
+                         f"({n_expected}); pass the same features, in the same order, as used in "
+                         f"'AAPred.fit'.")
+
+
 def check_binary_labels(labels=None):
     """Check that labels define exactly two classes (AAPred is a binary predictor)."""
     classes = list(np.unique(labels))
@@ -902,6 +918,7 @@ class AAPred(Wrapper):
         check_is_fitted(list_models=self.list_models_)
         check_estimators_proba(list_estimators=self._list_estimators, context="predict_proba")
         X = ut.check_X(X=X, min_n_samples=1)
+        check_match_X_fitted(X=X, list_models=self.list_models_)
         ut.check_str_options(name="score_range", val=score_range, list_str_options=ut.LIST_SCORE_RANGES)
         # Score the precomputed matrix with the fitted ensemble (mean/std over models)
         pred, pred_std = self._predict_X(X=X)

--- a/docs/source/index/release_notes.rst
+++ b/docs/source/index/release_notes.rst
@@ -711,6 +711,18 @@ Changed
 Fixed
 ~~~~~
 
+- **Clearer failure messages on the golden pipelines**: an invalid call now names the offending
+  input in the package's own voice. :func:`~aaanalysis.pipe.find_features` validates ``labels`` up
+  front, so a single-class or length-misaligned label vector raises a precise ``ValueError``
+  ("``'labels'`` should contain more than one different value" / "should contain N values") instead
+  of an opaque "produced no valid configurations" runtime error, and
+  :meth:`~aaanalysis.AAPred.predict_proba` raises a self-explaining "``'X'`` n_features (...) should
+  match the fitted model's n_features" instead of scikit-learn's internal estimator message when a
+  feature matrix has the wrong width. The failure contract of the golden pipelines and the CPP to
+  :class:`~aaanalysis.AAPred` path (a bare ``ValueError`` / ``RuntimeError``, or an install-hint
+  ``ImportError`` for a missing ``[pro]`` dependency) is now regression-guarded by an integration
+  test suite and, from an installed distribution, by the packaging smoke check. See
+  :ref:`Failure contracts <error_contracts>`.
 - **Source install from the sdist now builds**: the published sdist previously omitted the Cython
   source ``_filters_c/_inner.pyx``, so the default ``python -m build`` (which builds the wheel from
   the sdist) and any source install (``pip install <sdist>``, ``pip install aaanalysis --no-binary``)

--- a/docs/source/index/usage_principles.rst
+++ b/docs/source/index/usage_principles.rst
@@ -70,3 +70,4 @@ concepts of AAanalysis are provided by the following sections:
    usage_principles/feature_identification
    usage_principles/pu_learning
    usage_principles/xai
+   usage_principles/error_contracts

--- a/docs/source/index/usage_principles/error_contracts.rst
+++ b/docs/source/index/usage_principles/error_contracts.rst
@@ -1,0 +1,108 @@
+.. _error_contracts:
+
+Failure Contracts of the Golden Pipelines
+=========================================
+
+The golden pipelines (:func:`~aaanalysis.pipe.find_features`,
+:func:`~aaanalysis.pipe.predict_samples`, :func:`~aaanalysis.pipe.explain_features`) and the
+core :class:`~aaanalysis.CPP` to :class:`~aaanalysis.AAPred` path are called from scripts and
+coding agents as well as notebooks, so their behaviour on the *unhappy* path is a documented
+contract, not an accident. Every invalid call raises a **bare** :class:`ValueError` or
+:class:`RuntimeError` (or, for an unavailable optional dependency, an :class:`ImportError` with
+an install hint), and the message names the offending input in the package's own voice. A caller
+can therefore tell "I called it wrong" from "the library broke" from the message alone, without
+reading a traceback. AAanalysis deliberately keeps these as plain built-in exceptions: there is
+no custom exception hierarchy and no error-code taxonomy, since mapping a raised error to a
+structured, recoverable result is a downstream adapter's job.
+
+The worked pairs below show one correct and one incorrect invocation per pipeline.
+
+find_features
+-------------
+
+Correct, with binary labels aligned to the ``df_seq`` rows:
+
+.. code-block:: python
+
+    import aaanalysis as aa
+    from aaanalysis import pipe as ap
+
+    df_seq = aa.load_dataset(name="DOM_GSEC", n=20)
+    labels = df_seq["label"].to_list()
+    df_feat, ax, df_eval = ap.find_features(labels=labels, df_seq=df_seq, plot=False)
+
+Incorrect, a single-class label vector cannot define a test-versus-reference contrast:
+
+.. code-block:: python
+
+    ap.find_features(labels=[1] * len(df_seq), df_seq=df_seq, plot=False)
+    # ValueError: 'labels' should contain more than one different value ({1}).
+
+predict_samples
+---------------
+
+Correct, one or more CPP feature sets with labels aligned to ``df_seq``:
+
+.. code-block:: python
+
+    models, ax, df_eval = ap.predict_samples(list_df_feat=[df_feat], df_seq=df_seq,
+                                             labels=labels, plot=False)
+
+Incorrect, an empty feature set has nothing to score:
+
+.. code-block:: python
+
+    ap.predict_samples(list_df_feat=[], df_seq=df_seq, labels=labels, plot=False)
+    # ValueError: 'list_df_feat' should contain at least one feature DataFrame.
+
+explain_features (pro)
+----------------------
+
+:func:`~aaanalysis.pipe.explain_features` needs the ``[pro]`` extra (SHAP). Correct, with
+``[pro]`` installed:
+
+.. code-block:: python
+
+    df_impact, ax, _ = ap.explain_features(df_feat=df_feat, df_seq=df_seq, labels=labels, plot=False)
+
+Incorrect, without the ``[pro]`` extra the function degrades to an install hint:
+
+.. code-block:: python
+
+    ap.explain_features(df_feat=df_feat, df_seq=df_seq, labels=labels)
+    # ImportError: 'explain_features' needs additional dependencies. Install via:
+    #     pip install 'aaanalysis[pro]'
+
+CPP to AAPred
+-------------
+
+``X`` below is the CPP feature matrix (for example from
+:meth:`~aaanalysis.SequenceFeature.feature_matrix`). Correct, a fitted
+:class:`~aaanalysis.AAPred` scores a matrix of the same width used in fit:
+
+.. code-block:: python
+
+    aap = aa.AAPred().fit(X=X, labels=labels)
+    df_pred = aap.predict_proba(X=X)
+
+Incorrect, scoring a matrix whose width does not match the fitted model, or scoring before
+fitting:
+
+.. code-block:: python
+
+    aap.predict_proba(X=X[:, :3])
+    # ValueError: 'X' n_features (3) should match the fitted model's n_features (20); ...
+
+    aa.AAPred().predict_proba(X=X)
+    # ValueError: 'AAPred' is not fitted; call 'AAPred.fit' first.
+
+Contract summary
+----------------
+
+- Validation errors are :class:`ValueError`; runtime-state errors (such as calling ``eval``
+  before ``run``) are :class:`RuntimeError`.
+- An unavailable optional ``[pro]`` dependency raises :class:`ImportError` with a
+  ``pip install 'aaanalysis[pro]'`` hint.
+- Messages quote the offending input name, so they are self-explaining.
+- The contract is regression-guarded by an integration failure-contract test suite and, from an
+  installed distribution, by the packaging smoke check.

--- a/tests/_check_public_api_packaged.py
+++ b/tests/_check_public_api_packaged.py
@@ -19,7 +19,7 @@ covers the general build -> install (wheel or sdist) -> public-API-import contra
 Run as ``python <this-file>`` **from a directory that is not the repo root** so
 ``import aaanalysis`` resolves to the installed distribution, never the checkout —
 the source-tree guard below fails loudly if it did resolve to source anyway. It
-checks three things:
+checks four things:
 
 1. every name in :data:`aaanalysis.__all__` is importable from the install;
 2. each ``pro`` / ``dev`` optional-dependency symbol degrades to a
@@ -27,7 +27,13 @@ checks three things:
    called) instead of breaking the import, whenever its extra is absent;
 3. bundled ``_data`` resources load — a representative ``load_scales()`` (top
    level ``_data/*.tsv``) and ``load_dataset(...)`` (``_data/benchmarks/*.tsv``)
-   succeed, proving the package data shipped in the distribution.
+   succeed, proving the package data shipped in the distribution;
+4. the golden-pipeline **error surface** holds from the install — a couple of
+   core failure paths raise the documented bare ``ValueError``, and (base-deps
+   only) ``ap.explain_features`` degrades to an install-hint ``ImportError`` — so
+   the failure contract is part of the packaging smoke, not only the editable
+   dev tree. The full condition matrix lives in
+   ``tests/integration/test_failure_contracts.py``.
 """
 import importlib.util
 import sys
@@ -103,5 +109,49 @@ df_scales = _load(aa.load_scales, "load_scales()", "_data/*.tsv")
 df_seq = _load(lambda: aa.load_dataset(name="DOM_GSEC", n=2), "load_dataset('DOM_GSEC')",
                "_data/benchmarks/*.tsv")
 print(f"OK: bundled _data loads (scales {df_scales.shape}, DOM_GSEC {df_seq.shape})")
+
+# --- 4. Golden-pipeline error surface holds from the installed distribution ----
+# A coding agent meets the public API on the unhappy path too. Assert a few failure paths raise
+# the documented bare error *from the install*, so a broken re-export or a message regression is
+# caught by the packaging gate, not only by the editable dev suite. Pick fail-fast validation
+# (no model fitting). find_features / predict_samples are core; explain_features gates on [pro].
+import pandas as pd
+from aaanalysis import pipe as ap
+
+
+def _expect_valueerror(call, needle, what):
+    try:
+        call()
+    except ValueError as exc:
+        if type(exc) is not ValueError:
+            _fail(f"{what}: expected a bare ValueError, got {type(exc).__name__}")
+        if needle not in str(exc):
+            _fail(f"{what}: ValueError {str(exc)!r} does not name the offending input ({needle!r})")
+    except Exception as exc:  # noqa: BLE001 - report the wrong error type explicitly
+        _fail(f"{what}: expected ValueError, got {type(exc).__name__}: {exc}")
+    else:
+        _fail(f"{what}: expected a ValueError from the install, none raised")
+
+
+_expect_valueerror(lambda: aa.CPP(df_parts=pd.DataFrame()),
+                   "'df_parts'", "CPP(empty df_parts)")
+_expect_valueerror(lambda: ap.predict_samples(list_df_feat=[], df_seq=df_seq,
+                                              labels=df_seq["label"].to_list()),
+                   "'list_df_feat'", "predict_samples(empty list_df_feat)")
+print("OK: core golden-pipeline validation raises bare, self-explaining ValueErrors from the install")
+
+# explain_features gates on [pro] (SHAP). In the base-deps packaging venv it is a
+# missing_feature_stub: calling it must raise ImportError naming the extra to install.
+if importlib.util.find_spec("shap") is None:
+    try:
+        ap.explain_features(df_feat=df_seq, df_seq=df_seq, labels=[0, 1])
+    except ImportError as exc:
+        if "aaanalysis[pro]" not in str(exc):
+            _fail(f"ap.explain_features stub ImportError lacks the install hint: {exc!r}")
+    except Exception as exc:  # noqa: BLE001 - report the wrong error type explicitly
+        _fail(f"ap.explain_features without [pro] raised {type(exc).__name__}, expected ImportError")
+    else:
+        _fail("ap.explain_features without [pro] did not raise (expected an install-hint ImportError)")
+    print("OK: ap.explain_features degrades to an install-hint ImportError without the [pro] extra")
 
 print("PASS: built distribution installs clean and its public API imports")

--- a/tests/integration/test_failure_contracts.py
+++ b/tests/integration/test_failure_contracts.py
@@ -1,0 +1,268 @@
+"""This is a script to test the failure contract of the golden pipelines + CPP/AAPred path.
+
+Integration tier. A coding agent or a scripted caller mostly meets the golden pipelines
+(``ap.find_features``, ``ap.predict_samples``, ``ap.explain_features``) and the core
+CPP -> ``AAPred`` path on the *unhappy* path: missing labels, malformed sequences, a
+feature matrix that does not match the model, an optional ``pro`` dependency that is not
+installed, too few positives to split, an unfitted component. This suite pins that
+**failure contract** so it stays stable across releases:
+
+  * each invalid invocation raises a **bare** ``ValueError`` / ``RuntimeError`` (or, for the
+    missing-``pro`` case, ``ImportError`` with an install hint) - never a bespoke subclass;
+  * the message is **self-explaining** (names the offending input in the package's own voice),
+    so a caller can tell "I called it wrong" from "the library broke" without a private
+    traceback detail;
+  * everything is driven through the **public API only**, so the suite doubles as a smoke of
+    the error surface a downstream (e.g. ProtXplain) adapter maps to structured errors.
+
+These are **composition failures** (the higher-tier job): labels-vs-samples misalignment, a
+schema/shape mismatch at a seam, an unfitted component. Per-parameter invalid-input sweeps
+(``model='xyz'``, out-of-range scalars) stay at the unit tier. The missing-``pro`` stub is
+also asserted from an installed wheel by ``tests/_check_public_api_packaged.py``.
+"""
+import importlib.util
+
+import numpy as np
+import pandas as pd
+import pytest
+from hypothesis import settings
+
+import aaanalysis as aa
+from aaanalysis import pipe as ap
+from tests import _pipeline
+
+settings.register_profile("ci", deadline=None)
+settings.load_profile("ci")
+
+pytestmark = pytest.mark.integration
+
+# ``ap.explain_features`` needs SHAP (the ``[pro]`` extra). When absent it degrades to a
+# ``missing_feature_stub`` raising ImportError; its real composition failures can only be
+# exercised where the extra is installed.
+_HAS_PRO = importlib.util.find_spec("shap") is not None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _assert_contract(exc_type, match, call):
+    """A failure invocation raises exactly ``exc_type`` (no subclass) with a matching message.
+
+    ``pytest.raises`` matches subclasses too; asserting ``type(...) is exc_type`` pins the
+    *bare* ``ValueError`` / ``RuntimeError`` contract (no bespoke exception hierarchy).
+    """
+    with pytest.raises(exc_type, match=match) as excinfo:
+        call()
+    assert type(excinfo.value) is exc_type, (
+        f"expected a bare {exc_type.__name__}, got {type(excinfo.value).__name__}")
+    return excinfo.value
+
+
+@pytest.fixture(scope="module")
+def fitted_aapred(pipeline):
+    """A once-fitted ``AAPred`` on the seeded feature matrix (reused by the scoring tests)."""
+    return aa.AAPred().fit(X=np.asarray(pipeline["X"]), labels=pipeline["labels"])
+
+
+# ---------------------------------------------------------------------------
+# ap.find_features
+# ---------------------------------------------------------------------------
+class TestFindFeaturesFailureContract:
+    """``ap.find_features`` rejects misaligned/degenerate labels and malformed df_seq early."""
+
+    def test_labels_none(self, pipeline):
+        _assert_contract(ValueError, r"'labels' should not be None",
+                         lambda: ap.find_features(labels=None, df_seq=pipeline["df_seq"], plot=False))
+
+    def test_labels_single_class(self, pipeline):
+        # Composition failure: one class cannot define a test-vs-reference contrast. Without the
+        # frontend guard this surfaced as an opaque "produced no valid configurations" RuntimeError.
+        n = len(pipeline["df_seq"])
+        _assert_contract(ValueError, r"should contain more than one different value",
+                         lambda: ap.find_features(labels=[1] * n, df_seq=pipeline["df_seq"], plot=False))
+
+    def test_labels_length_mismatch(self, pipeline):
+        _assert_contract(ValueError, r"'labels' \(n=\d+\) should contain \d+ values",
+                         lambda: ap.find_features(labels=pipeline["labels"][:-1],
+                                                  df_seq=pipeline["df_seq"], plot=False))
+
+    def test_malformed_df_seq(self, pipeline):
+        # Malformed input frame: neither the required 'entry' nor a recognized sequence format.
+        bad = pd.DataFrame({"foo": [1, 2, 3, 4]})
+        _assert_contract(ValueError, r"'df_seq'",
+                         lambda: ap.find_features(labels=[0, 1, 0, 1], df_seq=bad, plot=False))
+
+
+# ---------------------------------------------------------------------------
+# ap.predict_samples
+# ---------------------------------------------------------------------------
+class TestPredictSamplesFailureContract:
+    """``ap.predict_samples`` rejects an empty/invalid feature set and misaligned labels."""
+
+    def test_empty_feature_set(self, pipeline):
+        _assert_contract(ValueError, r"'list_df_feat' should contain at least one feature DataFrame",
+                         lambda: ap.predict_samples(list_df_feat=[], df_seq=pipeline["df_seq"],
+                                                    labels=pipeline["labels"], plot=False))
+
+    def test_feature_schema_mismatch(self, pipeline):
+        # Schema mismatch at the df_feat -> model seam: a frame missing the canonical CPP columns.
+        bad_feat = pd.DataFrame({"foo": [1, 2, 3]})
+        _assert_contract(ValueError, r"'df_feat' is missing required columns",
+                         lambda: ap.predict_samples(list_df_feat=[bad_feat], df_seq=pipeline["df_seq"],
+                                                    labels=pipeline["labels"], plot=False))
+
+    def test_labels_length_mismatch(self, pipeline):
+        _assert_contract(ValueError, r"'labels' \(n=\d+\) should contain \d+ values",
+                         lambda: ap.predict_samples(list_df_feat=[pipeline["df_feat"]],
+                                                    df_seq=pipeline["df_seq"],
+                                                    labels=pipeline["labels"][:-1], plot=False))
+
+    def test_labels_single_class(self, pipeline):
+        n = len(pipeline["df_seq"])
+        _assert_contract(ValueError, r"should contain more than one different value",
+                         lambda: ap.predict_samples(list_df_feat=[pipeline["df_feat"]],
+                                                    df_seq=pipeline["df_seq"],
+                                                    labels=[1] * n, plot=False))
+
+
+# ---------------------------------------------------------------------------
+# ap.explain_features (pro-gated: SHAP)
+# ---------------------------------------------------------------------------
+class TestExplainFeaturesFailureContract:
+    """``ap.explain_features`` degrades to an install hint without ``[pro]``; else fails early."""
+
+    @pytest.mark.skipif(_HAS_PRO, reason="shap installed: the pro stub is not active "
+                                         "(the installed-wheel contract is covered by the packaging gate)")
+    def test_missing_pro_dependency_install_hint(self, pipeline):
+        # Without shap, ap.explain_features is a missing_feature_stub: calling it raises ImportError
+        # naming the extra to install. This is the contract a coding agent hits on a base install.
+        exc = _assert_contract(ImportError, r"aaanalysis\[pro\]",
+                               lambda: ap.explain_features(df_feat=pipeline["df_feat"],
+                                                           df_seq=pipeline["df_seq"],
+                                                           labels=pipeline["labels"], plot=False))
+        assert "explain_features" in str(exc)
+
+    @pytest.mark.skipif(not _HAS_PRO, reason="requires the [pro] extra (shap) for the real function")
+    def test_feature_schema_mismatch(self, pipeline):
+        bad_feat = pd.DataFrame({"foo": [1, 2, 3]})
+        _assert_contract(ValueError, r"'df_feat' is missing required columns",
+                         lambda: ap.explain_features(df_feat=bad_feat, df_seq=pipeline["df_seq"],
+                                                     labels=pipeline["labels"], plot=False))
+
+    @pytest.mark.skipif(not _HAS_PRO, reason="requires the [pro] extra (shap) for the real function")
+    def test_labels_single_class(self, pipeline):
+        n = len(pipeline["df_seq"])
+        _assert_contract(ValueError, r"should contain more than one different value",
+                         lambda: ap.explain_features(df_feat=pipeline["df_feat"], df_seq=pipeline["df_seq"],
+                                                     labels=[0] * n, plot=False))
+
+
+# ---------------------------------------------------------------------------
+# CPP construction / run (the interpretable core the pipelines wrap)
+# ---------------------------------------------------------------------------
+class TestCPPFailureContract:
+    """``CPP`` rejects empty/invalid parts, uncovered residues, and degenerate labels."""
+
+    def test_empty_df_parts(self):
+        _assert_contract(ValueError, r"'df_parts' should not be empty",
+                         lambda: aa.CPP(df_parts=pd.DataFrame()))
+
+    def test_invalid_part_name(self, pipeline):
+        # Invalid 'parts' requested from get_df_parts (the parts a caller would feed CPP).
+        _assert_contract(ValueError, r"\['not_a_part'\] not valid part",
+                         lambda: aa.SequenceFeature().get_df_parts(df_seq=pipeline["df_seq"],
+                                                                   list_parts=["not_a_part"]))
+
+    def test_malformed_sequence_uncovered_residue(self, pipeline):
+        # Malformed sequence at the parts <-> scales seam: a residue no scale covers.
+        df_parts_bad = pipeline["df_parts"].copy()
+        first = str(df_parts_bad.iloc[0, 0])
+        df_parts_bad.iloc[0, 0] = "Z" + first[1:]
+        _assert_contract(ValueError, r"Not all characters in sequences from 'df_parts' are covered",
+                         lambda: aa.CPP(df_parts=df_parts_bad, df_scales=pipeline["df_scales"],
+                                        verbose=False).run(labels=pipeline["labels"], n_jobs=1))
+
+    def test_labels_single_class(self, pipeline):
+        n = len(pipeline["df_parts"])
+        _assert_contract(ValueError, r"should contain more than one different value",
+                         lambda: aa.CPP(df_parts=pipeline["df_parts"], df_scales=pipeline["df_scales"],
+                                        verbose=False).run(labels=[1] * n, n_jobs=1))
+
+
+# ---------------------------------------------------------------------------
+# AAPred (the prediction endpoint the CPP path feeds)
+# ---------------------------------------------------------------------------
+class TestAAPredFailureContract:
+    """``AAPred`` rejects unfitted scoring, too-few-positives splits, and shape mismatch."""
+
+    def test_predict_unfitted(self, pipeline):
+        _assert_contract(ValueError, r"'AAPred' is not fitted",
+                         lambda: aa.AAPred().predict(df_seq=pipeline["df_seq"]))
+
+    def test_predict_proba_unfitted(self, pipeline):
+        _assert_contract(ValueError, r"'AAPred' is not fitted",
+                         lambda: aa.AAPred().predict_proba(X=np.asarray(pipeline["X"])))
+
+    def test_too_few_positives_to_split(self, pipeline):
+        # More CV folds than the smallest class can populate (the "too few positives to split" case).
+        _assert_contract(ValueError, r"should not be greater than the smallest class count",
+                         lambda: aa.AAPred().eval(X=np.asarray(pipeline["X"]),
+                                                  labels=pipeline["labels"], n_cv=999))
+
+    def test_predict_proba_feature_width_mismatch(self, pipeline, fitted_aapred):
+        # Feature matrix / model shape mismatch on the matrix-scoring path: a self-explaining
+        # message naming 'X', not scikit-learn's internal "<Estimator> is expecting M features".
+        X_narrow = np.asarray(pipeline["X"])[:, :3]
+        _assert_contract(ValueError, r"'X' n_features \(\d+\) should match the fitted model's n_features",
+                         lambda: fitted_aapred.predict_proba(X=X_narrow))
+
+    def test_eval_holdout_width_mismatch(self, pipeline):
+        X = np.asarray(pipeline["X"])
+        _assert_contract(ValueError, r"'X_holdout' n_features \(\d+\) should match 'X' n_features",
+                         lambda: aa.AAPred().eval(X=X, labels=pipeline["labels"],
+                                                  X_holdout=X[:, :3], labels_holdout=pipeline["labels"]))
+
+
+# ---------------------------------------------------------------------------
+# CPPGrid: eval before run (unfitted-component contract, RuntimeError side)
+# ---------------------------------------------------------------------------
+class TestCPPGridFailureContract:
+    """``CPPGrid.eval`` before ``run`` is a runtime-state error (bare RuntimeError)."""
+
+    def test_eval_before_run(self, pipeline):
+        _assert_contract(RuntimeError, r"'eval' requires a prior 'run'",
+                         lambda: aa.CPPGrid(df_seq=pipeline["df_seq"], labels=pipeline["labels"],
+                                            verbose=False).eval())
+
+
+# ---------------------------------------------------------------------------
+# Contract hygiene (the KPIs, asserted, not just eyeballed)
+# ---------------------------------------------------------------------------
+class TestFailureContractHygiene:
+    """The raised errors are bare builtins with self-explaining, input-naming messages."""
+
+    def test_error_types_are_bare_builtins(self, pipeline):
+        # No bespoke exception hierarchy: every contract failure is exactly one of these.
+        cases = [
+            lambda: ap.find_features(labels=[1] * len(pipeline["df_seq"]),
+                                     df_seq=pipeline["df_seq"], plot=False),
+            lambda: ap.predict_samples(list_df_feat=[], df_seq=pipeline["df_seq"],
+                                       labels=pipeline["labels"], plot=False),
+            lambda: aa.CPP(df_parts=pd.DataFrame()),
+            lambda: aa.AAPred().predict_proba(X=np.asarray(pipeline["X"])),
+            lambda: aa.CPPGrid(df_seq=pipeline["df_seq"], labels=pipeline["labels"],
+                               verbose=False).eval(),
+        ]
+        for call in cases:
+            with pytest.raises((ValueError, RuntimeError)) as excinfo:
+                call()
+            assert type(excinfo.value) in (ValueError, RuntimeError)
+
+    def test_messages_name_the_offending_input(self, pipeline):
+        # The message alone identifies the user error (no private traceback detail needed): it
+        # quotes the offending input name and uses the canonical "should"/"requires" phrasing.
+        with pytest.raises(ValueError) as excinfo:
+            ap.predict_samples(list_df_feat=[pipeline["df_feat"]], df_seq=pipeline["df_seq"],
+                               labels=pipeline["labels"][:-1], plot=False)
+        msg = str(excinfo.value)
+        assert "'labels'" in msg and "should contain" in msg

--- a/tests/unit/pipe_tests/test_ap_find_features.py
+++ b/tests/unit/pipe_tests/test_ap_find_features.py
@@ -183,6 +183,21 @@ class TestFindFeatures:
             with pytest.raises(ValueError):
                 ap.find_features(labels, df_seq=df_seq, search="fast", model=bad, plot=False)
 
+    def test_invalid_labels(self):
+        # None, single-class, and a length-misaligned vector are all rejected by the frontend
+        # check_labels before the search runs.
+        for bad in [None, [1] * len(df_seq), labels[:-1]]:
+            with pytest.raises(ValueError):
+                ap.find_features(bad, df_seq=df_seq, search="fast", plot=False)
+
+    def test_labels_error_message_is_precise(self):
+        # Regression: a degenerate/misaligned label vector must raise a ValueError naming 'labels',
+        # not surface later as the opaque "produced no valid configurations" runtime error.
+        with pytest.raises(ValueError, match="more than one different value"):
+            ap.find_features([1] * len(df_seq), df_seq=df_seq, search="fast", plot=False)
+        with pytest.raises(ValueError, match=r"'labels' \(n=\d+\) should contain \d+ values"):
+            ap.find_features(labels[:-1], df_seq=df_seq, search="fast", plot=False)
+
     def test_invalid_cv(self):
         for bad in [1, 0, -1, "x"]:
             with pytest.raises(ValueError):

--- a/tests/unit/prediction_tests/test_aa_pred.py
+++ b/tests/unit/prediction_tests/test_aa_pred.py
@@ -928,6 +928,20 @@ class TestAAPredPredictProba:
         with pytest.raises(ValueError):
             aap.predict_proba(X, score_range="pct")
 
+    def test_feature_width_mismatch_raises(self):
+        # A matrix whose width does not match fit raises a self-explaining ValueError naming 'X',
+        # not scikit-learn's internal "<Estimator> is expecting M features".
+        X, labels = _data(n_feat=6)
+        aap = aa.AAPred(models=["rf"], random_state=0).fit(X, labels)
+        with pytest.raises(ValueError,
+                           match=r"'X' n_features \(3\) should match the fitted model's n_features \(6\)"):
+            aap.predict_proba(np.asarray(X)[:, :3])
+
+    def test_unfitted_predict_proba_raises(self):
+        X, _ = _data()
+        with pytest.raises(ValueError, match="'AAPred' is not fitted"):
+            aa.AAPred().predict_proba(X)
+
     def test_single_sample(self):
         # min_n_samples=1: a one-row candidate matrix scores fine (no identical-samples guard).
         X, labels = _data()


### PR DESCRIPTION
## Summary

Pins the **failure contract** of the golden pipelines (`ap.find_features`,
`ap.predict_samples`, `ap.explain_features`) and the core CPP → `AAPred` path, so an
invalid call raises a bare `ValueError`/`RuntimeError` (or, without `[pro]`, an
install-hint `ImportError`) with a self-explaining message that names the offending
input. A coding agent or scripted caller mostly meets these entry points on the
*unhappy* path, and until now that behaviour was assorted and untested.

## What's included

**Failure-path contract suite** — `tests/integration/test_failure_contracts.py`
(integration tier, public API only). Composition-failure tests over each golden
pipeline + CPP/AAPred/CPPGrid, covering: missing/empty/single-class/misaligned labels,
malformed sequences (uncovered residue), feature/model shape mismatch, invalid parts,
missing-`pro` dependency (install-hint `ImportError`), too-few-positives split, and
unfitted `predict`/`predict_proba`. A hygiene test asserts the errors are bare builtins
(no bespoke subclass) with input-naming messages.

**Installed-package coverage** — `tests/_check_public_api_packaged.py` gains a 4th
section asserting the error surface from the installed wheel/sdist (core bare
`ValueError`s + the `ap.explain_features` install-hint `ImportError` in the base-deps
venv), reusing the packaging gate.

**Message polish** (validation-tightening, non-breaking; no new exception classes):
- `ap.find_features` validates `labels` up front → a single-class/misaligned/empty
  vector raises a precise `ValueError` naming `labels`, instead of an opaque
  `RuntimeError: "produced no valid configurations"`.
- `AAPred.predict_proba` raises `"'X' n_features (…) should match the fitted model's
  n_features"` instead of scikit-learn's internal estimator message on a width
  mismatch.

**Ripple**: unit tests for both fixes, a worked correct/incorrect docs page
(`usage_principles/error_contracts.rst`, wired into the toctree), and a release-notes
entry. No new public symbols, dependencies, or signature changes; default behaviour on
valid input is unchanged.

## Verification

- Unit + full integration/e2e tier: **168 passed, 0 failed** (1 skipped: the pro-stub
  test skips where `shap` is installed and runs where it is absent).
- Docstring checker: 0 defects. Doc-vs-signature drift: 0. flake8 error-lint: clean.

Closes #477
