### PR TITLE
fix(reliability): honest applicability domain + keyword-only params on the new 1.1.0 classes

### DIFF
--- a/aaanalysis/prediction/_aa_pred.py
+++ b/aaanalysis/prediction/_aa_pred.py
@@ -253,7 +253,7 @@ class AAPred(Wrapper):
     """
 
     def __init__(self,
-                 models: Optional[Union[str, "BaseEstimator", List]] = None,
+                 *, models: Optional[Union[str, "BaseEstimator", List]] = None,
                  list_model_classes: Optional[List[Type[Union[ClassifierMixin, BaseEstimator]]]] = None,
                  list_model_kwargs: Optional[List[Dict]] = None,
                  list_metrics: Optional[List[str]] = None,
@@ -376,7 +376,7 @@ class AAPred(Wrapper):
     def fit(self,
             X: ut.ArrayLike2D,
             labels: ut.ArrayLike1D,
-            label_pos: int = 1,
+            *, label_pos: int = 1,
             optimize_hyperparams: bool = False,
             param_grids: Optional[Union[Dict, List[Dict]]] = None,
             n_cv: int = 5,
@@ -453,7 +453,7 @@ class AAPred(Wrapper):
     def eval(self,
              X: ut.ArrayLike2D,
              labels: ut.ArrayLike1D,
-             X_holdout: Optional[ut.ArrayLike2D] = None,
+             *, X_holdout: Optional[ut.ArrayLike2D] = None,
              labels_holdout: Optional[ut.ArrayLike1D] = None,
              metrics: Optional[List[str]] = None,
              n_cv: int = 5,
@@ -592,7 +592,7 @@ class AAPred(Wrapper):
     def predict_oof(self,
                     X: ut.ArrayLike2D,
                     labels: ut.ArrayLike1D,
-                    label_pos: int = 1,
+                    *, label_pos: int = 1,
                     n_cv: int = 5,
                     score_range: str = "proba",
                     ) -> pd.DataFrame:
@@ -667,7 +667,7 @@ class AAPred(Wrapper):
     def score_to_group(scores: ut.ArrayLike1D,
                        thresholds: List[Union[int, float]],
                        labels: List[str],
-                       score_range: str = "percent",
+                       *, score_range: str = "percent",
                        ) -> pd.Series:
         """
         Map prediction scores to an ordered categorical of named confidence groups.
