### PR TITLE
docs: stamp v1.1.0 release date (changelog + release notes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ notes — with cross-references and examples — live in
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-19
+
 This release substantially expands the feature-engineering surface: a unified
 feature-preprocessor family (embedding / structure / annotation sources), a
 numerical mode for CPP, a configuration-sweep wrapper, sequence-window sampling,
@@ -192,9 +194,11 @@ and a suite of site-localization metrics and plotting helpers.
 - Test release of the first beta version (`CPP`, `dPULearn`, `AAclust`,
   `SequenceFeature`, `load_dataset`, `load_scales`).
 
-<!-- Only tags 0.1.1, v1.0.0, v1.0.3 exist; intermediate versions (1.0.1/1.0.2,
-     0.1.2–0.1.5) were never tagged, so only the real tags are linked here. -->
-[Unreleased]: https://github.com/breimanntools/aaanalysis/compare/v1.0.3...HEAD
+<!-- Real tags: 0.1.1, v1.0.0, v1.0.3, and v1.1.0 (this release); intermediate
+     versions (1.0.1/1.0.2, 0.1.2–0.1.5) were never tagged, so only the real tags
+     are linked here. -->
+[Unreleased]: https://github.com/breimanntools/aaanalysis/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/breimanntools/aaanalysis/compare/v1.0.3...v1.1.0
 [1.0.3]: https://github.com/breimanntools/aaanalysis/compare/v1.0.0...v1.0.3
 [1.0.0]: https://github.com/breimanntools/aaanalysis/compare/0.1.1...v1.0.0
 [0.1.1]: https://github.com/breimanntools/aaanalysis/releases/tag/0.1.1

--- a/docs/source/index/release_notes.rst
+++ b/docs/source/index/release_notes.rst
@@ -6,7 +6,7 @@ Release Notes
 Version 1.1
 --------------------------------
 
-v1.1.0 (Unreleased)
+v1.1.0 (2026-07-19)
 --------------------------------
 
 This release substantially expands the feature-engineering surface: a unified


### PR DESCRIPTION
Release-prep doc stamp for **v1.1.0**. All v1.1 milestone issues are closed (53/53) and `pyproject` is already at `1.1.0`; this converts the changelog/release-notes from *Unreleased* to the dated 1.1.0 section so the released docs read correctly.

## Changes
- `CHANGELOG.md`: `## [Unreleased]` → new dated `## [1.1.0] - 2026-07-19` section (empty `[Unreleased]` retained on top for the next cycle); add the `v1.0.3...v1.1.0` compare link and repoint `[Unreleased]` at `v1.1.0...HEAD`.
- `docs/source/index/release_notes.rst`: heading `v1.1.0 (Unreleased)` → `v1.1.0 (2026-07-19)`.

## Not in this PR (by design)
- The RTD *unreleased development version* banner needs no change: it keys off whether the Read the Docs build is a `tag` build (`is_dev_build = rtd_version_type != "tag"`), so it turns off automatically once the `v1.1.0` tag is built.
- The `[1.1.0]` compare link resolves once the tag exists — this is the standard release-prep commit that immediately precedes the tag.

## Remaining release steps (operator / human)
1. Register the PyPI trusted publisher for `release.yml` + environment `pypi` on pypi.org, and create the `pypi` GitHub Environment (the OIDC publish fails closed until this exists).
2. Cut the GitHub Release with tag `v1.1.0` — publishing the Release triggers `release.yml` → OIDC publish to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)