### PR TITLE
docs(api): mark ReliabilityModel and SeqOpt experimental, uniform with the v1.1 tier

### DIFF
--- a/aaanalysis/prediction/_reliability_model.py
+++ b/aaanalysis/prediction/_reliability_model.py
@@ -107,6 +107,12 @@ class ReliabilityModel(Wrapper):
     (features here are a descriptor space), calibration follows [Guo17]_ (a raw ``predict_proba`` is
     not a confidence until calibrated), and the conformal set follows [Angelopoulos23]_.
 
+    .. warning::
+
+        **Experimental.** This class is part of the new v1.1.0 prediction layer and is under active
+        development; its API (signatures, defaults, return objects) may change between minor releases
+        without the usual deprecation cycle. Pin a version if you depend on the current behaviour.
+
     .. versionadded:: 1.1.0
 
     Notes

--- a/aaanalysis/prediction/_reliability_model_plot.py
+++ b/aaanalysis/prediction/_reliability_model_plot.py
@@ -32,6 +32,12 @@ class ReliabilityModelPlot:
     and a score-vs-OOD map colored by the ``reliable`` flag (:meth:`trust_map`; the last three from
     :meth:`ReliabilityModel.predict`).
 
+    .. warning::
+
+        **Experimental.** This class is part of the new v1.1.0 prediction layer and is under active
+        development; its API (signatures, defaults, return objects) may change between minor releases
+        without the usual deprecation cycle. Pin a version if you depend on the current behaviour.
+
     .. versionadded:: 1.1.0
 
     See Also

--- a/aaanalysis/protein_engineering/_seqopt.py
+++ b/aaanalysis/protein_engineering/_seqopt.py
@@ -169,6 +169,12 @@ class SeqOpt(Tool):
     ``region``, ``to_aa``), the ``algorithm="greedy"`` baseline, and any ``callable(sequence)``
     objective.
 
+    .. warning::
+
+        **Experimental.** This class is part of the new v1.1.0 protein-design/optimization layer and is
+        under active development; its API (signatures, defaults, return objects) may change between minor
+        releases without the usual deprecation cycle. Pin a version if you depend on the current behaviour.
+
     .. versionadded:: 1.1.0
 
     """

--- a/aaanalysis/protein_engineering/_seqopt_plot.py
+++ b/aaanalysis/protein_engineering/_seqopt_plot.py
@@ -47,6 +47,12 @@ class SeqOptPlot:
     ``fig, ax = ...``. For backward compatibility, the returned object also forwards attribute
     access to ``ax``.
 
+    .. warning::
+
+        **Experimental.** This class is part of the new v1.1.0 protein-design/optimization layer and is
+        under active development; its API (signatures, defaults, return objects) may change between minor
+        releases without the usual deprecation cycle. Pin a version if you depend on the current behaviour.
+
     .. versionadded:: 1.1.0
 
     """


### PR DESCRIPTION
## Why

`AAPred`, `ModelEvaluator`, and `SequenceFeatureTransformer` shipped with an `.. warning:: **Experimental.**` banner — their API may change between minor releases without the usual deprecation cycle. `ReliabilityModel`, `SeqOpt`, and their `*Plot` siblings did **not** carry it, so under strict-semver-from-v1.x they would **hard-freeze at the v1.1.0 tag** while the rest of the new tier stayed flexible.

This is a deliberate pre-release decision: keep the whole new prediction/design tier uniformly **experimental** for v1.1.0, so nothing in it freezes at the tag. The naming/units/defaults consistency pass (renames, `ci` units, `SeqOpt()` default, `mcc` parity) then lands in v1.2 with no deprecation cost, and the banners come off when it does — tracked in #510.

## What

Adds the exact banner already used on the sibling classes to `ReliabilityModel`, `ReliabilityModelPlot`, `SeqOpt`, `SeqOptPlot`. **Docstring-only** — no code, signatures, defaults, return objects, or behaviour change (24 inserted lines, all inside class docstrings).

## Checks

- Docstring structural checker: 0 defects on all four files (pre-existing advisories unrelated).
- Imports clean; banner reaches `help()` / RTD for each class.

Unblocks the v1.1.0 tag.