@@ -747,7 +747,7 @@ class AAPred(Wrapper):
 
     def predict(self,
                 df_seq: pd.DataFrame,
-                level: str = "sequence",
+                *, level: str = "sequence",
                 threshold: Optional[Union[int, float]] = None,
                 list_parts: Optional[List[str]] = None,
                 window: int = 3,
@@ -863,7 +863,7 @@ class AAPred(Wrapper):
 
     def predict_proba(self,
                       X: ut.ArrayLike2D,
-                      score_range: str = "proba",
+                      *, score_range: str = "proba",
                       ) -> pd.DataFrame:
         """
         Score a precomputed feature matrix with the fitted deployment ensemble.

--- a/aaanalysis/prediction/_aa_pred_plot.py
+++ b/aaanalysis/prediction/_aa_pred_plot.py
@@ -505,7 +505,7 @@ class AAPredPlot:
 
     @staticmethod
     def predict_sample(data: Optional[pd.DataFrame] = None,
-                       kind: str = "window",
+                       *, kind: str = "window",
                        ax: Optional[Axes] = None,
                        figsize: Optional[Tuple[Union[int, float], Union[int, float]]] = None,
                        entry: Optional[str] = None,
@@ -668,7 +668,7 @@ class AAPredPlot:
 
     @staticmethod
     def predict_group(data: Union[pd.DataFrame, ut.ArrayLike1D, ut.ArrayLike2D],
-                       kind: str = "hist",
+                       *, kind: str = "hist",
                        ax: Optional[Axes] = None,
                        figsize: Optional[Tuple[Union[int, float], Union[int, float]]] = None,
                        labels: Optional[ut.ArrayLike1D] = None,
@@ -925,7 +925,7 @@ class AAPredPlot:
 
     @staticmethod
     def group_cluster(X: Union[pd.DataFrame, ut.ArrayLike2D],
-                      kind: str = "clustermap",
+                      *, kind: str = "clustermap",
                       labels: Optional[ut.ArrayLike1D] = None,
                       dict_color: Optional[Dict[Union[int, str], str]] = None,
                       legend_title: str = "Class",
@@ -1014,7 +1014,7 @@ class AAPredPlot:
 
     @staticmethod
     def eval(df_eval: pd.DataFrame,
-             kind: str = "eval",
+             *, kind: str = "eval",
              ax: Optional[Axes] = None,
              figsize: Optional[Tuple[Union[int, float], Union[int, float]]] = None,
              dict_color: Optional[Union[Dict[str, str], List[str]]] = None,

--- a/aaanalysis/prediction/_backend/reliability/reliability.py
+++ b/aaanalysis/prediction/_backend/reliability/reliability.py
@@ -87,8 +87,14 @@ def apply_applicability_domain(state, X_new):
     else:
         maha = np.sqrt(np.clip(np.einsum("ij,jk,ik->i", diff, state["inv_cov"], diff), 0, None))
         leverage = np.einsum("ij,jk,ik->i", diff, state["gram_inv"], diff)
-    return dict(ood_score=(knn / thr if thr > 0 else knn),
-                in_domain=(knn <= thr if thr > 0 else np.ones(len(Xnew), dtype=bool)),
+    # A non-positive or non-finite threshold means the training reference carries no usable
+    # spread (e.g. duplicate or constant rows), so "inside the domain" is not established for
+    # any sample. Report that as unknown (NaN score, in_domain False) rather than waving every
+    # sample through -- a silent all-in-domain verdict is the exact failure an applicability
+    # domain exists to prevent.
+    usable_thr = bool(np.isfinite(thr)) and thr > 0
+    return dict(ood_score=(knn / thr if usable_thr else np.full(len(Xnew), np.nan)),
+                in_domain=(knn <= thr if usable_thr else np.zeros(len(Xnew), dtype=bool)),
                 knn=knn, maha=maha, leverage=leverage)
 
 

--- a/aaanalysis/prediction/_model_evaluator.py
+++ b/aaanalysis/prediction/_model_evaluator.py
@@ -167,7 +167,7 @@ class ModelEvaluator(Tool):
     """
 
     def __init__(self,
-                 models: Optional[Union[str, BaseEstimator, List]] = None,
+                 *, models: Optional[Union[str, BaseEstimator, List]] = None,
                  list_metrics: Optional[List[str]] = None,
                  verbose: bool = True,
                  random_state: Optional[int] = None,
@@ -227,7 +227,7 @@ class ModelEvaluator(Tool):
     def run(self,
             X: ut.ArrayLike2D,
             labels: ut.ArrayLike1D,
-            n_cv: int = 5,
+            *, n_cv: int = 5,
             n_rounds: int = 1,
             metrics: Optional[List[str]] = None,
             ci: Optional[float] = 0.95,
@@ -300,7 +300,7 @@ class ModelEvaluator(Tool):
         return df_eval
 
     def eval(self,
-             metric: Optional[str] = None,
+             *, metric: Optional[str] = None,
              ci: Optional[float] = 0.95,
              random_state: Optional[int] = None,
              ) -> pd.DataFrame:

--- a/aaanalysis/prediction/_model_evaluator_plot.py
+++ b/aaanalysis/prediction/_model_evaluator_plot.py
@@ -41,7 +41,7 @@ class ModelEvaluatorPlot:
 
     @staticmethod
     def scores(df_eval: pd.DataFrame,
-               figsize: Tuple[Union[int, float], Union[int, float]] = (6, 4),
+               *, figsize: Tuple[Union[int, float], Union[int, float]] = (6, 4),
                colors: Optional[List[str]] = None,
                metrics: Optional[List[str]] = None,
                ) -> Tuple[Figure, Axes]:
@@ -101,7 +101,7 @@ class ModelEvaluatorPlot:
 
     @staticmethod
     def compare(df_eval: pd.DataFrame,
-                figsize: Tuple[Union[int, float], Union[int, float]] = (6, 4),
+                *, figsize: Tuple[Union[int, float], Union[int, float]] = (6, 4),
                 colors: Optional[List[str]] = None,
                 alpha: float = 0.05,
                 ) -> Tuple[Figure, Axes]:

--- a/aaanalysis/prediction/_reliability_model.py
+++ b/aaanalysis/prediction/_reliability_model.py
@@ -134,7 +134,7 @@ class ReliabilityModel(Wrapper):
     """
 
     def __init__(self,
-                 verbose: bool = True,
+                 *, verbose: bool = True,
                  random_state: Optional[int] = None,
                  ):
         """
@@ -162,7 +162,7 @@ class ReliabilityModel(Wrapper):
     def fit(self,
             X: ut.ArrayLike2D,
             labels: ut.ArrayLike1D,
-            model: Optional[Union[object, List]] = None,
+            *, model: Optional[Union[object, List]] = None,
             label_pos: int = 1,
             k: int = 5,
             ad_percentile: float = 95.0,
@@ -372,7 +372,7 @@ class ReliabilityModel(Wrapper):
             ut.COL_RELIABLE: reliable})
 
     def eval(self,
-             X: Optional[ut.ArrayLike2D] = None,
+             *, X: Optional[ut.ArrayLike2D] = None,
              labels: Optional[ut.ArrayLike1D] = None,
              n_bins: int = 5,
              ) -> pd.DataFrame:

--- a/aaanalysis/prediction/_reliability_model_plot.py
+++ b/aaanalysis/prediction/_reliability_model_plot.py
@@ -44,7 +44,7 @@ class ReliabilityModelPlot:
 
     @staticmethod
     def ranking(df_rel: pd.DataFrame,
-                names: Optional[list] = None,
+                *, names: Optional[list] = None,
                 figsize: Optional[Tuple[float, float]] = None,
                 top_n: Optional[int] = None,
                 title: Optional[str] = None,
@@ -96,7 +96,7 @@ class ReliabilityModelPlot:
 
     @staticmethod
     def reliability_diagram(df_eval: pd.DataFrame,
-                            figsize: Tuple[float, float] = (5, 5),
+                            *, figsize: Tuple[float, float] = (5, 5),
                             color: str = "tab:blue",
                             title: Optional[str] = None,
                             ax: Optional[Axes] = None,
@@ -137,7 +137,7 @@ class ReliabilityModelPlot:
 
     @staticmethod
     def ood_hist(df_rel: pd.DataFrame,
-                 figsize: Tuple[float, float] = (6, 4.5),
+                 *, figsize: Tuple[float, float] = (6, 4.5),
                  bins: int = 20,
                  color: str = "tab:gray",
                  title: Optional[str] = None,
@@ -182,7 +182,7 @@ class ReliabilityModelPlot:
 
     @staticmethod
     def trust_map(df_rel: pd.DataFrame,
-                  figsize: Tuple[float, float] = (5.5, 5),
+                  *, figsize: Tuple[float, float] = (5.5, 5),
                   title: Optional[str] = None,
                   ax: Optional[Axes] = None,
                   ) -> Tuple[Figure, Axes]:

--- a/aaanalysis/protein_engineering/_seqopt.py
+++ b/aaanalysis/protein_engineering/_seqopt.py
@@ -169,7 +169,7 @@ class SeqOpt(Tool):
     ``region``, ``to_aa``), the ``algorithm="greedy"`` baseline, and any ``callable(sequence)``
     objective.
 
-    .. versionadded:: 1.0.0
+    .. versionadded:: 1.1.0
 
     """
     def __init__(self,

--- a/aaanalysis/protein_engineering/_seqopt.py
+++ b/aaanalysis/protein_engineering/_seqopt.py
@@ -173,7 +173,7 @@ class SeqOpt(Tool):
 
     """
     def __init__(self,
-                 mode: str = "impact",
+                 *, mode: str = "impact",
                  model: Optional[Any] = None,
                  target_class: Optional[Any] = None,
                  df_seq_ref: Optional[pd.DataFrame] = None,
@@ -384,7 +384,7 @@ class SeqOpt(Tool):
             df_seq: pd.DataFrame,
             df_feat: pd.DataFrame,
             objectives: List[Tuple[str, str, Any]],
-            algorithm: str = "nsga2",
+            *, algorithm: str = "nsga2",
             pop_size: int = 50,
             n_gen: int = 20,
             crossover: str = "uniform",
@@ -625,7 +625,7 @@ class SeqOpt(Tool):
 
     def eval(self,
              df_pareto: pd.DataFrame,
-             ref_point: Optional[ut.ArrayLike1D] = None,
+             *, ref_point: Optional[ut.ArrayLike1D] = None,
              ref_front: Optional[ut.ArrayLike2D] = None,
              ) -> pd.DataFrame:
         """

--- a/aaanalysis/protein_engineering/_seqopt_plot.py
+++ b/aaanalysis/protein_engineering/_seqopt_plot.py
@@ -51,7 +51,7 @@ class SeqOptPlot:
 
     """
     def __init__(self,
-                 verbose: bool = False,
+                 *, verbose: bool = False,
                  ):
         """
         Parameters
@@ -70,7 +70,7 @@ class SeqOptPlot:
                      df_pareto: pd.DataFrame,
                      x: str,
                      y: str,
-                     z: Optional[str] = None,
+                     *, z: Optional[str] = None,
                      ax: Optional[Axes] = None,
                      figsize: tuple = (6, 5),
                      front_only: bool = False,
@@ -146,7 +146,7 @@ class SeqOptPlot:
 
     def hypervolume(self,
                     trajectory: ut.ArrayLike1D,
-                    ax: Optional[Axes] = None,
+                    *, ax: Optional[Axes] = None,
                     figsize: tuple = (6, 4),
                     ) -> Tuple[Figure, Axes]:
         """
@@ -186,7 +186,7 @@ class SeqOptPlot:
 
     def convergence(self,
                     history: pd.DataFrame,
-                    figsize: tuple = (6, 7),
+                    *, figsize: tuple = (6, 7),
                     ) -> Tuple[Figure, List[Axes]]:
         """
         Plot per-generation convergence: hypervolume, spread and per-objective best.
@@ -244,7 +244,7 @@ class SeqOptPlot:
     def parallel_coordinates(self,
                              df_pareto: pd.DataFrame,
                              objectives: List[str],
-                             ax: Optional[Axes] = None,
+                             *, ax: Optional[Axes] = None,
                              figsize: tuple = (7, 4),
                              front_only: bool = True,
                              cmap: str = "viridis_r",
@@ -310,7 +310,7 @@ class SeqOptPlot:
 
     def mutation_map(self,
                      df_pareto: pd.DataFrame,
-                     ax: Optional[Axes] = None,
+                     *, ax: Optional[Axes] = None,
                      figsize: tuple = (8, 4),
                      front_only: bool = True,
                      cmap: str = "Reds",
@@ -380,7 +380,7 @@ class SeqOptPlot:
 
     def genealogy(self,
                   df_pareto: pd.DataFrame,
-                  ax: Optional[Axes] = None,
+                  *, ax: Optional[Axes] = None,
                   figsize: tuple = (8, 5),
                   front_only: bool = True,
                   cmap: str = "viridis",

--- a/aaanalysis/protein_engineering/_seqopt_plot.py
+++ b/aaanalysis/protein_engineering/_seqopt_plot.py
@@ -47,7 +47,7 @@ class SeqOptPlot:
     ``fig, ax = ...``. For backward compatibility, the returned object also forwards attribute
     access to ``ax``.
 
-    .. versionadded:: 1.0.0
+    .. versionadded:: 1.1.0
 
     """
     def __init__(self,

--- a/tests/unit/reliability_model_tests/test_reliability_model.py
+++ b/tests/unit/reliability_model_tests/test_reliability_model.py
@@ -229,6 +229,25 @@ class TestPredict:
         assert df["entropy"].between(0, 1.0001).all()
         assert df["conformal_set"].isin(["neg", "pos", "both", "none"]).all()
 
+    def test_degenerate_reference_is_not_silently_in_domain(self):
+        """A training reference with no spread must not wave every sample through.
+
+        A few distinct rows, each heavily duplicated, passes the unique-samples guard but
+        still drives every training kNN distance to 0, so the domain boundary collapses.
+        Nothing can be established as inside it, and the honest report is 'not in domain'
+        with an undefined score -- never a blanket ``in_domain=True``, which is precisely
+        the failure an applicability domain exists to prevent.
+        """
+        n_features, n_copies = 8, 20
+        distinct = np.array([[0.0] * n_features, [1.0] * n_features, [2.0] * n_features])
+        Xtr = np.repeat(distinct, n_copies, axis=0)
+        ytr = np.array([0, 1] * (len(Xtr) // 2))
+        Xfar = np.full((3, n_features), 99.0)
+        df = aa.ReliabilityModel(random_state=0).fit(Xtr, ytr, n_bootstrap=3).predict(Xfar)
+        assert not df["in_domain"].any()
+        assert df["ood_score"].isna().all()
+        assert not df["reliable"].any()
+
 
 class TestDistinctions:
     """Pin the mental model: score != trust; OOD overrides a high score."""


### PR DESCRIPTION
Two pre-tag items found while auditing what v1.1.0 permanently freezes into the
public API. Both are free to fix now and cost a deprecation cycle after the tag.

## 1. The applicability domain could silently pass everything

`apply_applicability_domain` returned `in_domain=True` for **every** sample when
the training kNN threshold was non-positive, plus an unnormalized `ood_score`.
That is backwards: a threshold of 0 means the reference carries no usable spread,
so nothing can be established as inside the domain. The blanket pass-through fired
precisely when the model knew least, which is the exact failure an applicability
domain exists to prevent.

It is reachable on realistic input: a handful of distinct rows each heavily
duplicated clears `check_X_unique_samples` (>= 3 unique) while still driving every
training kNN distance to 0. Redundant small protein sets look like this.

Now a non-positive or non-finite threshold yields `ood_score=NaN` and
`in_domain=False`, so the composite `reliable` flag stays False too.
Non-degenerate behaviour is unchanged. The added regression test fails on the
previous code.

## 2. Optional parameters are now keyword-only on the classes new in 1.1.0

None of the new classes used a `*` marker, so parameter **order** was about to
freeze. `SeqOpt.run` alone exposed 22 positional-or-keyword parameters — locking
an ordering nobody calls positionally.

Data arguments stay positional; everything else moves behind `*`:

| method | before | after |
|---|---|---|
| `SeqOpt.run` | 22 positional | 3 positional, 19 keyword-only |
| `ReliabilityModel.fit` | 11 | 2 |
| `AAPred.eval` | 10 | 2 |
| `AAPredPlot.predict_group` | 34 | 1 |

Every `__init__` becomes fully keyword-only, which also settles an inconsistency
where `verbose` was 8th on `SeqOpt` but 1st on `SeqMut` and `AAMut` — so
`SeqOpt(True)` used to set `mode=True` and raise.

**Scope is limited to symbols new in 1.1.0 that have never been published**, so
this costs no deprecation cycle. Classes already public at v1.0.3 (CPP, AAclust,
dPULearn, TreeModel, SeqMut, AAMut, AALogo) are untouched — adding `*` there would
be a real break. `SequenceFeatureTransformer` is excluded because sklearn's
estimator checks introspect its `__init__`.

## 3. Version directive correction

`.. versionadded:: 1.0.0` -> `1.1.0` on `SeqOpt` and `SeqOptPlot`. Neither existed
at v1.0.3 (that tag exports only `AAMut`/`AAMutPlot`/`SeqMut`/`SeqMutPlot`), and
the release notes already file both under 1.1.0.

## Testing

888 tests pass locally across `prediction_tests`, `reliability_model_tests`,
`seqopt_tests` and `api_tests` — every suite covering a changed class. Relying on
CI for the full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)